### PR TITLE
fix(Tooltip): avoid breaking all words and break only when necessary

### DIFF
--- a/.changeset/cool-buttons-pump.md
+++ b/.changeset/cool-buttons-pump.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fixed tooltip to break word automatically and correctly when content is too long

--- a/packages/ui/src/internalComponents/Popup/index.tsx
+++ b/packages/ui/src/internalComponents/Popup/index.tsx
@@ -67,7 +67,7 @@ const StyledTooltip = styled('div', {
   text-align: center;
   position: absolute;
   max-width: ${({ maxWidth }) => maxWidth}px;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   font-size: 0.8rem;
   inset: 0 auto auto 0;
   top: 0;

--- a/packages/ui/src/internalComponents/Popup/index.tsx
+++ b/packages/ui/src/internalComponents/Popup/index.tsx
@@ -67,7 +67,7 @@ const StyledTooltip = styled('div', {
   text-align: center;
   position: absolute;
   max-width: ${({ maxWidth }) => maxWidth}px;
-  word-break: break-all;
+  overflow-wrap: anywhere;
   font-size: 0.8rem;
   inset: 0 auto auto 0;
   top: 0;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

We use to break all words on tooltip in case the content is too big but it cause problems as it will also break words in the middle of them as reported here:

![Screenshot 2023-09-13 at 10 02 21](https://github.com/scaleway/ultraviolet/assets/15812968/eb20c176-3f58-4ec6-93fc-62ea18a45465)

To solve this we removed CSS property `word-break: break-all` and replaced it by `overflow-wrap: anywhere`. This is the correct way to do this for this kind of situation.

Examples:

<img width="226" alt="Screenshot 2023-09-14 at 10 30 53" src="https://github.com/scaleway/ultraviolet/assets/15812968/03639bdb-6a75-4096-a1c6-2a63b03ccf82">
<img width="250" alt="Screenshot 2023-09-14 at 10 31 17" src="https://github.com/scaleway/ultraviolet/assets/15812968/d7fdebb7-54c2-4fb9-b50f-4696d4822b01">
