### PR TITLE
ci: add github action to auto assign when pull request is created

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,2 @@
+# The author of the pull request will be automatically assigned to it
+addAssignees: author

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,10 @@
+name: 'Auto Assign Pull Request'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.5

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,4 +1,4 @@
-name: 'Auto Assign Pull Request'
+name: Auto Assign Pull Request
 on:
   pull_request:
     types: [opened, ready_for_review]


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

In our current workflow the creator of the PR is the assigned to it. With this rule we can safely put a github action that auto assign the PR to the author in case we forget to do it.
