### PR TITLE
docs(themes): fix auto closing global in readme

### DIFF
--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -23,7 +23,7 @@ import { Global, css, ThemeProvider } from '@emotion/react'
 
 const App = () => (
   <ThemeProvider theme={consoleDarkTheme}>
-    <Global styles={css`${normalize()}`}>
+    <Global styles={css`${normalize()}`} />
     <Button variant="primary" onClick={() => console.log('clicked')}>
       Click Me
     </Button>


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Fix example where `<Global />` component is not auto closing.
