### PR TITLE
docs(Icons): add documentation about product category and icons

### DIFF
--- a/packages/icons/src/components/CategoryIcon/__stories__/Documentation.md
+++ b/packages/icons/src/components/CategoryIcon/__stories__/Documentation.md
@@ -1,0 +1,52 @@
+CategoryIcon defines a sets of icons that are linked to Scaleway products. They are used to represent this product with a simple icon.
+
+### ➕ How to add a new one?
+
+Simply edit the file `packages/icons/src/components/CategoryIcon/Icons.tsx`, add the new category icon into the object.
+As you can see from existing icons, you should not include the `<svg>` tag it will be added automatically.
+
+> ** IMPORTANT: ** Make sure that the icon name is unique, otherwise it will override the existing one.\
+> The name should be camelCase and should not contain any special characters.
+
+### ⚙️ How does it works?
+
+Those icons have 3 sets of colors that changes depending on theme. It is all automatic but here is how it works:
+Let's take an example with our AI category icon SVG:
+
+```svg
+<svg>
+    <g className="AI">
+      <path
+        fill="#A365F6"
+        d="M17.784 11.897c.021-.066.034-.136.05-.204a2.818 2.818 0 0 0-.958-2.862 3.037 3.037 0 0 0-.44-3.427 2.726 2.726 0 0 0-1.74-.926 4.032 4.032 0 0 0-2.512-2.275 2.736 2.736 0 0 0-2.094.013 2.348 2.348 0 0 0-.992 2.401l.002.103-.01 9.861c0 .01.005.017.005.026a3.184 3.184 0 0 0 2.663 3.367c.144.016.29.024.435.024a2.972 2.972 0 0 0 2.742-1.619 2.548 2.548 0 0 0 1.496-1.501c.183-.459.223-.962.113-1.444a2.728 2.728 0 0 0 1.24-1.537Zm-3.052 2.328a.693.693 0 0 1-.583.48.935.935 0 0 0-.762.668 1.203 1.203 0 0 1-1.44.792c-.514-.054-1.033-.613-1.033-1.578 0-.006-.004-.011-.004-.017l.003-2.594a1.26 1.26 0 0 1 .177-.716.835.835 0 0 1 .819-.485.911.911 0 0 0-.092-1.818c-.307.01-.61.068-.9.17l.004-4.423-.003-.126c-.016-.25-.01-.502.019-.752.23-.024.462.01.674.102a1.954 1.954 0 0 1 1.195.927c-.49.346-.87.828-1.092 1.385a.91.91 0 0 0 1.675.713c.191-.449.434-.682.724-.694a1.09 1.09 0 0 1 .925.311 1.276 1.276 0 0 1-.124 1.896.915.915 0 0 0 .327 1.468c.36.152.648.435.806.792.026.115.041.232.046.35-.007.151-.047.3-.118.435a1.065 1.065 0 0 1-.14.152 1.109 1.109 0 0 1-.944.281.91.91 0 0 0-.47 1.758c.102.019.206.032.31.039a.566.566 0 0 1 .001.483Z"
+        className="fillStrong"
+      />
+      <path
+        fill="#4F0599"
+        d="m10.922 14.581-.01-9.844.002-.117a2.352 2.352 0 0 0-.991-2.406A2.753 2.753 0 0 0 7.829 2.2a4.041 4.041 0 0 0-2.511 2.277 2.75 2.75 0 0 0-1.74.927 3.038 3.038 0 0 0-.44 3.426 2.884 2.884 0 0 0-.998 1.809 2.547 2.547 0 0 0 .786 2.418c.165.15.347.281.542.39a2.43 2.43 0 0 0 .114 1.43 2.55 2.55 0 0 0 1.496 1.502A2.971 2.971 0 0 0 7.82 18c.14 0 .285-.009.435-.024a3.185 3.185 0 0 0 2.663-3.368c0-.01.005-.017.005-.026Zm-2.856 1.584c-1.095.105-1.378-.579-1.436-.779a.91.91 0 0 0-.766-.681.694.694 0 0 1-.584-.482.58.58 0 0 1-.017-.428c.104-.007.207-.02.31-.039a.909.909 0 0 0 .227-1.675.911.911 0 0 0-.699-.083c-.21.037-.426.01-.62-.077a1.133 1.133 0 0 1-.11-.06l-.028-.02a.958.958 0 0 1-.407-.985c.005-.029.003-.047.01-.077v-.002a1.48 1.48 0 0 1 .819-.84.91.91 0 0 0 .335-1.472 1.277 1.277 0 0 1-.125-1.896 1.077 1.077 0 0 1 .925-.31c.29.012.533.245.724.693a.91.91 0 1 0 1.675-.712 3.11 3.11 0 0 0-1.092-1.386 2.054 2.054 0 0 1 1.27-.953 1.63 1.63 0 0 1 .574-.102c.052.257.066.52.043.781l-.002.14.007 6.592a2.205 2.205 0 0 0-.88-.199.91.91 0 1 0 0 1.82c.358 0 .88.645.88 1.653 0 .966-.52 1.525-1.033 1.579Z"
+        className="fill"
+      />
+    </g>
+</svg>
+```
+
+You will notice that those path inside svg are having a class name, this is what we use to change the color of the icon depending on the theme.
+If you look at the code, you will see that in CSS we target those two classes:
+
+```jsx
+const StyledIcon = styled.svg`
+  .fill {
+    fill: ${({ theme }) => theme.colors.other.icon.category.primary.fill};
+  }
+
+  .fillStrong {
+    fill: ${({ theme }) => theme.colors.other.icon.category.primary.fillStrong};
+  }
+`
+```
+
+We say that when `<path />` tag has class fill, it will take the color of `theme.colors.other.icon.category.primary.fill`.
+
+If the class is fillStrong, it will take the color of `theme.colors.other.icon.category.primary.fillStrong`.
+
+This way, we can have different colors for the same icon depending on the theme, and it will switch the color automatically when the theme changes.

