### PR TITLE
ci: fix renovate to check examples folder

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,10 @@
   "semanticCommitScope": "deps",
   "packageRules": [
     {
+      "paths": ["examples/**"],
+      "enabled": true
+    },
+    {
       "matchDepTypes": ["engines", "peerDependencies"],
       "versionStrategy": "widen"
     },


### PR DESCRIPTION
Renovate is not updating dependencies into folder examples which is not good. We need to maintain those as much as packages.