### PR TITLE
fix(Tooltip): remove pointer event

### DIFF
--- a/.changeset/wet-shoes-taste.md
+++ b/.changeset/wet-shoes-taste.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fix Tooltip to remove pointer events on tooltip itself

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import type { ComponentProps, Ref } from 'react'
 import { forwardRef } from 'react'
 import { Popup } from '../../internalComponents'
@@ -16,6 +17,10 @@ type TooltipProps = Pick<
   | 'data-testid'
   | 'containerFullWidth'
 >
+
+const StyledPopup = styled(Popup)`
+  pointer-events: none;
+`
 
 /**
  * Tooltip component is used to display additional information on hover or focus.
@@ -38,7 +43,7 @@ export const Tooltip = forwardRef(
     }: TooltipProps,
     tooltipRef: Ref<HTMLDivElement>,
   ) => (
-    <Popup
+    <StyledPopup
       id={id}
       ref={tooltipRef}
       role={role}
@@ -52,6 +57,6 @@ export const Tooltip = forwardRef(
       innerRef={innerRef}
     >
       {children}
-    </Popup>
+    </StyledPopup>
   ),
 )


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

We have some issues with Tooltip as you can see on this video:

https://github.com/scaleway/ultraviolet/assets/15812968/4bd76cb6-28cc-4652-ae1d-00448e07a2b8

This is an infinite loop on tooltip, the tooltip is shown where the mouse is but then as the tooltip over the mouse then the hover is no more detected on container and so tooltip disapear, etc

