### PR TITLE
fix(Button): add more aria props for better compatibility

### DIFF
--- a/.changeset/violet-weeks-appear.md
+++ b/.changeset/violet-weeks-appear.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': minor
+---
+
+Add props `aria-controls`, `aria-expanded` and `aria-haspopup` to Button component

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -284,6 +284,9 @@ type CommonProps = {
   isLoading?: boolean
   'aria-label'?: string
   'aria-current'?: boolean
+  'aria-controls'?: string
+  'aria-expanded'?: boolean
+  'aria-haspopup'?: boolean
   onClick?: MouseEventHandler<HTMLElement>
   tooltip?: string
   tabIndex?: ButtonHTMLAttributes<HTMLButtonElement>['tabIndex']
@@ -349,6 +352,9 @@ export const Button = forwardRef<Element, FinalProps>(
       name,
       'aria-label': ariaLabel,
       'aria-current': ariaCurrent,
+      'aria-controls': ariaControls,
+      'aria-expanded': ariaExpanded,
+      'aria-haspopup': ariaHaspopup,
       href,
       download,
       target,
@@ -397,6 +403,9 @@ export const Button = forwardRef<Element, FinalProps>(
             onClick={onClick}
             aria-label={ariaLabel}
             aria-current={ariaCurrent}
+            aria-controls={ariaControls}
+            aria-expanded={ariaExpanded}
+            aria-haspopup={ariaHaspopup}
             href={href}
             target={target}
             download={download}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Add props `aria-controls`, `aria-expanded` and `aria-haspopup` to Button component
