### PR TITLE
ci(changeset): add examples project into ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@examples/next-advanced", "@examples/next-simple"]
+  "ignore": ["@examples/*"]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@examples/next-advanced", "@examples/next-simple"]
 }


### PR DESCRIPTION
There is an issue when renovate tries to update package in examples folder it generate a changeset out of it while it shouldn't. To avoid that I added those projects into ignore of the config file.
