### PR TITLE
fix: use `exports` field and `type: module`

### DIFF
--- a/.changeset/lovely-worms-give.md
+++ b/.changeset/lovely-worms-give.md
@@ -1,0 +1,7 @@
+---
+'@ultraviolet/themes': patch
+'@ultraviolet/form': patch
+'@ultraviolet/ui': patch
+---
+
+Use `exports` field with `type: module`

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import I18n from '@scaleway/use-i18n'
 import { Preview } from '@storybook/react'
 import { css, ThemeProvider, Global, Theme } from '@emotion/react'
-import normalize from '@ultraviolet/ui/src/utils/normalize'
+import { normalize } from '@ultraviolet/ui'
 import { useDarkMode } from 'storybook-dark-mode'
 import { themes } from '@storybook/theming'
 import seedrandom from 'seedrandom'

--- a/examples/next-advanced/tsconfig.json
+++ b/examples/next-advanced/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react",
     "forceConsistentCasingInFileNames": true,
+    "noPropertyAccessFromIndexSignature": false,
     "noEmit": true,
     "incremental": true,
     "isolatedModules": true,
@@ -15,9 +16,16 @@
       "esnext"
     ],
     "allowJs": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "Node"
   },
-  "include": ["global.d.ts", "emotion.d.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "global.d.ts",
+    "emotion.d.ts",
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
   "exclude": [
     "node_modules"
   ]

--- a/examples/next-simple/tsconfig.json
+++ b/examples/next-simple/tsconfig.json
@@ -15,9 +15,16 @@
       "esnext"
     ],
     "allowJs": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "Node"
   },
-  "include": ["global.d.ts", "emotion.d.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "global.d.ts",
+    "emotion.d.ts",
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
   "exclude": [
     "node_modules"
   ]

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@rollup/plugin-url": "8.0.1",
     "@scaleway/eslint-config-react": "3.15.15",
     "@scaleway/jest-helpers": "3.0.7",
-    "@scaleway/tsconfig": "1.1.0",
+    "@scaleway/tsconfig": "1.1.1",
     "@ultraviolet/ui": "workspace:*",
     "@scaleway/use-i18n": "5.3.2",
     "@size-limit/file": "8.2.6",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -26,10 +26,11 @@
     "linux"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "jsnext:main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  },
   "peerDependencies": {
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -25,8 +25,9 @@
     "linux"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "jsnext:main": "dist/index.js",
-  "types": "dist/index.d.ts"
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -26,6 +26,7 @@
   ],
   "sideEffects": false,
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     "types": "./dist/index.d.ts",
     "default": "./dist/index.js"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,6 +27,7 @@
   ],
   "sideEffects": false,
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     "types": "./dist/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,10 +26,11 @@
     "linux"
   ],
   "sideEffects": false,
-  "main": "dist/src/index.js",
-  "module": "dist/src/index.js",
-  "jsnext:main": "dist/src/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/src/index.js"
+  },
   "peerDependencies": {
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",

--- a/packages/ui/src/components/LineChart/CustomLegend.tsx
+++ b/packages/ui/src/components/LineChart/CustomLegend.tsx
@@ -94,6 +94,7 @@ export const CustomLegend = ({
   'data-testid': dataTestId,
 }: CustomLegendProps) => (
   <StyledContainer className={className} data-testid={dataTestId}>
+    {/* @ts-expect-error todo */}
     <div css={styles.head}>
       <LongContainer>Legend</LongContainer>
       <Cell variant="body" value="Minimum" />
@@ -101,6 +102,7 @@ export const CustomLegend = ({
       <Cell variant="body" value="Average" />
       <Cell variant="body" value="Current" />
     </div>
+    {/* @ts-expect-error todo */}
     <div css={styles.body}>
       {data?.map((row, index) => {
         const values = row.data.map(val => val.y as number)
@@ -121,6 +123,7 @@ export const CustomLegend = ({
                   <Text as="span" variant="bodySmall" color="neutral">
                     {row?.['label']}
                   </Text>
+                  {/* @ts-expect-error todo */}
                   <div data-testid={`label-${id}`} css={styles.legend(index)} />
                 </CellValueContainer>
               </Checkbox>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: 3.0.7
         version: 3.0.7(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
       '@scaleway/tsconfig':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.1.1
+        version: 1.1.1
       '@scaleway/use-i18n':
         specifier: 5.3.2
         version: 5.3.2(date-fns@2.30.0)(react-dom@18.2.0)(react@18.2.0)
@@ -4885,8 +4885,8 @@ packages:
     engines: {node: '>=14.x'}
     dev: false
 
-  /@scaleway/tsconfig@1.1.0:
-    resolution: {integrity: sha512-dZyeub6snbFUD0oTTgiUsdHYYOcyZDbQ5lSgAaZBCVS6FxF2R2HiLVwtrD6pw9IebhyPne2z8M4BsZQ4Rg+K1w==}
+  /@scaleway/tsconfig@1.1.1:
+    resolution: {integrity: sha512-E67Gge9Az7HaX/i9fYXP2cw8xlsDAwb9d3TpoVO0Xnccal9j+YfGMyblKSyuf5SqZVaduy0lplhu3lk3SSTE+w==}
     dev: true
 
   /@scaleway/use-i18n@5.3.2(date-fns@2.30.0)(react-dom@18.2.0)(react@18.2.0):

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "@scaleway/tsconfig",
   "compilerOptions": {
     "target": "esnext",
-    // For storybook compatibility we use commonjs
-    "module": "commonjs",
+    "module": "esnext",
     "jsxImportSource": "@emotion/react",
 
     "noEmit": true,


### PR DESCRIPTION
## Summary

### Summarise concisely:

#### What is expected?

Following https://github.com/scaleway/scaleway-lib/pull/1380 in scw-lib, needs `@scaleway/tsconfig@1.1.1`
