### PR TITLE
fix(Tooltip): implement esc key without focus

### DIFF
--- a/.changeset/spotty-islands-unite.md
+++ b/.changeset/spotty-islands-unite.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': minor
+---
+
+Tooltip and Popover will now close when ESC keys is pressed

--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -326,6 +326,7 @@ exports[`Button render with a tooltip 1`] = `
 }
 
 <div
+    aria-controls=":r1l:"
     aria-describedby=":r1l:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -263,6 +263,7 @@ export const buttonVariants = Object.keys(
 
 type CommonProps = {
   type?: ButtonHTMLAttributes<HTMLButtonElement>['type']
+  autoFocus?: ButtonHTMLAttributes<HTMLButtonElement>['autoFocus']
   variant?: ButtonVariant
   role?: AriaRole
   size?: ButtonSize
@@ -352,6 +353,7 @@ export const Button = forwardRef<Element, FinalProps>(
       role,
       tooltip,
       tabIndex,
+      autoFocus,
     },
     ref,
   ) => {
@@ -403,6 +405,7 @@ export const Button = forwardRef<Element, FinalProps>(
             ref={ref as Ref<HTMLAnchorElement>}
             iconOnly={!!icon && !children}
             tabIndex={tabIndex}
+            autoFocus={autoFocus}
           >
             {content}
           </Component>
@@ -434,6 +437,7 @@ export const Button = forwardRef<Element, FinalProps>(
           aria-haspopup={ariaHaspopup}
           iconOnly={!!icon && !children}
           tabIndex={tabIndex}
+          autoFocus={autoFocus}
         >
           {content}
         </Component>

--- a/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
@@ -5730,6 +5730,7 @@ exports[`Checkbox renders correctly with tooltip 1`] = `
 }
 
 <div
+    aria-controls=":r9:"
     aria-describedby=":r9:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
@@ -75,6 +75,7 @@ exports[`CopyButton renders correctly 1`] = `
 }
 
 <div
+    aria-controls=":r0:"
     aria-describedby=":r0:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -173,6 +174,7 @@ exports[`CopyButton renders correctly sentiment large 1`] = `
 }
 
 <div
+    aria-controls=":r2:"
     aria-describedby=":r2:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -271,6 +273,7 @@ exports[`CopyButton renders correctly sentiment neutral 1`] = `
 }
 
 <div
+    aria-controls=":r4:"
     aria-describedby=":r4:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -369,6 +372,7 @@ exports[`CopyButton renders correctly sentiment primary 1`] = `
 }
 
 <div
+    aria-controls=":r3:"
     aria-describedby=":r3:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -467,6 +471,7 @@ exports[`CopyButton renders correctly sentiment small 1`] = `
 }
 
 <div
+    aria-controls=":r1:"
     aria-describedby=":r1:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -565,6 +570,7 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
 }
 
 <div
+    aria-controls=":r8:"
     aria-describedby=":r8:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -663,6 +669,7 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
 }
 
 <div
+    aria-controls=":r7:"
     aria-describedby=":r7:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -761,6 +768,7 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
 }
 
 <div
+    aria-controls=":r6:"
     aria-describedby=":r6:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"
@@ -858,6 +866,7 @@ exports[`CopyButton renders correctly with no border 1`] = `
 }
 
 <div
+    aria-controls=":r5:"
     aria-describedby=":r5:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     data-container-full-width="false"

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -3612,6 +3612,7 @@ exports[`List Should render correctly with info 1`] = `
       >
         Column 1
         <div
+          aria-controls=":r4v:"
           aria-describedby=":r4v:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -3632,6 +3633,7 @@ exports[`List Should render correctly with info 1`] = `
       >
         Column 2
         <div
+          aria-controls=":r50:"
           aria-describedby=":r50:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -3652,6 +3654,7 @@ exports[`List Should render correctly with info 1`] = `
       >
         Column 3
         <div
+          aria-controls=":r51:"
           aria-describedby=":r51:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -3672,6 +3675,7 @@ exports[`List Should render correctly with info 1`] = `
       >
         Column 4
         <div
+          aria-controls=":r52:"
           aria-describedby=":r52:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -3692,6 +3696,7 @@ exports[`List Should render correctly with info 1`] = `
       >
         Column 5
         <div
