### PR TITLE
fix(TagInput): not to block focus while pressing key tab

### DIFF
--- a/.changeset/wise-berries-poke.md
+++ b/.changeset/wise-berries-poke.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fixed `TagInput` not to block focus while pressing key Tab

--- a/packages/ui/src/components/TagInput/index.tsx
+++ b/packages/ui/src/components/TagInput/index.tsx
@@ -193,7 +193,7 @@ export const TagInput = ({
   }
 
   const handleInputKeydown: KeyboardEventHandler<HTMLInputElement> = event => {
-    if (event.key === ' ' || event.key === 'Enter' || event.key === 'Tab') {
+    if (event.key === ' ' || event.key === 'Enter') {
       addTag()
       event.preventDefault()
     }
@@ -228,7 +228,6 @@ export const TagInput = ({
     <TagInputContainer
       onClick={handleContainerClick}
       variant={variant}
-      onBlur={addTag}
       className={className}
       data-testid={dataTestId}
     >
@@ -254,6 +253,7 @@ export const TagInput = ({
           type="text"
           placeholder={!tagInputState.length ? placeholder : ''}
           value={input}
+          onBlur={addTag}
           onChange={onInputChange}
           onKeyDown={handleInputKeydown}
           onPaste={handlePaste}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

On TagInput it was impossible to navigate outside of the component because we were catching the Tab input.
