### PR TITLE
fix: prevent keyDown propagation on List.Cell

### DIFF
--- a/.changeset/eleven-bikes-kneel.md
+++ b/.changeset/eleven-bikes-kneel.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+List: preventClick on Cell also prevent keyDown event to be propagated

--- a/packages/ui/src/components/List/Cell.tsx
+++ b/packages/ui/src/components/List/Cell.tsx
@@ -1,5 +1,10 @@
 import styled from '@emotion/styled'
-import type { ForwardedRef, MouseEventHandler, ReactNode } from 'react'
+import type {
+  ForwardedRef,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  ReactNode,
+} from 'react'
 import { forwardRef } from 'react'
 
 const StyledCell = styled.div`
@@ -30,12 +35,19 @@ export const Cell = forwardRef(
       }
     }
 
+    const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = event => {
+      if (preventClick) {
+        event.stopPropagation()
+      }
+    }
+
     return (
       <StyledCell
         ref={ref}
         role="cell"
         className={className}
         onClick={handleClick}
+        onKeyDown={handleKeyDown}
         data-testid={dataTestid}
       >
         {children}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

We add preventClick to avoid conflict with expand/collapse when clicking/keyDown on  row. However keyDown event was still propagated.

Naming stays a bit strange but since we plan to modify expand/collapse behavior it sounds ok 