+          aria-controls=":r53:"
           aria-describedby=":r53:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"

--- a/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -252,6 +252,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
       class="cache-1hor4qk-List e12qyakg8"
     >
       <div
+        aria-controls="chart-legend-compute"
         aria-describedby="chart-legend-compute"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -292,6 +293,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-gpu"
         aria-describedby="chart-legend-gpu"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -588,6 +590,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
       class="cache-1hor4qk-List e12qyakg8"
     >
       <div
+        aria-controls="chart-legend-compute"
         aria-describedby="chart-legend-compute"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -628,6 +631,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-gpu"
         aria-describedby="chart-legend-gpu"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1073,6 +1077,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
       class="cache-1hor4qk-List e12qyakg8"
     >
       <div
+        aria-controls="chart-legend-compute"
         aria-describedby="chart-legend-compute"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1113,6 +1118,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-gpu"
         aria-describedby="chart-legend-gpu"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1339,6 +1345,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
       class="cache-1hor4qk-List e12qyakg8"
     >
       <div
+        aria-controls="chart-legend-discount"
         aria-describedby="chart-legend-discount"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1826,6 +1833,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       class="cache-1hor4qk-List e12qyakg8"
     >
       <div
+        aria-controls="chart-legend-compute"
         aria-describedby="chart-legend-compute"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1866,6 +1874,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-gpu"
         aria-describedby="chart-legend-gpu"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1906,6 +1915,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-functions"
         aria-describedby="chart-legend-functions"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1946,6 +1956,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-containers"
         aria-describedby="chart-legend-containers"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -1986,6 +1997,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-s3"
         aria-describedby="chart-legend-s3"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -2026,6 +2038,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-dns"
         aria-describedby="chart-legend-dns"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -2066,6 +2079,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-appleSilicon"
         aria-describedby="chart-legend-appleSilicon"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -2106,6 +2120,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-baremetal"
         aria-describedby="chart-legend-baremetal"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -2146,6 +2161,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-database"
         aria-describedby="chart-legend-database"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -2186,6 +2202,7 @@ exports[`PieChart renders correctly with legend 1`] = `
         </li>
       </div>
       <div
+        aria-controls="chart-legend-lb"
         aria-describedby="chart-legend-lb"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"

--- a/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Tooltip should render correctly with component in content prop 1`] = `
 }
 
 <div
+    aria-controls=":r5:"
     aria-describedby=":r5:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -31,6 +32,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 }
 
 <div
+    aria-controls=":rk:"
     aria-describedby=":rk:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -55,6 +57,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 }
 
 <div
+    aria-controls=":rc:"
     aria-describedby=":rc:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -79,6 +82,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 }
 
 <div
+    aria-controls=":rg:"
     aria-describedby=":rg:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -103,6 +107,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 }
 
 <div
+    aria-controls=":r8:"
     aria-describedby=":r8:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -127,6 +132,7 @@ exports[`Tooltip should render correctly with required props 1`] = `
 }
 
 <div
+    aria-controls=":r0:"
     aria-describedby=":r0:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -147,6 +153,7 @@ exports[`Tooltip should render correctly with required props and visible 1`] = `
 }
 
 <div
+    aria-controls=":r1:"
     aria-describedby=":r1:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -167,6 +174,7 @@ exports[`Tooltip should render correctly with sentiment should renders tooltip w
 }
 
 <div
+    aria-controls=":ro:"
     aria-describedby=":ro:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -191,6 +199,7 @@ exports[`Tooltip should render correctly with sentiment should renders tooltip w
 }
 
 <div
+    aria-controls=":rs:"
     aria-describedby=":rs:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -215,6 +224,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 }
 
 <div
+    aria-controls=":r18:"
     aria-describedby=":r18:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -239,6 +249,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 }
 
 <div
+    aria-controls=":r14:"
     aria-describedby=":r14:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -263,6 +274,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 }
 
 <div
+    aria-controls=":r10:"
     aria-describedby=":r10:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/Radio/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Radio/__tests__/__snapshots__/index.test.tsx.snap
