### PR TITLE
chore: remove `prop-types` & `@types/prop-types`

### DIFF
--- a/.changeset/fuzzy-knives-wink.md
+++ b/.changeset/fuzzy-knives-wink.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Remove prop-types dependency

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",
     "@types/node": "18.17.15",
-    "@types/prop-types": "15.7.5",
     "@types/react": "18.2.21",
     "@types/react-datepicker": "4.15.0",
     "@types/react-dom": "18.2.7",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -62,7 +62,6 @@
     "@ultraviolet/icons": "workspace:*",
     "@scaleway/use-media": "2.0.1",
     "deepmerge": "4.3.1",
-    "prop-types": "15.8.1",
     "react-datepicker": "4.17.0",
     "react-flatten-children": "1.1.2",
     "react-select": "5.7.4",


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

#### What is expected?

We no longer use `prop-types` so it can safely be removed.