### PR TITLE
fix(modal): dialog should use overflow y

### DIFF
--- a/.changeset/happy-squids-design.md
+++ b/.changeset/happy-squids-design.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Dialog should only prevent overflow y, not overflow x

--- a/packages/ui/src/components/Modal/Dialog.tsx
+++ b/packages/ui/src/components/Modal/Dialog.tsx
@@ -132,9 +132,9 @@ export const Dialog = ({
   // Handle body scroll
   useEffect(() => {
     if (open && preventBodyScroll) {
-      document.body.style.overflow = 'hidden'
+      document.body.style.overflowY = 'hidden'
     } else {
-      document.body.style.overflow = 'auto'
+      document.body.style.overflowY = 'auto'
     }
   }, [preventBodyScroll, open])
 

--- a/packages/ui/src/components/Modal/Dialog.tsx
+++ b/packages/ui/src/components/Modal/Dialog.tsx
@@ -131,10 +131,14 @@ export const Dialog = ({
 
   // Handle body scroll
   useEffect(() => {
+    const previousOverflow = document.body.style.overflow
+
     if (open && preventBodyScroll) {
-      document.body.style.overflowY = 'hidden'
-    } else {
-      document.body.style.overflowY = 'auto'
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.body.style.overflow = previousOverflow
     }
   }, [preventBodyScroll, open])
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Dialog should only update the `overflow-y` property of the body (to prevent scrolling)

