### PR TITLE
refactor(Popup): create first internal component popup used by tooltip and popover

### DIFF
--- a/.changeset/mean-candles-bow.md
+++ b/.changeset/mean-candles-bow.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': minor
+---
+
+Create internal component popup for Tooltip and Popover

--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -323,7 +323,7 @@ exports[`Button render with a tooltip 1`] = `
 
 <div
     aria-describedby=":r1f:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
@@ -72,7 +72,7 @@ exports[`CopyButton renders correctly 1`] = `
 
 <div
     aria-describedby=":r0:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -165,7 +165,7 @@ exports[`CopyButton renders correctly sentiment large 1`] = `
 
 <div
     aria-describedby=":r2:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -258,7 +258,7 @@ exports[`CopyButton renders correctly sentiment neutral 1`] = `
 
 <div
     aria-describedby=":r4:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -351,7 +351,7 @@ exports[`CopyButton renders correctly sentiment primary 1`] = `
 
 <div
     aria-describedby=":r3:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -444,7 +444,7 @@ exports[`CopyButton renders correctly sentiment small 1`] = `
 
 <div
     aria-describedby=":r1:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -537,7 +537,7 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
 
 <div
     aria-describedby=":r8:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -630,7 +630,7 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
 
 <div
     aria-describedby=":r7:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -723,7 +723,7 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
 
 <div
     aria-describedby=":r6:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button
@@ -815,7 +815,7 @@ exports[`CopyButton renders correctly with no border 1`] = `
 
 <div
     aria-describedby=":r5:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -3609,7 +3609,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 1
         <div
           aria-describedby=":r38:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <svg
@@ -3629,7 +3629,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 2
         <div
           aria-describedby=":r39:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <svg
@@ -3649,7 +3649,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 3
         <div
           aria-describedby=":r3a:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <svg
@@ -3669,7 +3669,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 4
         <div
           aria-describedby=":r3b:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <svg
@@ -3689,7 +3689,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 5
         <div
           aria-describedby=":r3c:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <svg

--- a/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -289,7 +289,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -581,7 +581,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -621,7 +621,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1062,7 +1062,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1102,7 +1102,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1324,7 +1324,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
     >
       <div
         aria-describedby="chart-legend-discount"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1807,7 +1807,7 @@ exports[`PieChart renders correctly with legend 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1847,7 +1847,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1887,7 +1887,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-functions"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1927,7 +1927,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-containers"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -1967,7 +1967,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-s3"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -2007,7 +2007,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-dns"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -2047,7 +2047,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-appleSilicon"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -2087,7 +2087,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-baremetal"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -2127,7 +2127,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-database"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li
@@ -2167,7 +2167,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-lb"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <li

--- a/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Tooltip should render correctly with component in content prop 1`] = `
 
 <div
     aria-describedby=":r5:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     Children
@@ -24,7 +24,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 <div
     aria-describedby=":rk:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -44,7 +44,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 <div
     aria-describedby=":rc:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -64,7 +64,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 <div
     aria-describedby=":rg:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -84,7 +84,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 <div
     aria-describedby=":r8:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -104,7 +104,7 @@ exports[`Tooltip should render correctly with required props 1`] = `
 
 <div
     aria-describedby=":r0:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     Children
@@ -120,7 +120,7 @@ exports[`Tooltip should render correctly with required props and visible 1`] = `
 
 <div
     aria-describedby=":r1:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     Children
@@ -136,7 +136,7 @@ exports[`Tooltip should render correctly with sentiment should renders tooltip w
 
 <div
     aria-describedby=":ro:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -156,7 +156,7 @@ exports[`Tooltip should render correctly with sentiment should renders tooltip w
 
 <div
     aria-describedby=":rs:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -176,7 +176,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 
 <div
     aria-describedby=":r18:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -196,7 +196,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 
 <div
     aria-describedby=":r14:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p
@@ -216,7 +216,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 
 <div
     aria-describedby=":r10:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <p

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import type { ComponentProps, ReactNode } from 'react'
 import { useCallback, useEffect, useRef } from 'react'
+import { Popup } from '../../internalComponents'
 import { Button } from '../Button'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
-import { Tooltip } from '../Tooltip'
 
 type SentimentType = 'neutral' | 'primary'
 
