### PR TITLE
fix(List): avoid propagation outside Expandable

### DIFF
--- a/.changeset/sour-buttons-carry.md
+++ b/.changeset/sour-buttons-carry.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+List: avoid event propagation outside List.Expandable

--- a/packages/ui/src/components/List/Row.tsx
+++ b/packages/ui/src/components/List/Row.tsx
@@ -216,6 +216,9 @@ export const Row = forwardRef(
             onClick={e => {
               e.stopPropagation()
             }}
+            onKeyDown={e => {
+              e.stopPropagation()
+            }}
           >
             {expandable}
           </ExpandableWrapper>

--- a/packages/ui/src/components/List/__stories__/Example.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Example.stories.tsx
@@ -1,6 +1,11 @@
 import type { StoryFn } from '@storybook/react'
 import { useMemo, useState } from 'react'
 import { List } from '..'
+import { Button } from '../../Button/index'
+import { Modal } from '../../Modal'
+import { Stack } from '../../Stack'
+import { Text } from '../../Text'
+import { TextInput } from '../../TextInput'
 import { data as sourceData } from './resources'
 
 export const Example: StoryFn = () => {
@@ -53,7 +58,28 @@ export const Example: StoryFn = () => {
         <List.Row
           key={planet.id}
           id={planet.id}
-          expandable="Planet description...."
+          expandable={
+            <Stack direction="row" justifyContent="space-between">
+              <div>A planet description</div>
+              <Modal
+                disclosure={
+                  <Button size="small" icon="pencil">
+                    Edit
+                  </Button>
+                }
+              >
+                <Stack gap={3}>
+                  <Text as="h6" variant="headingSmall">
+                    Edit description
+                  </Text>
+                  <TextInput
+                    name="description"
+                    label="Type planet description"
+                  />
+                </Stack>
+              </Modal>
+            </Stack>
+          }
           sentiment={planet.id === 'home-sweet-home' ? 'info' : undefined}
         >
           <List.Cell>{planet.name}</List.Cell>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Add a stop propagation for kewdown on the expandable content of a List.Row. It can avoid strange behavior when we need to type something inside an expandable content.