### PR TITLE
fix: changesets

### DIFF
--- a/.changeset/renovate-7410c46.md
+++ b/.changeset/renovate-7410c46.md
@@ -1,6 +1,4 @@
 ---
-'@examples/next-advanced': patch
-'@examples/next-simple': patch
 '@ultraviolet/form': patch
 '@ultraviolet/icons': patch
 '@ultraviolet/ui': patch


### PR DESCRIPTION
## Summary

## Type

Following the fix in https://github.com/scaleway/scaleway-lib/pull/1531, this removes the example packages in changeset.