### PR TITLE
ci: fix changeset

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "root",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "packageManager": "pnpm@8.7.3",
   "engines": {


### PR DESCRIPTION
There is still an issue with changeset as examples folder doesn't exists in workspace. It causes this error:

```sh
 error The package or glob expression "@examples/next-simple" is specified in the `ignore` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.
```