### PR TITLE
fix(Badge): simplify and correct badge tags in the dom

### DIFF
--- a/.changeset/sharp-rockets-search.md
+++ b/.changeset/sharp-rockets-search.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Correct and simplify bagde tags in the DOM

--- a/packages/ui/src/components/Badge/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Badge/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,16 @@
 
 exports[`Badge renders correctly prominence default 1`] = `
 <DocumentFragment>
-  .cache-abjcpx-StyledSpan {
+  .cache-6f2izv-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -23,42 +32,34 @@ exports[`Badge renders correctly prominence default 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    class="cache-abjcpx-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-6f2izv-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly prominence strong 1`] = `
 <DocumentFragment>
-  .cache-gvtkie-StyledSpan {
+  .cache-fscxeq-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -79,42 +80,34 @@ exports[`Badge renders correctly prominence strong 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #ffffff;
   background: #151a2d;
   border: 1px solid #151a2d;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    class="cache-gvtkie-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-fscxeq-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly sentiment danger 1`] = `
 <DocumentFragment>
-  .cache-1he3rw9-StyledSpan {
+  .cache-z9kyl8-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -135,43 +128,34 @@ exports[`Badge renders correctly sentiment danger 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #b3144d;
   background: #ffebf2;
   border: 1px solid #ffebf2;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    aria-label="danger"
-    class="cache-1he3rw9-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-z9kyl8-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly sentiment info 1`] = `
 <DocumentFragment>
-  .cache-2ik0ci-StyledSpan {
+  .cache-o7c0gk-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -192,43 +176,34 @@ exports[`Badge renders correctly sentiment info 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #005da3;
   background: #e0f2ff;
   border: 1px solid #e0f2ff;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    aria-label="info"
-    class="cache-2ik0ci-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-o7c0gk-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly sentiment neutral 1`] = `
 <DocumentFragment>
-  .cache-abjcpx-StyledSpan {
+  .cache-6f2izv-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -249,42 +224,34 @@ exports[`Badge renders correctly sentiment neutral 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    class="cache-abjcpx-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-6f2izv-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly sentiment primary 1`] = `
 <DocumentFragment>
-  .cache-pjlakp-StyledSpan {
+  .cache-1uuj7dt-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -305,42 +272,34 @@ exports[`Badge renders correctly sentiment primary 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #521094;
   background: #f1eefc;
   border: 1px solid #f1eefc;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    class="cache-pjlakp-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-1uuj7dt-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly sentiment secondary 1`] = `
 <DocumentFragment>
-  .cache-5z9cr9-StyledSpan {
+  .cache-1sruvm5-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -361,43 +320,34 @@ exports[`Badge renders correctly sentiment secondary 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #ac22e7;
   background: #f9ebff;
   border: 1px solid #f9ebff;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    aria-label="secondary"
-    class="cache-5z9cr9-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-1sruvm5-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly sentiment success 1`] = `
 <DocumentFragment>
-  .cache-1nmi5rd-StyledSpan {
+  .cache-ad2fjs-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -418,43 +368,34 @@ exports[`Badge renders correctly sentiment success 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #22674e;
   background: #daf6ec;
   border: 1px solid #daf6ec;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    aria-label="success"
-    class="cache-1nmi5rd-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-ad2fjs-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly sentiment warning 1`] = `
 <DocumentFragment>
-  .cache-125cmyy-StyledSpan {
+  .cache-zvya2g-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -475,12 +416,25 @@ exports[`Badge renders correctly sentiment warning 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #7c5400;
   background: #fff6e6;
   border: 1px solid #fff6e6;
 }
 
-.cache-1109ln7-StyledText-StyledText {
+<span
+    class="ej33bna0 cache-zvya2g-StyledText-StyledSpan e13y3mga0"
+  >
+    Sample badge
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Badge renders correctly size large 1`] = `
+<DocumentFragment>
+  .cache-fiqya7-StyledText-StyledSpan {
   color: #3f4250;
   font-size: 16px;
   font-family: Asap;
@@ -490,28 +444,6 @@ exports[`Badge renders correctly sentiment warning 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
-<span
-    aria-label="warning"
-    class="cache-125cmyy-StyledSpan ej33bna0"
-    role="status"
-  >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
-  </span>
-</DocumentFragment>
-`;
-
-exports[`Badge renders correctly size large 1`] = `
-<DocumentFragment>
-  .cache-j5mw8o-StyledSpan {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -532,12 +464,25 @@ exports[`Badge renders correctly size large 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 32px;
+  text-transform: uppercase;
+  font-size: 14px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.cache-1mczr76-StyledText-StyledText {
+<span
+    class="ej33bna0 cache-fiqya7-StyledText-StyledSpan e13y3mga0"
+  >
+    Sample badge
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Badge renders correctly size medium 1`] = `
+<DocumentFragment>
+  .cache-6f2izv-StyledText-StyledSpan {
   color: #3f4250;
   font-size: 16px;
   font-family: Asap;
@@ -547,27 +492,6 @@ exports[`Badge renders correctly size large 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-transform: uppercase;
-  font-size: 14px;
-  color: inherit;
-}
-
-<span
-    class="cache-j5mw8o-StyledSpan ej33bna0"
-    role="status"
-  >
-    <p
-      class="ej33bna1 cache-1mczr76-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
-  </span>
-</DocumentFragment>
-`;
-
-exports[`Badge renders correctly size medium 1`] = `
-<DocumentFragment>
-  .cache-abjcpx-StyledSpan {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -588,12 +512,25 @@ exports[`Badge renders correctly size medium 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.cache-1109ln7-StyledText-StyledText {
+<span
+    class="ej33bna0 cache-6f2izv-StyledText-StyledSpan e13y3mga0"
+  >
+    Sample badge
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Badge renders correctly size small 1`] = `
+<DocumentFragment>
+  .cache-1k0nst5-StyledText-StyledSpan {
   color: #3f4250;
   font-size: 16px;
   font-family: Asap;
@@ -603,27 +540,6 @@ exports[`Badge renders correctly size medium 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
-<span
-    class="cache-abjcpx-StyledSpan ej33bna0"
-    role="status"
-  >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
-  </span>
-</DocumentFragment>
-`;
-
-exports[`Badge renders correctly size small 1`] = `
-<DocumentFragment>
-  .cache-1osa4cx-StyledSpan {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -644,42 +560,34 @@ exports[`Badge renders correctly size small 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 16px;
+  text-transform: uppercase;
+  font-size: 10px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.cache-132ty73-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 10px;
-  color: inherit;
-}
-
 <span
-    class="cache-1osa4cx-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-1k0nst5-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-132ty73-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly when disabled 1`] = `
 <DocumentFragment>
-  .cache-uyfz49-StyledSpan {
+  .cache-1qliy49-StyledText-StyledSpan {
+  color: #727683;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -700,68 +608,25 @@ exports[`Badge renders correctly when disabled 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #727683;
   background: #e9eaeb;
   border: none;
 }
 
-.cache-iy8yz5-StyledText-StyledText {
-  color: #727683;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    class="cache-uyfz49-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-1qliy49-StyledText-StyledSpan e13y3mga0"
   >
-    <p
-      class="ej33bna1 cache-iy8yz5-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;
 
 exports[`Badge renders correctly with default values 1`] = `
 <DocumentFragment>
-  .cache-abjcpx-StyledSpan {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: 24px;
-  color: #3f4250;
-  background: #f9f9fa;
-  border: 1px solid #d9dadd;
-}
-
-.cache-1109ln7-StyledText-StyledText {
+  .cache-6f2izv-StyledText-StyledSpan {
   color: #3f4250;
   font-size: 16px;
   font-family: Asap;
@@ -771,27 +636,6 @@ exports[`Badge renders correctly with default values 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
-<span
-    class="cache-abjcpx-StyledSpan ej33bna0"
-    role="status"
-  >
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
-  </span>
-</DocumentFragment>
-`;
-
-exports[`Badge renders correctly with icon 1`] = `
-<DocumentFragment>
-  .cache-abjcpx-StyledSpan {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -812,6 +656,57 @@ exports[`Badge renders correctly with icon 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
+  color: #3f4250;
+  background: #f9f9fa;
+  border: 1px solid #d9dadd;
+}
+
+<span
+    class="ej33bna0 cache-6f2izv-StyledText-StyledSpan e13y3mga0"
+  >
+    Sample badge
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Badge renders correctly with icon 1`] = `
+<DocumentFragment>
+  .cache-6f2izv-StyledText-StyledSpan {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 16px;
+  padding: 0 16px;
+  gap: 8px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -826,24 +721,8 @@ exports[`Badge renders correctly with icon 1`] = `
   min-height: 16px;
 }
 
-.cache-1109ln7-StyledText-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
 <span
-    class="cache-abjcpx-StyledSpan ej33bna0"
-    role="status"
+    class="ej33bna0 cache-6f2izv-StyledText-StyledSpan e13y3mga0"
   >
     <svg
       class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
@@ -853,11 +732,7 @@ exports[`Badge renders correctly with icon 1`] = `
         d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
       />
     </svg>
-    <p
-      class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-    >
-      Sample badge
-    </p>
+    Sample badge
   </span>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/Badge/index.tsx
+++ b/packages/ui/src/components/Badge/index.tsx
@@ -11,12 +11,6 @@ import { Text } from '../Text'
 
 type IconName = ComponentProps<typeof Icon>['name']
 
-const StyledText = styled(Text)<{ fontSize: number }>`
-  text-transform: uppercase;
-  font-size: ${({ fontSize }) => fontSize}px;
-  color: inherit;
-`
-
 // TODO: remove when typography has been created
 const TEXT_SIZES = {
   large: 14,
@@ -94,9 +88,10 @@ const generateStyles = ({
   }
 }
 
-const StyledSpan = styled('span', {
-  shouldForwardProp: prop => !['sentiment', 'size'].includes(prop),
-})<{ size: number; sentiment: string }>`
+const StyledSpan = styled(Text, {
+  shouldForwardProp: prop =>
+    !['sentimentStyles', 'size', 'fontSize'].includes(prop),
+})<{ size: number; sentimentStyles: string; fontSize: number }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -109,7 +104,10 @@ const StyledSpan = styled('span', {
     size === SIZES.small ? theme.space['0.5'] : theme.space['1']};
   width: fit-content;
   height: ${({ size }) => size}px;
-  ${({ sentiment }) => sentiment}
+  text-transform: uppercase;
+  font-size: ${({ fontSize }) => fontSize}px;
+  color: inherit;
+  ${({ sentimentStyles }) => sentimentStyles}
 `
 
 type BadgeProps = {
@@ -161,26 +159,22 @@ export const Badge = ({
 
   return (
     <StyledSpan
-      role="status"
       aria-label={ariaLabel}
-      sentiment={
+      sentimentStyles={
         disabled ? generatedStyles['disabled'] : generatedStyles[sentiment]
       }
       size={sizeValue}
+      variant="bodyStrong"
+      as="span"
+      fontSize={TEXT_SIZES[size]}
+      prominence={disabled ? 'weak' : 'default'}
       className={className}
       data-testid={dataTestId}
     >
       {icon && sizeValue !== SIZES.small ? (
         <Icon name={icon} size={16} />
       ) : null}
-      <StyledText
-        variant="bodyStrong"
-        as="p"
-        fontSize={TEXT_SIZES[size]}
-        prominence={disabled ? 'weak' : 'default'}
-      >
-        {children}
-      </StyledText>
+      {children}
     </StyledSpan>
   )
 }

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -966,35 +966,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-u0igup-StyledSpan-StyledBadge {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: 24px;
-  color: #ffffff;
-  background: #521094;
-  border: 1px solid #521094;
-  padding: 0 8px;
-  margin-left: 8px;
-}
-
-.cache-1109ln7-StyledText-StyledText {
+.cache-137fywg-StyledText-StyledSpan-StyledBadge {
   color: #3f4250;
   font-size: 16px;
   font-family: Asap;
@@ -1004,12 +976,6 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
-.cache-zfwzve-StyledSpan-StyledBadge {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1030,6 +996,49 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
+  color: #ffffff;
+  background: #521094;
+  border: 1px solid #521094;
+  padding: 0 8px;
+  margin-left: 8px;
+}
+
+.cache-wvxa5r-StyledText-StyledSpan-StyledBadge {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 16px;
+  padding: 0 16px;
+  gap: 8px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -1267,14 +1276,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       First
       <span
-        class="e1hzf7cr3 cache-u0igup-StyledSpan-StyledBadge ej33bna0"
-        role="status"
+        class="e1hzf7cr3 ej33bna0 cache-137fywg-StyledText-StyledSpan-StyledBadge e13y3mga0"
       >
-        <p
-          class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-        >
-          2
-        </p>
+        2
       </span>
     </button>
     <button
@@ -1308,14 +1312,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       Counter
       <span
-        class="e1hzf7cr3 cache-zfwzve-StyledSpan-StyledBadge ej33bna0"
-        role="status"
+        class="e1hzf7cr3 ej33bna0 cache-wvxa5r-StyledText-StyledSpan-StyledBadge e13y3mga0"
       >
-        <p
-          class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-        >
-          12
-        </p>
+        12
       </span>
     </button>
     <button
@@ -1329,14 +1328,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       Counter no items
       <span
-        class="e1hzf7cr3 cache-zfwzve-StyledSpan-StyledBadge ej33bna0"
-        role="status"
+        class="e1hzf7cr3 ej33bna0 cache-wvxa5r-StyledText-StyledSpan-StyledBadge e13y3mga0"
       >
-        <p
-          class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-        >
-          0
-        </p>
+        0
       </span>
     </button>
     <button
@@ -1349,14 +1343,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       Conter and badge
       <span
-        class="e1hzf7cr3 cache-zfwzve-StyledSpan-StyledBadge ej33bna0"
-        role="status"
+        class="e1hzf7cr3 ej33bna0 cache-wvxa5r-StyledText-StyledSpan-StyledBadge e13y3mga0"
       >
-        <p
-          class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-        >
-          12
-        </p>
+        12
       </span>
       <span
         class="cache-1hjfwlj-BadgeContainer e1hzf7cr1"
@@ -1722,35 +1711,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-u0igup-StyledSpan-StyledBadge {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: 24px;
-  color: #ffffff;
-  background: #521094;
-  border: 1px solid #521094;
-  padding: 0 8px;
-  margin-left: 8px;
-}
-
-.cache-1109ln7-StyledText-StyledText {
+.cache-137fywg-StyledText-StyledSpan-StyledBadge {
   color: #3f4250;
   font-size: 16px;
   font-family: Asap;
@@ -1760,12 +1721,6 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
-}
-
-.cache-zfwzve-StyledSpan-StyledBadge {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1786,6 +1741,49 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   width: -moz-fit-content;
   width: fit-content;
   height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
+  color: #ffffff;
+  background: #521094;
+  border: 1px solid #521094;
+  padding: 0 8px;
+  margin-left: 8px;
+}
+
+.cache-wvxa5r-StyledText-StyledSpan-StyledBadge {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 16px;
+  padding: 0 16px;
+  gap: 8px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: 24px;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -1935,14 +1933,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           >
             First
             <span
-              class="e1hzf7cr3 cache-u0igup-StyledSpan-StyledBadge ej33bna0"
-              role="status"
+              class="e1hzf7cr3 ej33bna0 cache-137fywg-StyledText-StyledSpan-StyledBadge e13y3mga0"
             >
-              <p
-                class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-              >
-                2
-              </p>
+              2
             </span>
           </button>
           <button
@@ -1976,14 +1969,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           >
             Counter
             <span
-              class="e1hzf7cr3 cache-zfwzve-StyledSpan-StyledBadge ej33bna0"
-              role="status"
+              class="e1hzf7cr3 ej33bna0 cache-wvxa5r-StyledText-StyledSpan-StyledBadge e13y3mga0"
             >
-              <p
-                class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-              >
-                12
-              </p>
+              12
             </span>
           </button>
           <button
@@ -1997,14 +1985,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           >
             Counter no items
             <span
-              class="e1hzf7cr3 cache-zfwzve-StyledSpan-StyledBadge ej33bna0"
-              role="status"
+              class="e1hzf7cr3 ej33bna0 cache-wvxa5r-StyledText-StyledSpan-StyledBadge e13y3mga0"
             >
-              <p
-                class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-              >
-                0
-              </p>
+              0
             </span>
           </button>
           <button
@@ -2017,14 +2000,9 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           >
             Conter and badge
             <span
-              class="e1hzf7cr3 cache-zfwzve-StyledSpan-StyledBadge ej33bna0"
-              role="status"
+              class="e1hzf7cr3 ej33bna0 cache-wvxa5r-StyledText-StyledSpan-StyledBadge e13y3mga0"
             >
-              <p
-                class="ej33bna1 cache-1109ln7-StyledText-StyledText e13y3mga0"
-              >
-                12
-              </p>
+              12
             </span>
             <span
               class="cache-1hjfwlj-BadgeContainer e1hzf7cr1"


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Current badge is invalid as it has a paragraph (block element) inside a span (inline element). It also has 2 tags while it could ne simplified in one and make the dom less heavy.

Before:
<img width="505" alt="Screenshot 2023-09-19 at 10 50 05" src="https://github.com/scaleway/ultraviolet/assets/15812968/c12464b3-b4ef-47ba-a222-37118fad8ff9">

After:
<img width="552" alt="Screenshot 2023-09-19 at 10 50 32" src="https://github.com/scaleway/ultraviolet/assets/15812968/655a21d8-a181-4702-92da-9951d530f6fb">

