### PR TITLE
fix(tokens): update tokens for product icon warning sentiment

### DIFF
--- a/.changeset/wet-shoes-sneeze.md
+++ b/.changeset/wet-shoes-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/themes': patch
+'@ultraviolet/icons': patch
+---
+
+Update ProductIcon tokens color for warning sentiment

--- a/packages/icons/src/components/ProductIcon/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/icons/src/components/ProductIcon/__tests__/__snapshots__/index.tsx.snap
@@ -5722,28 +5722,28 @@ exports[`ProductIcon should work with all variants should work with primary 1`] 
 
 exports[`ProductIcon should work with all variants should work with warning 1`] = `
 <DocumentFragment>
-  .cache-u6ei6h-StyledIcon {
+  .cache-1n19dhy-StyledIcon {
   width: 32px;
   height: 32px;
 }
 
-.cache-u6ei6h-StyledIcon .fill,
-.cache-u6ei6h-StyledIcon .fill>* {
-  fill: #ffeccc;
+.cache-1n19dhy-StyledIcon .fill,
+.cache-1n19dhy-StyledIcon .fill>* {
+  fill: #7c5400;
 }
 
-.cache-u6ei6h-StyledIcon .fillStrong,
-.cache-u6ei6h-StyledIcon .fillStrong>* {
-  fill: #ffeccc;
+.cache-1n19dhy-StyledIcon .fillStrong,
+.cache-1n19dhy-StyledIcon .fillStrong>* {
+  fill: #7c5400;
 }
 
-.cache-u6ei6h-StyledIcon .fillWeak,
-.cache-u6ei6h-StyledIcon .fillWeak>* {
+.cache-1n19dhy-StyledIcon .fillWeak,
+.cache-1n19dhy-StyledIcon .fillWeak>* {
   fill: #fbc600;
 }
 
 <svg
-    class="cache-u6ei6h-StyledIcon euby9wl0"
+    class="cache-1n19dhy-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g

--- a/packages/themes/src/themes/console/light.ts
+++ b/packages/themes/src/themes/console/light.ts
@@ -192,9 +192,9 @@ export const lightTheme = {
             fillWeakDisabled: '#f3f3f4',
           },
           warning: {
-            fill: '#ffeccc',
+            fill: '#7c5400',
             fillDisabled: '#d9dadd',
-            fillStrong: '#ffeccc',
+            fillStrong: '#7c5400',
             fillStrongDisabled: '#d9dadd',
             fillWeak: '#fbc600',
             fillWeakDisabled: '#f3f3f4',


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Token color for product icon was wrong in warning sentiment so we fixed it.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1052" alt="Screenshot 2023-07-21 at 11 29 00" src="https://github.com/scaleway/ultraviolet/assets/15812968/8093030c-f792-4987-830c-6c5e458c5809"> | <img width="1039" alt="Screenshot 2023-07-21 at 11 29 05" src="https://github.com/scaleway/ultraviolet/assets/15812968/ebe68e18-6489-4904-aa11-9de534a9d605"> |
