### PR TITLE
fix(theme): deprecated theme name and replaced by new one

### DIFF
--- a/.changeset/violet-flowers-move.md
+++ b/.changeset/violet-flowers-move.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/icons': minor
+'@ultraviolet/ui': minor
+---
+
+Type `SCWUITheme` is now deprecated and should be replaced by `UltravioletUITheme`

--- a/examples/next-simple/emotion.d.ts
+++ b/examples/next-simple/emotion.d.ts
@@ -1,7 +1,7 @@
 import '@emotion/react'
-import type { SCWUITheme } from '@ultraviolet/ui'
+import type { UltravioletUITheme } from '@ultraviolet/ui'
 
 declare module '@emotion/react' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-empty-interface
-  export interface Theme extends SCWUITheme {}
+  export interface Theme extends UltravioletUITheme {}
 }

--- a/packages/icons/src/emotion.d.ts
+++ b/packages/icons/src/emotion.d.ts
@@ -1,7 +1,7 @@
 import type { consoleLightTheme } from '@ultraviolet/themes'
 
-type SCWUITheme = typeof consoleLightTheme
+type UltravioletUITheme = typeof consoleLightTheme
 declare module '@emotion/react' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface Theme extends SCWUITheme {}
+  export interface Theme extends UltravioletUITheme {}
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -42,10 +42,10 @@ Example, in a `emotion.d.ts` file:
 
 ```ts
 import '@emotion/react'
-import type { SCWUITheme } from '@ultraviolet/ui'
+import type { UltravioletUITheme } from '@ultraviolet/ui'
 
 declare module '@emotion/react' {
-  export interface Theme extends SCWUITheme {}
+  export interface Theme extends UltravioletUITheme {}
 }
 ```
 

--- a/packages/ui/src/components/Row/index.tsx
+++ b/packages/ui/src/components/Row/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import type { CSSProperties, ReactNode } from 'react'
-import type { SCWUITheme } from '../../theme'
+import type { UltravioletUITheme } from '../../theme'
 
 type StyledRowProps = Pick<
   RowProps,
@@ -19,7 +19,11 @@ export const StyledRow = styled('div', {
     justifyContent = 'normal',
   }) => `
     grid-template-columns: ${templateColumns};
-    ${gap ? `gap: ${theme.space[gap as keyof SCWUITheme['space']]};` : ''}
+    ${
+      gap
+        ? `gap: ${theme.space[gap as keyof UltravioletUITheme['space']]};`
+        : ''
+    }
     align-items: ${alignItems};
     justify-content: ${justifyContent};
   `}
@@ -30,7 +34,7 @@ type RowProps = {
   'data-testid'?: string
   children: ReactNode
   templateColumns: string
-  gap?: keyof SCWUITheme['space'] | number
+  gap?: keyof UltravioletUITheme['space'] | number
   alignItems?: CSSProperties['alignItems']
   justifyContent?: CSSProperties['justifyContent']
 }

--- a/packages/ui/src/components/Stack/index.tsx
+++ b/packages/ui/src/components/Stack/index.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import type { CSSProperties, ReactNode } from 'react'
-import type { SCWUITheme } from '../../theme'
+import type { UltravioletUITheme } from '../../theme'
 
 type StackProps = {
-  gap?: keyof SCWUITheme['space'] | number
+  gap?: keyof UltravioletUITheme['space'] | number
   direction?: 'row' | 'column'
   alignItems?: CSSProperties['alignItems']
   justifyContent?: CSSProperties['justifyContent']
@@ -37,7 +37,7 @@ export const Stack = styled('div', {
     width,
     flex,
   }) => `
-    gap: ${theme.space[gap as keyof SCWUITheme['space']]};
+    gap: ${theme.space[gap as keyof UltravioletUITheme['space']]};
     flex-direction: ${direction};
     align-items: ${alignItems};
     justify-content: ${justifyContent};

--- a/packages/ui/src/emotion.d.ts
+++ b/packages/ui/src/emotion.d.ts
@@ -1,6 +1,6 @@
-import type { SCWUITheme } from '.'
+import type { UltravioletUITheme } from '.'
 
 declare module '@emotion/react' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  export interface Theme extends SCWUITheme {}
+  export interface Theme extends UltravioletUITheme {}
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-syntax
 export * from './components'
 export { darkTheme, default as theme, extendTheme } from './theme'
-export type { SCWUITheme } from './theme'
+export type { SCWUITheme, UltravioletUITheme } from './theme'
 export {
   bounce,
   Breakpoint,

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -3,7 +3,11 @@ import deepmerge from 'deepmerge'
 
 export type ScreenSize = keyof typeof consoleLightTheme.screens
 
+/**
+ * @deprecated use UltravioletUITheme instead
+ */
 type SCWUITheme = typeof consoleLightTheme
+type UltravioletUITheme = typeof consoleLightTheme
 
 const { colors, shadows, typography, space, radii, screens } = consoleLightTheme
 
@@ -13,11 +17,11 @@ type RecursivePartial<T> = {
 
 /**
  * Will extend theme with new theme properties
- * @param {SCWUITheme} baseTheme the theme you want to extend from, by default it is set to light theme
- * @param {RecursivePartial<SCWUITheme>} extendedTheme the properties of a new theme you want to apply from baseTheme
+ * @param {UltravioletUITheme} baseTheme the theme you want to extend from, by default it is set to light theme
+ * @param {RecursivePartial<UltravioletUITheme>} extendedTheme the properties of a new theme you want to apply from baseTheme
  */
-const extendTheme = (extendedTheme: RecursivePartial<SCWUITheme>) =>
-  deepmerge(consoleLightTheme, extendedTheme) as SCWUITheme
+const extendTheme = (extendedTheme: RecursivePartial<UltravioletUITheme>) =>
+  deepmerge(consoleLightTheme, extendedTheme) as UltravioletUITheme
 
 // This type exclude overlay color
 type Color = Extract<
@@ -45,7 +49,7 @@ const SENTIMENTS_WITHOUT_NEUTRAL = SENTIMENTS.filter(
   sentiment => sentiment !== 'neutral',
 )
 
-export type { SCWUITheme, Color }
+export type { SCWUITheme, UltravioletUITheme, Color }
 
 export {
   colors,


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Old type `SCWUITheme` is now deprecated as the naming of the project changed. You should use `UltravioletUITheme` type in all your projects. This type will be removed in the next major.