--- a/packages/icons/src/components/CategoryIcon/__stories__/index.stories.tsx
+++ b/packages/icons/src/components/CategoryIcon/__stories__/index.stories.tsx
@@ -1,9 +1,17 @@
 import type { Meta } from '@storybook/react'
 import { CategoryIcon } from '..'
+import Documentation from './Documentation.md'
 
 export default {
   component: CategoryIcon,
   title: 'Icons/CategoryIcon',
+  parameters: {
+    docs: {
+      description: {
+        component: Documentation,
+      },
+    },
+  },
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/icons/src/components/Icon/__stories__/Documentation.md
+++ b/packages/icons/src/components/Icon/__stories__/Documentation.md
@@ -1,0 +1,11 @@
+Icons are inline SVGs that are used in the design system in our React components.
+Those are also called system icons, and they define the icons that are used in the design system in our React components.
+Those icons are customisable through props only.
+
+### ➕ How to add a new one?
+
+Simply edit the file `packages/icons/src/components/Icon/index.tsx`, add the new category icon into the object.
+As you can see from existing icons, you should not include the `<svg>` tag it will be added automatically.
+
+> ** IMPORTANT: ** Make sure that the icon name is unique, otherwise it will override the existing one.\
+> The name should be camelCase and should not contain any special characters.

--- a/packages/icons/src/components/Icon/__stories__/index.stories.tsx
+++ b/packages/icons/src/components/Icon/__stories__/index.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta } from '@storybook/react'
 import { Icon } from '..'
