### PR TITLE
ci: fix changeset by removing examples folder in changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@examples/**"]
 }

--- a/.changeset/renovate-9a9c9a8.md
+++ b/.changeset/renovate-9a9c9a8.md
@@ -1,6 +1,4 @@
 ---
-'@examples/next-advanced': patch
-'@examples/next-simple': patch
 '@ultraviolet/form': patch
 '@ultraviolet/icons': patch
 '@ultraviolet/ui': patch


### PR DESCRIPTION
There is an issue with changeset trying to release a new version for examples while it shouldn't. I remove the changeset md file mentioning it and I added into ignore of config file.