### PR TITLE
fix: make old package deprecated for one last release

### DIFF
--- a/.changeset/renaming-deprecated-ultraviolet.md
+++ b/.changeset/renaming-deprecated-ultraviolet.md
@@ -1,0 +1,11 @@
+---
+'@scaleway/ui': minor
+'@scaleway/form': minor
+'@scaleway/themes': minor
+---
+
+⚠️⚠️⚠️ **THOSE PACKAGES ARE DEPRECATED** ⚠️⚠️⚠️
+
+Please use `@ultraviolet/ui`, `@ultraviolet/form`, and `@ultraviolet/themes` instead.
+
+A renaming has been done over those packages and a major update is available for `@ultraviolet/ui`


### PR DESCRIPTION
## Summary

This PR has one and only purpose: make one last version bump before renaming so we can log in changelog that the package is deprecated and will be seen in renovate easily.
