### PR TITLE
fix: reintroduce hide function

### DIFF
--- a/.changeset/seven-pens-rescue.md
+++ b/.changeset/seven-pens-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+fix: reintroduce hide function on modal children

--- a/packages/ui/src/components/Modal/Disclosure.tsx
+++ b/packages/ui/src/components/Modal/Disclosure.tsx
@@ -28,6 +28,7 @@ export const Disclosure = ({
       toggle,
       onOpen: handleOpen,
       modalId: id,
+      hide: handleClose,
     })
   }
 

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -125,6 +125,7 @@ export const Modal = ({
                 onOpen: handleOpen,
                 toggle: handleToggle,
                 modalId: finalId,
+                hide: handleClose,
               })
             : children}
           <StyledContainer>

--- a/packages/ui/src/components/Modal/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Modal/__tests__/index.test.tsx
@@ -1,5 +1,12 @@
 import { css } from '@emotion/react'
-import { afterAll, beforeEach, describe, expect, jest, test } from '@jest/globals'
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals'
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Modal } from '..'
@@ -215,6 +222,27 @@ describe('Modal', () => {
       </Modal>,
     )
     const modalButton = screen.getByRole('button')
+    await userEvent.click(modalButton)
+    expect(mockOnClick).toBeCalledTimes(1)
+  })
+
+  test(`disclosure function render onClick props is call with hide`, async () => {
+    renderWithTheme(
+      <Modal ariaLabel="modal-test" id="modal-test" opened>
+        {({ hide }) => (
+          <button
+            type="button"
+            onClick={() => {
+              mockOnClick()
+              hide()
+            }}
+          >
+            Close
+          </button>
+        )}
+      </Modal>,
+    )
+    const modalButton = screen.getByRole('button', { name: 'Close' })
     await userEvent.click(modalButton)
     expect(mockOnClick).toBeCalledTimes(1)
   })

--- a/packages/ui/src/components/Modal/types.ts
+++ b/packages/ui/src/components/Modal/types.ts
@@ -20,6 +20,10 @@ export type ModalState = {
   toggle: () => void
   visible: boolean
   modalId: string
+  /**
+   * @deprecated use onClose
+   */
+  hide: () => void
 }
 
 export type DisclosureProps = {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Shoudlnt drop hide but make it deprecated

#### The following changes where made:

(Describe what you did)

1.

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
