### PR TITLE
fix(Popover): improve accessibility of the component

### DIFF
--- a/.changeset/green-sheep-grin.md
+++ b/.changeset/green-sheep-grin.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': minor
+---
+
+Improve accessibility of Popover component

--- a/packages/ui/src/components/Popover/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Popover/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, jest, test } from '@jest/globals'
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ComponentProps } from 'react'
 import { Popover } from '..'
@@ -135,5 +135,35 @@ describe('Tooltip', () => {
     await userEvent.click(outsideElement)
 
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test(`should open on space key and close on space key - a11y`, async () => {
+    const onClose = jest.fn(() => {})
+
+    renderWithTheme(
+      <div style={{ height: '500px', width: '500px' }}>
+        <Popover
+          title="Test"
+          content="Test"
+          data-testid="popover"
+          onClose={onClose}
+        >
+          Children
+        </Popover>
+      </div>,
+    )
+
+    await userEvent.keyboard('{Tab}')
+    await userEvent.keyboard('{ }')
+
+    const popover = screen.getByTestId('popover')
+    expect(popover).toBeVisible()
+
+    await userEvent.keyboard('{ }')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(popover).not.toBeVisible()
+    })
   })
 })

--- a/packages/ui/src/internalComponents/Popup/index.tsx
+++ b/packages/ui/src/internalComponents/Popup/index.tsx
@@ -1,6 +1,12 @@
 import { css, keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import type { KeyboardEventHandler, ReactNode, Ref, RefObject } from 'react'
+import type {
+  HTMLAttributes,
+  KeyboardEventHandler,
+  ReactNode,
+  Ref,
+  RefObject,
+} from 'react'
 import {
   forwardRef,
   useCallback,
@@ -143,6 +149,8 @@ type TooltipProps = {
   'data-testid'?: string
   hasArrow?: boolean
   onClose?: () => void
+  onKeyDown?: KeyboardEventHandler
+  'aria-haspopup'?: HTMLAttributes<HTMLDivElement>['aria-haspopup']
 }
 
 export const Popup = forwardRef(
@@ -161,6 +169,8 @@ export const Popup = forwardRef(
       'data-testid': dataTestId,
       hasArrow = true,
       onClose,
+      onKeyDown,
+      'aria-haspopup': ariaHasPopup,
     }: TooltipProps,
     tooltipRef: Ref<HTMLDivElement>,
   ) => {
@@ -292,7 +302,7 @@ export const Popup = forwardRef(
       }
     }, [isControlled, onPointerEvent, visible])
 
-    const onKeyDown: KeyboardEventHandler = useCallback(
+    const onLocalKeyDown: KeyboardEventHandler = useCallback(
       event => {
         if (event.code === 'Escape') {
           unmountTooltip()
@@ -353,18 +363,24 @@ export const Popup = forwardRef(
           onPointerLeave={!isControlled ? onPointerEvent(false) : noop}
           ref={childrenRef}
           tabIndex={0}
-          onKeyDown={onKeyDown}
+          onKeyDown={event => {
+            onKeyDown?.(event)
+            onLocalKeyDown(event)
+          }}
           data-container-full-width={containerFullWidth}
+          aria-haspopup={ariaHasPopup}
         >
           {children}
         </StyledChildrenContainer>
       )
     }, [
+      ariaHasPopup,
       children,
       containerFullWidth,
       generatedId,
       isControlled,
       onKeyDown,
+      onLocalKeyDown,
       onPointerEvent,
     ])
 


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Improvement of the accessibility of Popover component. It should open on focus with space key and close with escape key. Also, the focus should follow inside of the component when it opens and go back on the container when it closes.

## Relevant logs and/or screenshots

https://github.com/scaleway/ultraviolet/assets/15812968/ebfa1987-f58d-446f-a7e3-64daa1d2fb9a