@@ -1196,6 +1196,7 @@ exports[`Radio renders correctly with tooltip 1`] = `
 }
 
 <div
+    aria-controls=":r5:"
     aria-describedby=":r5:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -1946,6 +1946,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 }
 
 <div
+    aria-controls=":r12:"
     aria-describedby=":r12:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"
@@ -3778,6 +3779,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 }
 
 <div
+    aria-controls=":rv:"
     aria-describedby=":rv:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -171,6 +171,7 @@ exports[`Snippet renders correctly 1`] = `
         class="cache-1eagt2o-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":r1:"
           aria-describedby=":r1:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -458,6 +459,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
         class="cache-z90995-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":r3:"
           aria-describedby=":r3:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -783,6 +785,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
         class="cache-z90995-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":r9:"
           aria-describedby=":r9:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -1109,6 +1112,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
         class="cache-z90995-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":r6:"
           aria-describedby=":r6:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -1329,6 +1333,7 @@ exports[`Snippet renders correctly with copiedText 1`] = `
         class="cache-1eagt2o-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":ri:"
           aria-describedby=":ri:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -1526,6 +1531,7 @@ exports[`Snippet renders correctly with copyText 1`] = `
         class="cache-1eagt2o-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":rg:"
           aria-describedby=":rg:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -1813,6 +1819,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
         class="cache-z90995-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":rk:"
           aria-describedby=":rk:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -2123,6 +2130,7 @@ exports[`Snippet renders correctly with showText 1`] = `
         class="cache-z90995-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":rn:"
           aria-describedby=":rn:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -2358,6 +2366,7 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
         class="cache-1eagt2o-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":rc:"
           aria-describedby=":rc:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -2571,6 +2580,7 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
         class="cache-1eagt2o-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":re:"
           aria-describedby=":re:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"
@@ -2858,6 +2868,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
         class="cache-z90995-ButtonContainer e1q0gj904"
       >
         <div
+          aria-controls=":rq:"
           aria-describedby=":rq:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           data-container-full-width="false"

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -1174,6 +1174,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
 }
 
 <div
+    aria-controls=":re:"
     aria-describedby=":re:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -891,6 +891,7 @@ exports[`Table Should render correctly with info 1`] = `
           >
             Name
             <div
+              aria-controls=":r3b:"
               aria-describedby=":r3b:"
               class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
               tabindex="0"

--- a/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -263,6 +263,7 @@ exports[`Tag renders correctly with copiable 1`] = `
 }
 
 <div
+    aria-controls=":r1:"
     aria-describedby=":r1:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`TagList renders correctly 1`] = `
         </span>
       </div>
       <div
+        aria-controls=":r0:"
         aria-describedby=":r0:"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -203,6 +204,7 @@ exports[`TagList renders correctly with copiable 1`] = `
         class="cache-1alpvce-StyledTagContainer eb6op480"
       >
         <div
+          aria-controls=":r4:"
           aria-describedby=":r4:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -219,6 +221,7 @@ exports[`TagList renders correctly with copiable 1`] = `
           </button>
         </div>
         <div
+          aria-controls=":r5:"
           aria-describedby=":r5:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -443,6 +446,7 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
         </span>
       </div>
       <div
+        aria-controls=":r1:"
         aria-describedby=":r1:"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -561,6 +565,7 @@ exports[`TagList renders correctly with custom threshold and extra tags and maxL
         </span>
       </div>
       <div
+        aria-controls=":r2:"
         aria-describedby=":r2:"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"
@@ -662,6 +667,7 @@ exports[`TagList renders correctly with icons 1`] = `
         class="cache-1alpvce-StyledTagContainer eb6op480"
       >
         <div
+          aria-controls=":r6:"
           aria-describedby=":r6:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -678,6 +684,7 @@ exports[`TagList renders correctly with icons 1`] = `
           </button>
         </div>
         <div
+          aria-controls=":r7:"
           aria-describedby=":r7:"
           class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
           tabindex="0"
@@ -815,6 +822,7 @@ exports[`TagList renders correctly with multiline 1`] = `
         </span>
       </div>
       <div
+        aria-controls=":r3:"
         aria-describedby=":r3:"
         class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
         tabindex="0"

--- a/packages/ui/src/components/Toggle/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Toggle/__tests__/__snapshots__/index.test.tsx.snap
@@ -2237,6 +2237,7 @@ exports[`Toggle renders correctly with tooltip 1`] = `
 }
 
 <div
