### PR TITLE
refactor(Notice): changed to span and reduced icon size

### DIFF
--- a/.changeset/pretty-cameras-push.md
+++ b/.changeset/pretty-cameras-push.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/form': minor
+'@ultraviolet/ui': minor
+---
+
+Refactoring of Notice component to be a span with smaller icon so it fits better in TextInput

--- a/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -590,40 +590,7 @@ exports[`TextInputField should render correctly notice 1`] = `
   padding-top: 2px;
 }
 
-.cache-159nqe {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  margin-top: 8px;
-}
-
-.cache-k1vg20-sizeStyles {
-  vertical-align: middle;
-  fill: #727683;
-  height: 20px;
-  width: 20px;
-  min-width: 20px;
-  min-height: 20px;
-}
-
-.cache-g106tl {
+.cache-1oazdw8 {
   color: #727683;
   font-size: 12px;
   font-family: Asap;
@@ -633,6 +600,25 @@ exports[`TextInputField should render correctly notice 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.cache-1eowv3p-sizeStyles {
+  vertical-align: middle;
+  fill: #727683;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 <form
@@ -657,23 +643,19 @@ exports[`TextInputField should render correctly notice 1`] = `
           class="cache-xbtm7g el3h3g94"
         />
       </div>
-      <div
-        class="el3h3g93 cache-159nqe ehpbis70"
+      <span
+        class="el3h3g93 e19pqvs30 cache-1oazdw8 e13y3mga0"
       >
         <svg
-          class="cache-k1vg20-sizeStyles e1gt4cfo0"
+          class="cache-1eowv3p-sizeStyles e1gt4cfo0"
           viewBox="0 0 24 24"
         >
           <path
             d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
           />
         </svg>
-        <p
-          class="cache-g106tl e13y3mga0"
-        >
-          notice
-        </p>
-      </div>
+        notice
+      </span>
     </div>
   </form>
 </DocumentFragment>

--- a/packages/ui/src/components/Notice/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Notice/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,39 +2,7 @@
 
 exports[`Notice renders correctly with default props 1`] = `
 <DocumentFragment>
-  .cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-k1vg20-sizeStyles {
-  vertical-align: middle;
-  fill: #727683;
-  height: 20px;
-  width: 20px;
-  min-width: 20px;
-  min-height: 20px;
-}
-
-.cache-zmz950-StyledText {
+  .cache-77mh00-StyledText-StyledSpan {
   color: #727683;
   font-size: 12px;
   font-family: Asap;
@@ -44,24 +12,38 @@ exports[`Notice renders correctly with default props 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 8px;
 }
 
-<div
-    class="cache-irytw7-Stack ehpbis70"
+.cache-1eowv3p-sizeStyles {
+  vertical-align: middle;
+  fill: #727683;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<span
+    class="e19pqvs30 cache-77mh00-StyledText-StyledSpan e13y3mga0"
   >
     <svg
-      class="cache-k1vg20-sizeStyles e1gt4cfo0"
+      class="cache-1eowv3p-sizeStyles e1gt4cfo0"
       viewBox="0 0 24 24"
     >
       <path
         d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
       />
     </svg>
-    <p
-      class="cache-zmz950-StyledText e13y3mga0"
-    >
-      Hello
-    </p>
-  </div>
+    Hello
+  </span>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/Notice/index.tsx
+++ b/packages/ui/src/components/Notice/index.tsx
@@ -1,6 +1,6 @@
+import styled from '@emotion/styled'
 import { Icon } from '@ultraviolet/icons'
 import type { ReactNode } from 'react'
-import { Stack } from '../Stack'
 import { Text } from '../Text'
 
 type NoticeProps = {
@@ -8,6 +8,12 @@ type NoticeProps = {
   className?: string
   'data-testid'?: string
 }
+
+const StyledSpan = styled(Text)`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space['1']};
+`
 
 /**
  * A Notice is used to display a short message to the user.
@@ -17,25 +23,20 @@ export const Notice = ({
   className,
   'data-testid': dataTestId,
 }: NoticeProps) => (
-  <Stack
-    direction="row"
-    alignItems="center"
-    gap={1}
+  <StyledSpan
+    as="span"
+    variant="caption"
+    sentiment="neutral"
+    prominence="weak"
     data-testid={dataTestId}
     className={className}
   >
     <Icon
       name="information-outline"
-      size={20}
+      size={16}
       color="neutral"
       prominence="weak"
     />
-    {typeof children === 'string' ? (
-      <Text as="p" variant="caption" color="neutral" prominence="weak">
-        {children}
-      </Text>
-    ) : (
-      children
-    )}
-  </Stack>
+    {children}
+  </StyledSpan>
 )

--- a/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -3143,40 +3143,7 @@ exports[`TextInput should render correctly with notice 1`] = `
   padding-top: 2px;
 }
 
-.cache-1ul7jq-Stack-StyledNotice {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  margin-top: 8px;
-}
-
-.cache-k1vg20-sizeStyles {
-  vertical-align: middle;
-  fill: #727683;
-  height: 20px;
-  width: 20px;
-  min-width: 20px;
-  min-height: 20px;
-}
-
-.cache-zmz950-StyledText {
+.cache-eav41n-StyledText-StyledSpan-StyledNotice {
   color: #727683;
   font-size: 12px;
   font-family: Asap;
@@ -3186,6 +3153,25 @@ exports[`TextInput should render correctly with notice 1`] = `
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.cache-1eowv3p-sizeStyles {
+  vertical-align: middle;
+  fill: #727683;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 <div>
@@ -3213,23 +3199,19 @@ exports[`TextInput should render correctly with notice 1`] = `
         class="cache-1aqops6-StyledError el3h3g94"
       />
     </div>
-    <div
-      class="el3h3g93 cache-1ul7jq-Stack-StyledNotice ehpbis70"
+    <span
+      class="el3h3g93 e19pqvs30 cache-eav41n-StyledText-StyledSpan-StyledNotice e13y3mga0"
     >
       <svg
-        class="cache-k1vg20-sizeStyles e1gt4cfo0"
+        class="cache-1eowv3p-sizeStyles e1gt4cfo0"
         viewBox="0 0 24 24"
       >
         <path
           d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
         />
       </svg>
-      <p
-        class="cache-zmz950-StyledText e13y3mga0"
-      >
-        Test notice
-      </p>
-    </div>
+      Test notice
+    </span>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -169,7 +169,7 @@ const StyledError = styled.div`
 `
 
 const StyledNotice = styled(Notice)`
-  margin-top: ${({ theme }) => theme.space['1']};
+  margin-top: ${({ theme }) => theme.space['0.5']};
 `
 
 type StyledInputProps = {


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Current Notice is a paragraph while it should be a span avoiding the margin top and bottom of the paragraph. Plus we reduced the size of the icon fitting better into a TextInput.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1023" alt="Screenshot 2023-09-19 at 16 32 01" src="https://github.com/scaleway/ultraviolet/assets/15812968/22398137-ea50-4cbd-8dd0-efb446e0fb97"> | <img width="1038" alt="Screenshot 2023-09-19 at 16 32 12" src="https://github.com/scaleway/ultraviolet/assets/15812968/c9305358-e5d8-4a89-b094-ba86b227183e"> |
| url  | <img width="1032" alt="Screenshot 2023-09-19 at 16 32 35" src="https://github.com/scaleway/ultraviolet/assets/15812968/b27945b7-67c3-41e3-8157-feaadf7ca625"> | <img width="1038" alt="Screenshot 2023-09-19 at 16 32 40" src="https://github.com/scaleway/ultraviolet/assets/15812968/cc49bd03-aac6-401b-86d9-8098bc79d858"> |
| url  | <img width="557" alt="Screenshot 2023-09-19 at 16 33 13" src="https://github.com/scaleway/ultraviolet/assets/15812968/900db001-0a04-4159-93d8-10e65c895931"> | <img width="598" alt="Screenshot 2023-09-19 at 16 33 29" src="https://github.com/scaleway/ultraviolet/assets/15812968/3a0c0d88-9030-45a5-a4a1-66805ed79661"> |
