### PR TITLE
fix: modal restore focus

### DIFF
--- a/.changeset/seven-kings-serve.md
+++ b/.changeset/seven-kings-serve.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+fix(modal): focus cant be restored on shire and cause errors

--- a/packages/ui/src/components/Modal/Dialog.tsx
+++ b/packages/ui/src/components/Modal/Dialog.tsx
@@ -88,7 +88,6 @@ export const Dialog = ({
     const element = containerRef.current
     if (open) {
       document.body.appendChild(element)
-      dialogRef.current?.focus()
     }
 
     return () => {
@@ -113,6 +112,7 @@ export const Dialog = ({
       }
     }
     if (open) {
+      dialogRef.current?.focus()
       document.body.addEventListener('keyup', handleEscPress, { capture: true })
       document.body.addEventListener('keydown', handleEscPress, {
         capture: true,
@@ -181,11 +181,17 @@ export const Dialog = ({
     const lastFocusableEl = focusableEls[focusableEls.length - 1] as HTMLElement
 
     if (event.shiftKey) {
-      if (document.activeElement === firstFocusableEl) {
+      if (
+        document.activeElement === firstFocusableEl ||
+        document.activeElement === dialogRef.current
+      ) {
         lastFocusableEl.focus()
         event.preventDefault()
       }
-    } else if (document.activeElement === lastFocusableEl) {
+    } else if (
+      document.activeElement === lastFocusableEl ||
+      document.activeElement === dialogRef.current
+    ) {
       firstFocusableEl.focus()
       event.preventDefault()
     }
@@ -222,6 +228,7 @@ export const Dialog = ({
         onClose={stopCancel}
         aria-modal
         ref={dialogRef}
+        tabIndex={0}
       >
         {open ? children : null}
       </StyledDialog>

--- a/packages/ui/src/components/Modal/Disclosure.tsx
+++ b/packages/ui/src/components/Modal/Disclosure.tsx
@@ -21,12 +21,6 @@ export const Disclosure = ({
     }
   }, [handleOpen, disclosureRef])
 
-  useEffect(() => {
-    if (!visible) {
-      disclosureRef.current?.focus()
-    }
-  }, [visible, disclosureRef])
-
   if (typeof disclosure === 'function') {
     return disclosure({
       visible,

--- a/packages/ui/src/components/Modal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Modal/__tests__/__snapshots__/index.test.tsx.snap
@@ -185,6 +185,7 @@ exports[`Modal renders opened custom size 1`] = `
         data-size="medium"
         id=":ra:"
         open=""
+        tabindex="0"
       >
         <div>
           test
@@ -398,6 +399,7 @@ exports[`Modal renders opened custom size and width (size take predecence) 1`] =
         data-size="medium"
         id=":rc:"
         open=""
+        tabindex="0"
       >
         <div>
           test
@@ -611,6 +613,7 @@ exports[`Modal renders opened custom width 1`] = `
         data-size="medium"
         id=":r8:"
         open=""
+        tabindex="0"
       >
         <div>
           test
@@ -824,6 +827,7 @@ exports[`Modal renders with custom classNames 1`] = `
         data-size="small"
         id=":rg:"
         open=""
+        tabindex="0"
       >
         <div>
           test
@@ -1039,6 +1043,7 @@ exports[`Modal renders with customStyle 1`] = `
         data-size="small"
         id=":re:"
         open=""
+        tabindex="0"
       >
         <div>
           test
@@ -1266,6 +1271,7 @@ exports[`Modal renders with default Props and function children opened 1`] = `
         data-size="small"
         id=":r3:"
         open=""
+        tabindex="0"
       >
         <div>
           test
@@ -1508,6 +1514,7 @@ exports[`Modal renders with disclosure and onClose 1`] = `
         data-testid="test"
         id="modal-test"
         open=""
+        tabindex="0"
       >
         <div>
           modal
@@ -1722,6 +1729,7 @@ exports[`Modal renders with opened={true} 1`] = `
         data-size="small"
         id=":r5:"
         open=""
+        tabindex="0"
       >
         <div>
           test
@@ -1872,6 +1880,7 @@ exports[`Modal renders with opened={true} and no close icon 1`] = `
         data-size="small"
         id=":r7:"
         open=""
+        tabindex="0"
       >
         <div>
           test


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

We cant implement 100% accessibility on Modal because when Menu change on Modal close the focus cant be restored and cause menu to be clause

#### The following changes where made:

(Describe what you did)

1.

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
