### PR TITLE
fix(pnpm): remove useless field pnpm peerDeps

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,14 +30,6 @@
   "module": "dist/src/index.js",
   "jsnext:main": "dist/src/index.js",
   "types": "dist/index.d.ts",
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "react": "18",
-        "react-dom": "18"
-      }
-    }
-  },
   "peerDependencies": {
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarise concisely:

#### What is expected?

```
packages/ui                              |  WARN  The field "pnpm" was found in /Volumes/Dev/scaleway/team-console/ultraviolet/packages/ui/package.json. This will not take effect. You should configure "pnpm" at the root of the workspace instead.
```
