### PR TITLE
ci(renovate): try to fix renovate by adding folder examples into work…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,6 @@
   "semanticCommitScope": "deps",
   "packageRules": [
     {
-      "paths": ["examples/**"],
-      "enabled": true
-    },
-    {
       "matchDepTypes": ["engines", "peerDependencies"],
       "versionStrategy": "widen"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "root",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "packageManager": "pnpm@8.6.12",
   "engines": {


### PR DESCRIPTION
Seems like renovate doesn't want to check `package.json` that are in `examples` folder. I'm trying to make it work by adding examples into workspaces of the main `package.json`.