+    aria-controls=":rf:"
     aria-describedby=":rf:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Tooltip should render correctly 1`] = `
 }
 
 <div
+    aria-controls=":r0:"
     aria-describedby=":r0:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/components/Tooltip/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Tooltip/__tests__/index.test.tsx
@@ -147,6 +147,8 @@ describe('Tooltip', () => {
     expect(tooltipPortal).toBeVisible()
 
     await userEvent.keyboard('{Escape}')
-    expect(tooltipPortal).not.toBeVisible()
+    await waitFor(() => {
+      expect(tooltipPortal).not.toBeVisible()
+    })
   })
 })

--- a/packages/ui/src/internalComponents/Popup/__tests__/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/internalComponents/Popup/__tests__/__tests__/__snapshots__/index.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Popup should render correctly 1`] = `
 }
 
 <div
+    aria-controls=":r0:"
     aria-describedby=":r0:"
     class="cache-1hzk1lh-StyledChildrenContainer efkq4700"
     tabindex="0"

--- a/packages/ui/src/internalComponents/Popup/__tests__/__tests__/index.test.tsx
+++ b/packages/ui/src/internalComponents/Popup/__tests__/__tests__/index.test.tsx
@@ -145,6 +145,8 @@ describe('Popup', () => {
     expect(PopupPortal).toBeVisible()
 
     await userEvent.keyboard('{Escape}')
-    expect(PopupPortal).not.toBeVisible()
+    await waitFor(() => {
+      expect(PopupPortal).not.toBeVisible()
+    })
   })
 })

--- a/packages/ui/src/internalComponents/Popup/index.tsx
+++ b/packages/ui/src/internalComponents/Popup/index.tsx
@@ -215,6 +215,20 @@ export const Popup = forwardRef(
     }, [onScrollDetected])
 
     /**
+     * This function is called when we need to hide tooltip. A timeout is set to allow animation end, then remove
+     * tooltip from dom.
+     */
+    const hideTooltip = useCallback(() => {
+      debounceTimer.current = setTimeout(() => {
+        setReverseAnimation(true)
+        timer.current = setTimeout(() => {
+          unmountTooltip()
+          onClose?.()
+        }, ANIMATION_DURATION)
+      }, 200)
+    }, [onClose, unmountTooltip])
+
+    /**
      * When mouse hover or stop hovering children this function display or hide tooltip. A timeout is set to allow animation
      * end, then remove tooltip from dom.
      */
@@ -224,13 +238,7 @@ export const Popup = forwardRef(
         // There is debounce in order to avoid tooltip to flicker when we move the mouse from children to tooltip
         // Timer is used to follow the animation duration
         if (!isVisible && innerTooltipRef.current && !debounceTimer.current) {
-          debounceTimer.current = setTimeout(() => {
-            setReverseAnimation(true)
-            timer.current = setTimeout(() => {
-              unmountTooltip()
-              onClose?.()
-            }, ANIMATION_DURATION)
-          }, 200)
+          hideTooltip()
         } else if (isVisible) {
           // This condition is for when we want to mount the tooltip
           // If the timer exists it means the tooltip was about to umount, but we hovered the children again,
@@ -249,7 +257,7 @@ export const Popup = forwardRef(
           setVisibleInDom(true)
         }
       },
-      [innerTooltipRef, onClose, unmountTooltip],
+      [hideTooltip, innerTooltipRef],
     )
 
     /**
@@ -299,13 +307,7 @@ export const Popup = forwardRef(
         if (event.key === 'Escape') {
           event.preventDefault()
           event.stopPropagation()
-          debounceTimer.current = setTimeout(() => {
-            setReverseAnimation(true)
-            timer.current = setTimeout(() => {
-              unmountTooltip()
-              onClose?.()
-            }, ANIMATION_DURATION)
-          }, 200)
+          hideTooltip()
         }
       }
       if (visibleInDom) {
@@ -325,7 +327,7 @@ export const Popup = forwardRef(
           capture: true,
         })
       }
-    }, [onClose, unmountTooltip, visibleInDom])
+    }, [hideTooltip, onClose, unmountTooltip, visibleInDom])
 
     /**
      * Will render children conditionally if children is a function or not.


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

We use to have ESC key handled on tooltip but only on focus, it is now handled without focus too. The same features is implemented in Popover as it uses Popup.