+import Documentation from './Documentation.md'
 
 export default {
   component: Icon,
   parameters: {
     docs: {
       description: {
-        component: 'Allow you to display an svg icon',
+        component: Documentation,
       },
     },
   },

--- a/packages/icons/src/components/ProductIcon/__stories__/Documentation.md
+++ b/packages/icons/src/components/ProductIcon/__stories__/Documentation.md
@@ -1,0 +1,50 @@
+ProductIcon component is used to render a set of icons that are linked to a product or service.
+Those icons are made of multiple colors that changes automatically based on the current theme.
+
+### ➕ How to add a new one?
+
+Simply edit the file `packages/icons/src/components/ProductIcon/Icons.tsx`, add the new category icon into the object.
+As you can see from existing icons, you should not include the `<svg>` tag it will be added automatically.
+
+> ** IMPORTANT: ** Make sure that the icon name is unique, otherwise it will override the existing one.\
+> The name should be camelCase and should not contain any special characters.
+
+### ⚙️ How does it works?
+
+Those icons have 2 sets of colors that changes depending on theme. It is all automatic but here is how it works:
+Let's take an example with our Apple Silicon product icon svg:
+
+```svg
+<svg>
+  <g className="MacMini-M1">
+    <g className=".Square">
+      <path
+        fill="#EEF"
+        d="M0 16C0 7.163 7.163 0 16 0h32c8.837 0 16 7.163 16 16v32c0 8.837-7.163 16-16 16H16C7.163 64 0 56.837 0 48V16Z"
+        className="fillWeak"
+      />
+    </g>
+    <g className="MacMini-M1">
+      <path
+        fill="#4F0599"
+        fillRule="evenodd"
+        d="M40 8.5c5.523 0 10 4.477 10 10v16c0 5.523-4.477 10-10 10h-7v5.17a3.009 3.009 0 0 1 1.83 1.83h13.334a1 1 0 0 1 .117 1.993l-.117.007H34.83a3.001 3.001 0 0 1-5.658 0H15a1 1 0 0 1-.117-1.993L15 51.5h14.171A3.009 3.009 0 0 1 31 49.67V44.5h-7c-5.523 0-10-4.477-10-10v-16c0-5.523 4.477-10 10-10h16Zm-8 34h-8l-.25-.004A8 8 0 0 1 16 34.5v-16l.004-.25A8 8 0 0 1 24 10.5h16l.25.004A8 8 0 0 1 48 18.5v16l-.004.25A8 8 0 0 1 40 42.5h-8Zm0 9a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"
+        className="fill"
+        clipRule="evenodd"
+      />
+      <path
+        fill="#A365F6"
+        fillRule="evenodd"
+        d="M45 18.5a5 5 0 0 0-5-5H24a5 5 0 0 0-5 5v16a5 5 0 0 0 5 5h16a5 5 0 0 0 5-5v-16Zm-21-3h16l.176.005A3 3 0 0 1 43 18.5v16l-.005.176A3 3 0 0 1 40 37.5H24l-.176-.005A3 3 0 0 1 21 34.5v-16l.005-.176A3 3 0 0 1 24 15.5Zm10.11 14.79v-6.98h-1.58l-2.22 5.19-2.22-5.19H26.5v6.98h1.4v-4.54l1.88 4.54h1.06l1.87-4.54v4.54h1.4ZM35.164 23v1.29h.97v6h1.44V23h-2.41Z"
+        className="fillStrong"
+        clipRule="evenodd"
+      />
+    </g>
+  </g>
+</svg>
+```
+
+The same way that we did for CategoryIcon, we have a className on the `<path />` tag that defines the color token to use from theme.
+In this case, we have 3 different colors: `fillWeak`, `fill` and `fillStrong`.
+
+In the code of the component we get the tokens associated with those className and we use them to fill the svg.

--- a/packages/icons/src/components/ProductIcon/__stories__/index.stories.tsx
+++ b/packages/icons/src/components/ProductIcon/__stories__/index.stories.tsx
@@ -1,9 +1,17 @@
 import type { Meta } from '@storybook/react'
 import { ProductIcon } from '..'
+import Documentation from './Documentation.md'
 
 export default {
   component: ProductIcon,
   title: 'Icons/ProductIcon',
+  parameters: {
+    docs: {
+      description: {
+        component: Documentation,
+      },
+    },
+  },
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/__stories__/Changelog/Changelog.stories.tsx
+++ b/packages/ui/src/__stories__/Changelog/Changelog.stories.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react'
 // eslint-disable-next-line import/no-relative-packages
 import ChangelogMdForm from '../../../../form/CHANGELOG.md'
 // eslint-disable-next-line import/no-relative-packages
+import ChangelogMdIcons from '../../../../icons/CHANGELOG.md'
+// eslint-disable-next-line import/no-relative-packages
 import ChangelogMdThemes from '../../../../themes/CHANGELOG.md'
 import ChangelogMdComponents from '../../../CHANGELOG.md'
 import { Stack, Tabs } from '../../components'
@@ -17,6 +19,7 @@ export const Changelog = () => {
         <Tabs.Tab value="components">Components</Tabs.Tab>
         <Tabs.Tab value="form">Form</Tabs.Tab>
         <Tabs.Tab value="themes">Themes</Tabs.Tab>
+        <Tabs.Tab value="icons">Icons</Tabs.Tab>
       </Tabs>
 
       {selected === 'components' && (
@@ -24,6 +27,7 @@ export const Changelog = () => {
       )}
       {selected === 'form' && <Markdown>{ChangelogMdForm}</Markdown>}
       {selected === 'themes' && <Markdown>{ChangelogMdThemes}</Markdown>}
+      {selected === 'icons' && <Markdown>{ChangelogMdIcons}</Markdown>}
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

I added more documentation about `CategoryIcon`, `ProductIcon` and `Icon`. Those documentation have been added to the doc page of each components.

![Screenshot 2023-09-13 at 15 56 20](https://github.com/scaleway/ultraviolet/assets/15812968/dc1bd709-97ba-4a7b-8aa5-68cfaac0539a)
![Screenshot 2023-09-13 at 15 56 34](https://github.com/scaleway/ultraviolet/assets/15812968/21245f0f-2b07-418c-b3e2-97a7aab7eb1f)
![Screenshot 2023-09-13 at 15 56 44](https://github.com/scaleway/ultraviolet/assets/15812968/6696a1dd-a17c-4b91-b25c-919f6f5f1136)