@@ -14,7 +14,7 @@ const SIZES_WIDTH = {
   large: 520,
 }
 
-const StyledTooltip = styled(Tooltip, {
+const StyledPopup = styled(Popup, {
   shouldForwardProp: prop => !['sentiment', 'size'].includes(prop),
 })<{
   sentiment: SentimentType
@@ -30,8 +30,10 @@ const StyledTooltip = styled(Tooltip, {
       return `
       background: ${theme.colors.neutral.background};
       box-shadow: ${theme.shadows.popover};
-      &::after {
-        border-color: ${theme.colors.neutral.background} transparent transparent transparent;
+      &[data-has-arrow='true'] {
+        &::after {
+          border-color: ${theme.colors.neutral.background} transparent transparent transparent;
+        }
       }
       `
     }
@@ -39,8 +41,10 @@ const StyledTooltip = styled(Tooltip, {
     return `
       background: ${theme.colors.primary.backgroundStrong};
       box-shadow: ${theme.shadows.popover};
-      &::after {
-        border-color: ${theme.colors.primary.backgroundStrong} transparent transparent transparent;
+      &[data-has-arrow='true'] {
+        &::after {
+          border-color: ${theme.colors.primary.backgroundStrong} transparent transparent transparent;
+        }
       }
       `
   }}
@@ -99,7 +103,7 @@ type PopoverProps = {
   onClose: () => void
   className?: string
   'data-testid'?: string
-} & Pick<ComponentProps<typeof Tooltip>, 'placement'>
+} & Pick<ComponentProps<typeof Popup>, 'placement'>
 
 export const Popover = ({
   visible = false,
@@ -133,7 +137,7 @@ export const Popover = ({
   }, [handleClickOutside])
 
   return (
-    <StyledTooltip
+    <StyledPopup
       visible={visible}
       placement={placement}
       text={
@@ -149,6 +153,6 @@ export const Popover = ({
       ref={ref}
     >
       {children}
-    </StyledTooltip>
+    </StyledPopup>
   )
 }

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -1408,7 +1408,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 
 <div
     aria-describedby=":rn:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <div
@@ -2987,7 +2987,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 
 <div
     aria-describedby=":rl:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <div

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`Snippet renders correctly 1`] = `
       >
         <div
           aria-describedby=":r1:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -450,7 +450,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
       >
         <div
           aria-describedby=":r3:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -770,7 +770,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
       >
         <div
           aria-describedby=":r9:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -1091,7 +1091,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
       >
         <div
           aria-describedby=":r6:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -1306,7 +1306,7 @@ exports[`Snippet renders correctly with copiedText 1`] = `
       >
         <div
           aria-describedby=":ri:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -1498,7 +1498,7 @@ exports[`Snippet renders correctly with copyText 1`] = `
       >
         <div
           aria-describedby=":rg:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -1780,7 +1780,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
       >
         <div
           aria-describedby=":rk:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -2085,7 +2085,7 @@ exports[`Snippet renders correctly with showText 1`] = `
       >
         <div
           aria-describedby=":rn:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -2315,7 +2315,7 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
       >
         <div
           aria-describedby=":rc:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -2523,7 +2523,7 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
       >
         <div
           aria-describedby=":re:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -2805,7 +2805,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
       >
         <div
           aria-describedby=":rq:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -1081,7 +1081,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
 
 <div
     aria-describedby=":ra:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <div

--- a/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -888,7 +888,7 @@ exports[`Table Should render correctly with info 1`] = `
             Name
             <div
               aria-describedby=":r2l:"
-              class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+              class="cache-yb56yg-StyledChildrenContainer efkq4700"
               tabindex="0"
             >
               <svg

--- a/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -260,7 +260,7 @@ exports[`Tag renders correctly with copiable 1`] = `
 
 <div
     aria-describedby=":r1:"
-    class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+    class="cache-yb56yg-StyledChildrenContainer efkq4700"
     tabindex="0"
   >
     <button

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`TagList renders correctly 1`] = `
       </div>
       <div
         aria-describedby=":r0:"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <span
@@ -196,7 +196,7 @@ exports[`TagList renders correctly with copiable 1`] = `
       >
         <div
           aria-describedby=":r4:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -212,7 +212,7 @@ exports[`TagList renders correctly with copiable 1`] = `
         </div>
         <div
           aria-describedby=":r5:"
-          class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+          class="cache-yb56yg-StyledChildrenContainer efkq4700"
           tabindex="0"
         >
           <button
@@ -432,7 +432,7 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
       </div>
       <div
         aria-describedby=":r1:"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <span
@@ -546,7 +546,7 @@ exports[`TagList renders correctly with custom threshold and extra tags and maxL
       </div>
       <div
         aria-describedby=":r2:"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <span
@@ -674,7 +674,7 @@ exports[`TagList renders correctly with multiline 1`] = `
       </div>
       <div
         aria-describedby=":r3:"
-        class="cache-yb56yg-StyledChildrenContainer e1h4zly10"
+        class="cache-yb56yg-StyledChildrenContainer efkq4700"
         tabindex="0"
       >
         <span

--- a/packages/ui/src/components/Tooltip/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Tooltip/__tests__/index.test.tsx
@@ -4,15 +4,17 @@ import type { ComponentProps } from 'react'
 import { Tooltip } from '..'
 import {
   renderWithTheme,
-  shouldMatchEmotionSnapshot,
+  shouldMatchEmotionSnapshotWithPortal,
 } from '../../../../.jest/helpers'
 
 describe('Tooltip', () => {
   test('should render correctly', () =>
-    shouldMatchEmotionSnapshot(<Tooltip text="test">Hover me</Tooltip>))
+    shouldMatchEmotionSnapshotWithPortal(
+      <Tooltip text="test">Hover me</Tooltip>,
+    ))
 
   test('should render correctly without text', () =>
-    shouldMatchEmotionSnapshot(<Tooltip>Hover me</Tooltip>))
+    shouldMatchEmotionSnapshotWithPortal(<Tooltip>Hover me</Tooltip>))
 
   test(`should display tooltip on hover`, async () => {
     renderWithTheme(

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -1,40 +1,20 @@
-import type { ComponentProps, ReactNode, Ref, RefObject } from 'react'
+import type { ComponentProps, Ref } from 'react'
 import { forwardRef } from 'react'
 import { Popup } from '../../internalComponents'
 
-type TooltipProps = {
-  /**
-   * Id is automatically generated if not set. It is used for associating tooltip wrapper with tooltip portal.
-   */
-  id?: string
-  children:
-    | ReactNode
-    | ((renderProps: {
-        className?: string
-        onBlur: () => void
-        onFocus: () => void
-        onPointerEnter: () => void
-        onPointerLeave: () => void
-        ref: RefObject<HTMLDivElement>
-      }) => ReactNode)
-  maxWidth?: number
-  /**
-   * `auto` placement will change the position of the tooltip if it doesn't fit in the viewport.
-   */
-  placement?: ComponentProps<typeof Popup>['placement']
-  /**
-   * Content of the tooltip, preferably text inside.
-   */
-  text?: ReactNode
-  className?: string
-  /**
-   * It will force display tooltip. This can be useful if you need to always display the tooltip without hover needed.
-   */
-  visible?: boolean
-  innerRef?: Ref<HTMLDivElement | null>
-  role?: string
-  'data-testid'?: string
-}
+type TooltipProps = Pick<
+  ComponentProps<typeof Popup>,
+  | 'id'
+  | 'children'
+  | 'maxWidth'
+  | 'placement'
+  | 'text'
+  | 'className'
+  | 'visible'
+  | 'innerRef'
+  | 'role'
+  | 'data-testid'
+>
 
 export const Tooltip = forwardRef(
   (

--- a/packages/ui/src/internalComponents/Popup/__tests__/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/internalComponents/Popup/__tests__/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tooltip should render correctly 1`] = `
+exports[`Popup should render correctly 1`] = `
 <DocumentFragment>
   .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
@@ -16,7 +16,7 @@ exports[`Tooltip should render correctly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Tooltip should render correctly without text 1`] = `
+exports[`Popup should render correctly without text 1`] = `
 <DocumentFragment>
   Hover me
 </DocumentFragment>

--- a/packages/ui/src/internalComponents/Popup/__tests__/__tests__/index.test.tsx
+++ b/packages/ui/src/internalComponents/Popup/__tests__/__tests__/index.test.tsx
@@ -1,0 +1,149 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
+import {
+  renderWithTheme,
+  shouldMatchEmotionSnapshot,
+} from '../../../../../.jest/helpers'
+import { Popup } from '../../index'
+
+describe('Popup', () => {
+  test('should render correctly', () =>
+    shouldMatchEmotionSnapshot(<Popup text="test">Hover me</Popup>))
+
+  test('should render correctly without text', () =>
+    shouldMatchEmotionSnapshot(<Popup>Hover me</Popup>))
+
+  test(`should display Popup on hover`, async () => {
+    renderWithTheme(
+      <Popup id="test" text="test success!">
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+  })
+
+  test(`should display Popup on hover with function children`, async () => {
+    renderWithTheme(
+      <Popup id="test" text="test success!">
+        {props => (
+          <p {...props} data-testid="children">
+            Hover me
+          </p>
+        )}
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+  })
+
+  test(`should display Popup on hover and hide when exit`, async () => {
+    renderWithTheme(
+      <Popup id="test" text="test success!">
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+    await userEvent.unhover(input)
+
+    await waitFor(() => {
+      expect(PopupPortal).not.toBeVisible()
+    })
+  })
+
+  test(`should display Popup on hover and hide when exit and hover back before animation ends`, async () => {
+    renderWithTheme(
+      <Popup id="test" text="test success!">
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+    await userEvent.unhover(input)
+    await userEvent.hover(input)
+    expect(PopupPortal).toBeVisible()
+  })
+
+  test(`should create Popup with random id`, async () => {
+    renderWithTheme(
+      <Popup text="test success!">
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+  })
+
+  test(`should renders Popup with maxWidth`, async () => {
+    renderWithTheme(
+      <Popup text="test success!" maxWidth={100}>
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+  })
+
+  describe(`defined placement`, () => {
+    ;['top', 'left', 'right', 'bottom'].forEach(placement => {
+      test(`should renders Popup with placement ${placement}`, async () => {
+        renderWithTheme(
+          <Popup
+            text="test success!"
+            placement={placement as ComponentProps<typeof Popup>['placement']}
+          >
+            <p data-testid="children">Hover me</p>
+          </Popup>,
+        )
+
+        const children = screen.getByTestId('children')
+        await userEvent.hover(children)
+
+        const PopupPortal = screen.getByText('test success!')
+        expect(PopupPortal).toBeVisible()
+      })
+    })
+  })
+
+  test(`should verify accessibility`, async () => {
+    renderWithTheme(
+      <Popup text="test success!" maxWidth={100}>
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    await userEvent.keyboard('{Tab}')
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+
+    await userEvent.keyboard('{Escape}')
+    expect(PopupPortal).not.toBeVisible()
+  })
+})

--- a/packages/ui/src/internalComponents/Popup/__tests__/__tests__/index.test.tsx
+++ b/packages/ui/src/internalComponents/Popup/__tests__/__tests__/index.test.tsx
@@ -3,16 +3,16 @@ import userEvent from '@testing-library/user-event'
 import type { ComponentProps } from 'react'
 import {
   renderWithTheme,
-  shouldMatchEmotionSnapshot,
+  shouldMatchEmotionSnapshotWithPortal,
 } from '../../../../../.jest/helpers'
 import { Popup } from '../../index'
 
 describe('Popup', () => {
   test('should render correctly', () =>
-    shouldMatchEmotionSnapshot(<Popup text="test">Hover me</Popup>))
+    shouldMatchEmotionSnapshotWithPortal(<Popup text="test">Hover me</Popup>))
 
   test('should render correctly without text', () =>
-    shouldMatchEmotionSnapshot(<Popup>Hover me</Popup>))
+    shouldMatchEmotionSnapshotWithPortal(<Popup>Hover me</Popup>))
 
   test(`should display Popup on hover`, async () => {
     renderWithTheme(

--- a/packages/ui/src/internalComponents/Popup/helpers.ts
+++ b/packages/ui/src/internalComponents/Popup/helpers.ts
@@ -1,6 +1,6 @@
 import type { RefObject } from 'react'
 
-export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left' | 'auto'
+export type PopupPlacement = 'top' | 'right' | 'bottom' | 'left' | 'auto'
 export const ARROW_WIDTH = 8 // in px
 const SPACE = 4 // in px
 const TOTAL_USED_SPACE = ARROW_WIDTH + SPACE // in px
@@ -50,7 +50,7 @@ const computePlacement = ({
 }
 
 type ComputePositionsTypes = {
-  placement: TooltipPlacement
+  placement: PopupPlacement
   childrenRef: RefObject<HTMLDivElement>
   tooltipRef: RefObject<HTMLDivElement>
 }

--- a/packages/ui/src/internalComponents/Popup/index.tsx
+++ b/packages/ui/src/internalComponents/Popup/index.tsx
@@ -56,7 +56,10 @@ type StyledTooltipProps = {
   reverseAnimation: boolean
 }
 
-const StyledTooltip = styled.div<StyledTooltipProps>`
+const StyledTooltip = styled('div', {
+  shouldForwardProp: prop =>
+    !['maxWidth', 'positions', 'reverseAnimation'].includes(prop),
+})<StyledTooltipProps>`
   background: ${({ theme }) => theme.colors.neutral.backgroundStronger};
   color: ${({ theme }) => theme.colors.neutral.textStronger};
   border-radius: ${({ theme }) => theme.radii.default};

--- a/packages/ui/src/internalComponents/Popup/index.tsx
+++ b/packages/ui/src/internalComponents/Popup/index.tsx
@@ -1,0 +1,342 @@
+import { css, keyframes } from '@emotion/react'
+import styled from '@emotion/styled'
+import type { KeyboardEventHandler, ReactNode, Ref, RefObject } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
+import type { PopupPlacement } from './helpers'
+import { ARROW_WIDTH, DEFAULT_POSITIONS, computePositions } from './helpers'
+
+const ANIMATION_DURATION = 230 // in ms
+
+function noop() {}
+
+const animation = (positions: PositionsType) => keyframes`
+  0% {
+    opacity: 0;
+    transform: ${positions.tooltipInitialPosition};
+  }
+  100% {
+    opacity: 1;
+    transform: ${positions.tooltipPosition};
+  }
+`
+
+const exitAnimation = (positions: PositionsType) => keyframes`
+  0% {
+    opacity: 1;
+    transform: ${positions.tooltipPosition};
+  }
+  100% {
+    opacity: 0;
+    transform: ${positions.tooltipInitialPosition};
+  }
+`
+
+type PositionsType = {
+  arrowLeft: number
+  arrowTop: number
+  arrowTransform: string
+  placement: string
+  rotate: number
+  tooltipInitialPosition: string
+  tooltipPosition: string
+}
+
+type StyledTooltipProps = {
+  maxWidth: number
+  positions: PositionsType
+  reverseAnimation: boolean
+}
+
+const StyledTooltip = styled.div<StyledTooltipProps>`
+  background: ${({ theme }) => theme.colors.neutral.backgroundStronger};
+  color: ${({ theme }) => theme.colors.neutral.textStronger};
+  border-radius: ${({ theme }) => theme.radii.default};
+  padding: ${({ theme }) => `${theme.space['0.5']} ${theme.space['1']}`};
+  text-align: center;
+  position: absolute;
+  max-width: ${({ maxWidth }) => maxWidth}px;
+  font-size: 0.8rem;
+  inset: 0 auto auto 0;
+  top: 0;
+  left: 0;
+  transform: ${({ positions }) => positions.tooltipPosition};
+  animation: ${({ positions, reverseAnimation }) =>
+    css`
+      ${ANIMATION_DURATION}ms ${!reverseAnimation
+        ? animation(positions)
+        : exitAnimation(positions)} forwards
+    `};
+
+  &[data-has-arrow='true'] {
+    &::after {
+      content: ' ';
+      position: absolute;
+      top: ${({ positions }) => positions.arrowTop}px;
+      left: ${({ positions }) => positions.arrowLeft}px;
+      transform: ${({ positions }) => positions.arrowTransform}
+        rotate(${({ positions }) => positions.rotate}deg);
+      margin-left: -${ARROW_WIDTH}px;
+      border-width: ${ARROW_WIDTH}px;
+      border-style: solid;
+      border-color: ${({ theme }) => theme.colors.neutral.backgroundStronger}
+        transparent transparent transparent;
+      pointer-events: none;
+    }
+  }
+`
+
+const StyledChildrenContainer = styled.div`
+  display: inherit;
+`
+
+type TooltipProps = {
+  /**
+   * Id is automatically generated if not set. It is used for associating tooltip wrapper with tooltip portal.
+   */
+  id?: string
+  children:
+    | ReactNode
+    | ((renderProps: {
+        className?: string
+        onBlur: () => void
+        onFocus: () => void
+        onPointerEnter: () => void
+        onPointerLeave: () => void
+        ref: RefObject<HTMLDivElement>
+      }) => ReactNode)
+  maxWidth?: number
+  /**
+   * `auto` placement will change the position of the tooltip if it doesn't fit in the viewport.
+   */
+  placement?: PopupPlacement
+  /**
+   * Content of the tooltip, preferably text inside.
+   */
+  text?: ReactNode
+  className?: string
+  /**
+   * It will force display tooltip. This can be useful if you need to always display the tooltip without hover needed.
+   */
+  visible?: boolean
+  innerRef?: Ref<HTMLDivElement | null>
+  role?: string
+  'data-testid'?: string
+  hasArrow?: boolean
+}
+
+export const Popup = forwardRef(
+  (
+    {
+      children,
+      text = '',
+      placement = 'auto',
+      id,
+      className,
+      maxWidth = 232,
+      visible,
+      innerRef,
+      role = 'tooltip',
+      'data-testid': dataTestId,
+      hasArrow = true,
+    }: TooltipProps,
+    tooltipRef: Ref<HTMLDivElement>,
+  ) => {
+    const childrenRef = useRef<HTMLDivElement>(null)
+    useImperativeHandle(innerRef, () => childrenRef.current)
+
+    const tempTooltipRef = useRef<HTMLDivElement>(null)
+    const innerTooltipRef =
+      (tooltipRef as RefObject<HTMLDivElement>) || tempTooltipRef
+
+    const timer = useRef<ReturnType<typeof setTimeout> | undefined>()
+
+    // Debounce timer will be used to prevent the tooltip from flickering when the user moves the mouse out and in the children element.
+    const debounceTimer = useRef<ReturnType<typeof setTimeout> | undefined>()
+    const [visibleInDom, setVisibleInDom] = useState(false)
+    const [reverseAnimation, setReverseAnimation] = useState(false)
+    const [positions, setPositions] = useState<PositionsType>({
+      ...DEFAULT_POSITIONS,
+    })
+    const uniqueId = useId()
+    const generatedId = id ?? uniqueId
+    const isControlled = visible !== undefined
+
+    const generatePositions = useCallback(() => {
+      if (childrenRef.current && innerTooltipRef.current) {
+        setPositions(
+          computePositions({
+            childrenRef,
+            placement,
+            tooltipRef: innerTooltipRef,
+          }),
+        )
+      }
+    }, [innerTooltipRef, placement])
+
+    const onScrollDetected = useCallback(() => {
+      // We remove animation on scroll or the animation will restart on every scroll
+      if (innerTooltipRef.current) {
+        innerTooltipRef.current.style.animation = 'none'
+      }
+      generatePositions()
+    }, [generatePositions, innerTooltipRef])
+
+    /**
+     * This function is called when we need to remove tooltip portal from DOM and remove event listener to it.
+     */
+    const unmountTooltip = useCallback(() => {
+      setVisibleInDom(false)
+      setReverseAnimation(false)
+
+      window.removeEventListener('scroll', onScrollDetected, true)
+    }, [onScrollDetected])
+
+    /**
+     * When mouse hover or stop hovering children this function display or hide tooltip. A timeout is set to allow animation
+     * end, then remove tooltip from dom.
+     */
+    const onPointerEvent = useCallback(
+      (isVisible: boolean) => () => {
+        // This condition is for when we want to unmount the tooltip
+        // There is debounce in order to avoid tooltip to flicker when we move the mouse from children to tooltip
+        // Timer is used to follow the animation duration
+        if (!isVisible && innerTooltipRef.current && !debounceTimer.current) {
+          debounceTimer.current = setTimeout(() => {
+            setReverseAnimation(true)
+            timer.current = setTimeout(
+              () => unmountTooltip(),
+              ANIMATION_DURATION,
+            )
+          }, 200)
+        } else if (isVisible) {
+          // This condition is for when we want to mount the tooltip
+          // If the timer exists it means the tooltip was about to umount, but we hovered the children again,
+          // so we clear the timer and the tooltip will not be unmounted
+          if (timer.current) {
+            setReverseAnimation(false)
+            clearTimeout(timer.current)
+            timer.current = undefined
+          }
+          // And here is when we currently are in a debounce timer, it means tooltip was hovered during
+          // that period, and so we can clear debounce timer
+          if (debounceTimer.current) {
+            clearTimeout(debounceTimer.current)
+            debounceTimer.current = undefined
+          }
+          setVisibleInDom(true)
+        }
+      },
+      [innerTooltipRef, unmountTooltip],
+    )
+
+    /**
+     * Once tooltip is visible in the dom we can compute positions, then set it visible on screen and add event to
+     * recompute positions on scroll or screen resize.
+     */
+    useEffect(() => {
+      if (visibleInDom) {
+        generatePositions()
+
+        // We want to detect scroll in order to recompute positions of tooltip
+        // Adding true as third parameter to event listener will detect nested scrolls.
+        window.addEventListener('scroll', onScrollDetected, true)
+      }
+
+      return () => {
+        window.removeEventListener('scroll', onScrollDetected, true)
+        if (timer.current) {
+          clearTimeout(timer.current)
+          timer.current = undefined
+        }
+      }
+    }, [generatePositions, onScrollDetected, visibleInDom])
+
+    /**
+     * If tooltip has `visible` prop it means the tooltip is manually controlled through this prop.
+     * In this cas we don't want to display tooltip on hover, but only when `visible` is true.
+     */
+    useEffect(() => {
+      if (isControlled) {
+        onPointerEvent(visible)()
+      }
+    }, [isControlled, onPointerEvent, visible])
+
+    const onKeyDown: KeyboardEventHandler = useCallback(
+      event => {
+        if (event.code === 'Escape') {
+          unmountTooltip()
+        }
+      },
+      [unmountTooltip],
+    )
+
+    /**
+     * Will render children conditionally if children is a function or not.
+     */
+    const renderChildren = useCallback(() => {
+      if (typeof children === 'function') {
+        return children({
+          onBlur: !isControlled ? onPointerEvent(false) : noop,
+          onFocus: !isControlled ? onPointerEvent(true) : noop,
+          onPointerEnter: !isControlled ? onPointerEvent(true) : noop,
+          onPointerLeave: !isControlled ? onPointerEvent(false) : noop,
+          ref: childrenRef,
+        })
+      }
+
+      return (
+        <StyledChildrenContainer
+          aria-describedby={generatedId}
+          onBlur={!isControlled ? onPointerEvent(false) : noop}
+          onFocus={!isControlled ? onPointerEvent(true) : noop}
+          onPointerEnter={!isControlled ? onPointerEvent(true) : noop}
+          onPointerLeave={!isControlled ? onPointerEvent(false) : noop}
+          ref={childrenRef}
+          tabIndex={0}
+          onKeyDown={onKeyDown}
+        >
+          {children}
+        </StyledChildrenContainer>
+      )
+    }, [children, generatedId, isControlled, onKeyDown, onPointerEvent])
+
+    if (!text) {
+      if (typeof children === 'function') return null
+
+      return <>{children}</>
+    }
+
+    return (
+      <>
+        {renderChildren()}
+        {visibleInDom
+          ? createPortal(
+              <StyledTooltip
+                ref={innerTooltipRef}
+                positions={positions}
+                maxWidth={maxWidth}
+                role={role}
+                id={generatedId}
+                className={className}
+                reverseAnimation={reverseAnimation}
+                data-testid={dataTestId}
+                data-has-arrow={hasArrow}
+              >
+                {text}
+              </StyledTooltip>,
+              document.body,
+            )
+          : null}
+      </>
+    )
+  },
+)

--- a/packages/ui/src/internalComponents/index.ts
+++ b/packages/ui/src/internalComponents/index.ts
@@ -1,0 +1,1 @@
+export { Popup } from './Popup'


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Creation of a new folder `src/internalComponents`. This folder will contains all components that are being used within the package and will never be exported outside of it. The goal is to have a centralised place for reusable components.

In this PR we created `Popup` a component that show on screen as popup depending on the location of the children. This component is used by `Tooltip` but also by `Popover` and will later be used for `SelectInput`, `Menu` and any other components needing `Popup` behavior.