### PR TITLE
fix(checkbox): decrease the size of the svg

### DIFF
--- a/.changeset/thick-penguins-explain.md
+++ b/.changeset/thick-penguins-explain.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fix checkbox size

--- a/packages/form/src/components/CheckboxField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/CheckboxField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -140,7 +140,7 @@ exports[`CheckboxField should render correctly 1`] = `
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -149,52 +149,52 @@ exports[`CheckboxField should render correctly 1`] = `
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -272,7 +272,7 @@ exports[`CheckboxField should render correctly 1`] = `
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-14lwnfj eqr7bqq2"
+        class="cache-13vokz2 eqr7bqq2"
         id="test"
         name="test"
         type="checkbox"
@@ -280,26 +280,29 @@ exports[`CheckboxField should render correctly 1`] = `
       />
       <svg
         class="cache-55x4xn eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-16eol3o eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -455,7 +458,7 @@ exports[`CheckboxField should render correctly checked without value 1`] = `
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -464,52 +467,52 @@ exports[`CheckboxField should render correctly checked without value 1`] = `
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -588,7 +591,7 @@ exports[`CheckboxField should render correctly checked without value 1`] = `
         aria-checked="true"
         aria-invalid="false"
         checked=""
-        class="cache-14lwnfj eqr7bqq2"
+        class="cache-13vokz2 eqr7bqq2"
         id="checked"
         name="checked"
         type="checkbox"
@@ -596,26 +599,29 @@ exports[`CheckboxField should render correctly checked without value 1`] = `
       />
       <svg
         class="cache-55x4xn eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-16eol3o eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -771,7 +777,7 @@ exports[`CheckboxField should render correctly disabled 1`] = `
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -780,52 +786,52 @@ exports[`CheckboxField should render correctly disabled 1`] = `
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -903,7 +909,7 @@ exports[`CheckboxField should render correctly disabled 1`] = `
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-14lwnfj eqr7bqq2"
+        class="cache-13vokz2 eqr7bqq2"
         disabled=""
         id="test"
         name="test"
@@ -912,26 +918,29 @@ exports[`CheckboxField should render correctly disabled 1`] = `
       />
       <svg
         class="cache-55x4xn eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-16eol3o eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -1087,7 +1096,7 @@ exports[`CheckboxField should render correctly with a value 1`] = `
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1096,52 +1105,52 @@ exports[`CheckboxField should render correctly with a value 1`] = `
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1219,7 +1228,7 @@ exports[`CheckboxField should render correctly with a value 1`] = `
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-14lwnfj eqr7bqq2"
+        class="cache-13vokz2 eqr7bqq2"
         id="value"
         name="value"
         type="checkbox"
@@ -1227,26 +1236,29 @@ exports[`CheckboxField should render correctly with a value 1`] = `
       />
       <svg
         class="cache-55x4xn eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-16eol3o eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -1268,7 +1280,7 @@ exports[`CheckboxField should render correctly with a value 1`] = `
         aria-checked="true"
         aria-invalid="false"
         checked=""
-        class="cache-14lwnfj eqr7bqq2"
+        class="cache-13vokz2 eqr7bqq2"
         id="value"
         name="value"
         type="checkbox"
@@ -1276,26 +1288,29 @@ exports[`CheckboxField should render correctly with a value 1`] = `
       />
       <svg
         class="cache-55x4xn eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-16eol3o eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -1451,7 +1466,7 @@ exports[`CheckboxField should render correctly with errors 1`] = `
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1460,52 +1475,52 @@ exports[`CheckboxField should render correctly with errors 1`] = `
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1606,7 +1621,7 @@ exports[`CheckboxField should render correctly with errors 1`] = `
         aria-checked="false"
         aria-describedby="test-hint"
         aria-invalid="true"
-        class="cache-14lwnfj eqr7bqq2"
+        class="cache-13vokz2 eqr7bqq2"
         id="test"
         name="test"
         required=""
@@ -1615,26 +1630,29 @@ exports[`CheckboxField should render correctly with errors 1`] = `
       />
       <svg
         class="cache-55x4xn eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-16eol3o eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -1815,7 +1833,7 @@ exports[`CheckboxField should trigger events correctly 1`] = `
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1824,52 +1842,52 @@ exports[`CheckboxField should trigger events correctly 1`] = `
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1947,7 +1965,7 @@ exports[`CheckboxField should trigger events correctly 1`] = `
       <input
         aria-checked="true"
         aria-invalid="false"
-        class="cache-14lwnfj eqr7bqq2"
+        class="cache-13vokz2 eqr7bqq2"
         id="test"
         name="test"
         type="checkbox"
@@ -1955,26 +1973,29 @@ exports[`CheckboxField should trigger events correctly 1`] = `
       />
       <svg
         class="cache-55x4xn eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-16eol3o eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>

--- a/packages/form/src/components/CheckboxGroupField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/CheckboxGroupField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -204,7 +204,7 @@ exports[`CheckboxField should render correctly checked 1`] = `
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -213,52 +213,52 @@ exports[`CheckboxField should render correctly checked 1`] = `
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -353,7 +353,7 @@ exports[`CheckboxField should render correctly checked 1`] = `
               <input
                 aria-checked="false"
                 aria-invalid="false"
-                class="cache-14lwnfj eqr7bqq2"
+                class="cache-13vokz2 eqr7bqq2"
                 id="Checkbox.value-1"
                 name="Checkbox.value-1"
                 type="checkbox"
@@ -361,26 +361,29 @@ exports[`CheckboxField should render correctly checked 1`] = `
               />
               <svg
                 class="cache-55x4xn eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-16eol3o eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -408,7 +411,7 @@ exports[`CheckboxField should render correctly checked 1`] = `
               <input
                 aria-checked="true"
                 aria-invalid="false"
-                class="cache-14lwnfj eqr7bqq2"
+                class="cache-13vokz2 eqr7bqq2"
                 id="Checkbox.value-2"
                 name="Checkbox.value-2"
                 type="checkbox"
@@ -416,26 +419,29 @@ exports[`CheckboxField should render correctly checked 1`] = `
               />
               <svg
                 class="cache-55x4xn eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-16eol3o eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -676,7 +682,7 @@ exports[`CheckboxField should trigger events correctly with required prop 1`] = 
   fill: #ffebf2;
 }
 
-.cache-14lwnfj {
+.cache-13vokz2 {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -685,52 +691,52 @@ exports[`CheckboxField should trigger events correctly with required prop 1`] = 
   border-width: 0;
 }
 
-.cache-14lwnfj:not(:disabled) {
+.cache-13vokz2:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-14lwnfj:disabled {
+.cache-13vokz2:disabled {
   cursor: not-allowed;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-14lwnfj:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-14lwnfj:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-14lwnfj:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-13vokz2:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 {
+.cache-13vokz2:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-14lwnfj:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-14lwnfj[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-13vokz2[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -833,7 +839,7 @@ exports[`CheckboxField should trigger events correctly with required prop 1`] = 
               <input
                 aria-checked="false"
                 aria-invalid="false"
-                class="cache-14lwnfj eqr7bqq2"
+                class="cache-13vokz2 eqr7bqq2"
                 id="test.value-1"
                 name="test.value-1"
                 type="checkbox"
@@ -841,26 +847,29 @@ exports[`CheckboxField should trigger events correctly with required prop 1`] = 
               />
               <svg
                 class="cache-55x4xn eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-16eol3o eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -888,7 +897,7 @@ exports[`CheckboxField should trigger events correctly with required prop 1`] = 
               <input
                 aria-checked="false"
                 aria-invalid="false"
-                class="cache-14lwnfj eqr7bqq2"
+                class="cache-13vokz2 eqr7bqq2"
                 id="test.value-2"
                 name="test.value-2"
                 type="checkbox"
@@ -896,26 +905,29 @@ exports[`CheckboxField should trigger events correctly with required prop 1`] = 
               />
               <svg
                 class="cache-55x4xn eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-16eol3o eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>

--- a/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
@@ -140,7 +140,7 @@ exports[`Checkbox renders correctly 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -149,52 +149,52 @@ exports[`Checkbox renders correctly 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -269,7 +269,7 @@ exports[`Checkbox renders correctly 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id="testing"
       name="testing"
       type="checkbox"
@@ -277,26 +277,29 @@ exports[`Checkbox renders correctly 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -458,7 +461,7 @@ exports[`Checkbox renders correctly checked 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -467,52 +470,52 @@ exports[`Checkbox renders correctly checked 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -588,7 +591,7 @@ exports[`Checkbox renders correctly checked 1`] = `
       aria-checked="true"
       aria-invalid="false"
       checked=""
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":ra:"
       name=":ra:"
       type="checkbox"
@@ -596,26 +599,29 @@ exports[`Checkbox renders correctly checked 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -777,7 +783,7 @@ exports[`Checkbox renders correctly checked and disabled 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -786,52 +792,52 @@ exports[`Checkbox renders correctly checked and disabled 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -907,7 +913,7 @@ exports[`Checkbox renders correctly checked and disabled 1`] = `
       aria-checked="true"
       aria-invalid="false"
       checked=""
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       disabled=""
       id=":rh:"
       name=":rh:"
@@ -916,26 +922,29 @@ exports[`Checkbox renders correctly checked and disabled 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -1097,7 +1106,7 @@ exports[`Checkbox renders correctly checked with helper 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1106,52 +1115,52 @@ exports[`Checkbox renders correctly checked with helper 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1239,7 +1248,7 @@ exports[`Checkbox renders correctly checked with helper 1`] = `
       aria-checked="true"
       aria-invalid="false"
       checked=""
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":rc:"
       name=":rc:"
       type="checkbox"
@@ -1247,26 +1256,29 @@ exports[`Checkbox renders correctly checked with helper 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -1433,7 +1445,7 @@ exports[`Checkbox renders correctly disabled 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1442,52 +1454,52 @@ exports[`Checkbox renders correctly disabled 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1562,7 +1574,7 @@ exports[`Checkbox renders correctly disabled 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       disabled=""
       id=":r4:"
       name=":r4:"
@@ -1571,26 +1583,29 @@ exports[`Checkbox renders correctly disabled 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -1752,7 +1767,7 @@ exports[`Checkbox renders correctly indeterminate 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1761,52 +1776,52 @@ exports[`Checkbox renders correctly indeterminate 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1881,7 +1896,7 @@ exports[`Checkbox renders correctly indeterminate 1`] = `
     <input
       aria-checked="mixed"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":rf:"
       name=":rf:"
       type="checkbox"
@@ -1889,18 +1904,19 @@ exports[`Checkbox renders correctly indeterminate 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <rect
           class="cache-1nkq693-CheckMixedMark eqr7bqq5"
@@ -2070,7 +2086,7 @@ exports[`Checkbox renders correctly indeterminate and disabled 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2079,52 +2095,52 @@ exports[`Checkbox renders correctly indeterminate and disabled 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2199,7 +2215,7 @@ exports[`Checkbox renders correctly indeterminate and disabled 1`] = `
     <input
       aria-checked="mixed"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       disabled=""
       id=":rj:"
       name=":rj:"
@@ -2208,18 +2224,19 @@ exports[`Checkbox renders correctly indeterminate and disabled 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <rect
           class="cache-1nkq693-CheckMixedMark eqr7bqq5"
@@ -2389,7 +2406,7 @@ exports[`Checkbox renders correctly invisible 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2398,52 +2415,52 @@ exports[`Checkbox renders correctly invisible 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2519,7 +2536,7 @@ exports[`Checkbox renders correctly invisible 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":rl:"
       name=":rl:"
       type="checkbox"
@@ -2527,26 +2544,29 @@ exports[`Checkbox renders correctly invisible 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -2708,7 +2728,7 @@ exports[`Checkbox renders correctly no child 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2717,52 +2737,52 @@ exports[`Checkbox renders correctly no child 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2838,7 +2858,7 @@ exports[`Checkbox renders correctly no child 1`] = `
       aria-checked="false"
       aria-invalid="false"
       aria-label="check"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":r2:"
       name=":r2:"
       type="checkbox"
@@ -2846,26 +2866,29 @@ exports[`Checkbox renders correctly no child 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -3020,7 +3043,7 @@ exports[`Checkbox renders correctly required 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -3029,52 +3052,52 @@ exports[`Checkbox renders correctly required 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -3158,7 +3181,7 @@ exports[`Checkbox renders correctly required 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":r6:"
       name=":r6:"
       required=""
@@ -3167,26 +3190,29 @@ exports[`Checkbox renders correctly required 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -3358,7 +3384,7 @@ exports[`Checkbox renders correctly with a value 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -3367,52 +3393,52 @@ exports[`Checkbox renders correctly with a value 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -3487,7 +3513,7 @@ exports[`Checkbox renders correctly with a value 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":ru:"
       name=":ru:"
       type="checkbox"
@@ -3495,26 +3521,29 @@ exports[`Checkbox renders correctly with a value 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -3676,7 +3705,7 @@ exports[`Checkbox renders correctly with an error 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -3685,52 +3714,52 @@ exports[`Checkbox renders correctly with an error 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -3819,7 +3848,7 @@ exports[`Checkbox renders correctly with an error 1`] = `
       aria-checked="false"
       aria-describedby=":rn:-hint"
       aria-invalid="true"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":rn:"
       name=":rn:"
       type="checkbox"
@@ -3827,26 +3856,29 @@ exports[`Checkbox renders correctly with an error 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -4013,7 +4045,7 @@ exports[`Checkbox renders correctly with indeterminate state 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -4022,52 +4054,52 @@ exports[`Checkbox renders correctly with indeterminate state 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -4142,7 +4174,7 @@ exports[`Checkbox renders correctly with indeterminate state 1`] = `
     <input
       aria-checked="mixed"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":r14:"
       name=":r14:"
       type="checkbox"
@@ -4150,18 +4182,19 @@ exports[`Checkbox renders correctly with indeterminate state 1`] = `
     />
     <svg
       class="cache-1acemqq-StyledIcon eqr7bqq4"
+      fill="none"
       size="24"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <rect
           class="cache-1nkq693-CheckMixedMark eqr7bqq5"
@@ -4348,7 +4381,7 @@ exports[`Checkbox renders correctly with progress 1`] = `
   transition: stroke-dashoffset 0.5s ease 0s;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -4357,52 +4390,52 @@ exports[`Checkbox renders correctly with progress 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -4488,7 +4521,7 @@ exports[`Checkbox renders correctly with progress 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":rq:"
       name=":rq:"
       type="checkbox"
@@ -4669,7 +4702,7 @@ exports[`Checkbox renders correctly with progress and no child 1`] = `
   transition: stroke-dashoffset 0.5s ease 0s;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -4678,52 +4711,52 @@ exports[`Checkbox renders correctly with progress and no child 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -4810,7 +4843,7 @@ exports[`Checkbox renders correctly with progress and no child 1`] = `
       aria-checked="false"
       aria-invalid="false"
       aria-label="check"
-      class="cache-rg9483-CheckboxInput eqr7bqq2"
+      class="cache-1xbtwks-CheckboxInput eqr7bqq2"
       id=":rs:"
       name=":rs:"
       type="checkbox"
@@ -4967,7 +5000,7 @@ exports[`Checkbox renders correctly with sizes 1`] = `
   fill: #ffebf2;
 }
 
-.cache-36jqjq-CheckboxInput {
+.cache-1jqt61k-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 37px;
@@ -4976,52 +5009,52 @@ exports[`Checkbox renders correctly with sizes 1`] = `
   border-width: 0;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled) {
+.cache-1jqt61k-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-36jqjq-CheckboxInput:disabled {
+.cache-1jqt61k-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-36jqjq-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-36jqjq-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-36jqjq-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-36jqjq-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -5096,7 +5129,7 @@ exports[`Checkbox renders correctly with sizes 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-36jqjq-CheckboxInput eqr7bqq2"
+      class="cache-1jqt61k-CheckboxInput eqr7bqq2"
       id=":r10:"
       name=":r10:"
       type="checkbox"
@@ -5104,26 +5137,29 @@ exports[`Checkbox renders correctly with sizes 1`] = `
     />
     <svg
       class="cache-1gpbo33-StyledIcon eqr7bqq4"
+      fill="none"
       size="37"
       viewBox="0 0 24 24"
     >
       <g>
         <rect
           class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-          height="20"
+          height="16"
           rx="2px"
           stroke-width="2"
-          width="20"
-          x="2"
-          y="2"
+          width="16"
+          x="4"
+          y="4"
         />
         <path
           clip-rule="evenodd"
           d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
           fill="white"
           fill-rule="evenodd"
-          height="14"
-          width="14"
+          height="9"
+          width="12"
+          x="5"
+          y="4"
         />
       </g>
     </svg>
@@ -5297,7 +5333,7 @@ exports[`Checkbox renders correctly with sizes 1`] = `
   transition: stroke-dashoffset 0.5s ease 0s;
 }
 
-.cache-36jqjq-CheckboxInput {
+.cache-1jqt61k-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 37px;
@@ -5306,52 +5342,52 @@ exports[`Checkbox renders correctly with sizes 1`] = `
   border-width: 0;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled) {
+.cache-1jqt61k-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-36jqjq-CheckboxInput:disabled {
+.cache-1jqt61k-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-36jqjq-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1jqt61k-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-36jqjq-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-36jqjq-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-36jqjq-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1jqt61k-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-36jqjq-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1jqt61k-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -5437,7 +5473,7 @@ exports[`Checkbox renders correctly with sizes 1`] = `
     <input
       aria-checked="false"
       aria-invalid="false"
-      class="cache-36jqjq-CheckboxInput eqr7bqq2"
+      class="cache-1jqt61k-CheckboxInput eqr7bqq2"
       id=":r12:"
       name=":r12:"
       type="checkbox"
@@ -5609,7 +5645,7 @@ exports[`Checkbox renders correctly with tooltip 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -5618,52 +5654,52 @@ exports[`Checkbox renders correctly with tooltip 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -5744,7 +5780,7 @@ exports[`Checkbox renders correctly with tooltip 1`] = `
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-rg9483-CheckboxInput eqr7bqq2"
+        class="cache-1xbtwks-CheckboxInput eqr7bqq2"
         id=":r8:"
         name=":r8:"
         type="checkbox"
@@ -5752,26 +5788,29 @@ exports[`Checkbox renders correctly with tooltip 1`] = `
       />
       <svg
         class="cache-1acemqq-StyledIcon eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>

--- a/packages/ui/src/components/Checkbox/index.tsx
+++ b/packages/ui/src/components/Checkbox/index.tsx
@@ -32,10 +32,10 @@ const CheckboxIconContainer = ({ children }: { children: ReactNode }) => {
   return (
     <g>
       <InnerCheckbox
-        x="2"
-        y="2"
-        width="20"
-        height="20"
+        x="4"
+        y="4"
+        width="16"
+        height="16"
         rx={theme.radii.small}
         strokeWidth="2"
       />
@@ -101,7 +101,7 @@ const CheckboxInput = styled('input', {
   &:focus + ${StyledIcon} {
     background-color: ${({ theme }) => theme.colors.primary.background};
     fill: ${({ theme }) => theme.colors.danger.background};
-    outline: 2px solid ${({ theme }) => theme.colors.primary.backgroundHover};
+    outline: 1px solid ${({ theme }) => theme.shadows.focusPrimary};
 
     ${InnerCheckbox} {
       stroke: ${({ theme }) => theme.colors.primary.borderHover};
@@ -112,7 +112,7 @@ const CheckboxInput = styled('input', {
   &[aria-invalid='true']:focus + ${StyledIcon} {
     background-color: ${({ theme }) => theme.colors.danger.background};
     fill: ${({ theme }) => theme.colors.danger.background};
-    outline: 2px solid ${({ theme }) => theme.colors.danger.backgroundHover};
+    outline: 1px solid ${({ theme }) => theme.shadows.focusDanger};
 
     ${InnerCheckbox} {
       stroke: ${({ theme }) => theme.colors.danger.borderHover};
@@ -385,14 +385,16 @@ export const Checkbox = forwardRef(
           />
 
           {!progress ? (
-            <StyledIcon size={size} viewBox="0 0 24 24">
+            <StyledIcon size={size} viewBox="0 0 24 24" fill="none">
               <CheckboxIconContainer>
                 {state !== 'indeterminate' ? (
                   <path
                     fillRule="evenodd"
                     clipRule="evenodd"
-                    width={14}
-                    height={14}
+                    width={12}
+                    height={9}
+                    x="5"
+                    y="4"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                   />

--- a/packages/ui/src/components/CheckboxGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/CheckboxGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`CheckboxGroup renders correctly 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -213,52 +213,52 @@ exports[`CheckboxGroup renders correctly 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -350,7 +350,7 @@ exports[`CheckboxGroup renders correctly 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-1"
               name="Checkbox.value-1"
               type="checkbox"
@@ -358,26 +358,29 @@ exports[`CheckboxGroup renders correctly 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -405,7 +408,7 @@ exports[`CheckboxGroup renders correctly 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-2"
               name="Checkbox.value-2"
               type="checkbox"
@@ -413,26 +416,29 @@ exports[`CheckboxGroup renders correctly 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -685,7 +691,7 @@ exports[`CheckboxGroup renders correctly with direction row 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -694,52 +700,52 @@ exports[`CheckboxGroup renders correctly with direction row 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -831,7 +837,7 @@ exports[`CheckboxGroup renders correctly with direction row 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-1"
               name="Checkbox.value-1"
               type="checkbox"
@@ -839,26 +845,29 @@ exports[`CheckboxGroup renders correctly with direction row 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -886,7 +895,7 @@ exports[`CheckboxGroup renders correctly with direction row 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-2"
               name="Checkbox.value-2"
               type="checkbox"
@@ -894,26 +903,29 @@ exports[`CheckboxGroup renders correctly with direction row 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -1143,7 +1155,7 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1152,52 +1164,52 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1301,7 +1313,7 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-1"
               name="Checkbox.value-1"
               type="checkbox"
@@ -1309,26 +1321,29 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -1356,7 +1371,7 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-2"
               name="Checkbox.value-2"
               type="checkbox"
@@ -1364,26 +1379,29 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -1618,7 +1636,7 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1627,52 +1645,52 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1776,7 +1794,7 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-1"
               name="Checkbox.value-1"
               type="checkbox"
@@ -1784,26 +1802,29 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -1831,7 +1852,7 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-2"
               name="Checkbox.value-2"
               type="checkbox"
@@ -1839,26 +1860,29 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -2093,7 +2117,7 @@ exports[`CheckboxGroup renders correctly with no CheckboxGroup.Checkbox name 1`]
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2102,52 +2126,52 @@ exports[`CheckboxGroup renders correctly with no CheckboxGroup.Checkbox name 1`]
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2239,7 +2263,7 @@ exports[`CheckboxGroup renders correctly with no CheckboxGroup.Checkbox name 1`]
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox."
               name="Checkbox."
               type="checkbox"
@@ -2247,26 +2271,29 @@ exports[`CheckboxGroup renders correctly with no CheckboxGroup.Checkbox name 1`]
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -2294,7 +2321,7 @@ exports[`CheckboxGroup renders correctly with no CheckboxGroup.Checkbox name 1`]
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox."
               name="Checkbox."
               type="checkbox"
@@ -2302,26 +2329,29 @@ exports[`CheckboxGroup renders correctly with no CheckboxGroup.Checkbox name 1`]
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -2561,7 +2591,7 @@ exports[`CheckboxGroup renders correctly with required prop 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2570,52 +2600,52 @@ exports[`CheckboxGroup renders correctly with required prop 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2715,7 +2745,7 @@ exports[`CheckboxGroup renders correctly with required prop 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-1"
               name="Checkbox.value-1"
               type="checkbox"
@@ -2723,26 +2753,29 @@ exports[`CheckboxGroup renders correctly with required prop 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -2770,7 +2803,7 @@ exports[`CheckboxGroup renders correctly with required prop 1`] = `
             <input
               aria-checked="false"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="Checkbox.value-2"
               name="Checkbox.value-2"
               type="checkbox"
@@ -2778,26 +2811,29 @@ exports[`CheckboxGroup renders correctly with required prop 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>

--- a/packages/ui/src/components/LineChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/LineChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -883,7 +883,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -892,52 +892,52 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1104,7 +1104,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
               aria-checked="true"
               aria-invalid="false"
               checked=""
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartSerie"
               name="lineChartSerie"
               type="checkbox"
@@ -1112,26 +1112,29 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -2738,7 +2741,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2747,52 +2750,52 @@ exports[`LineChart renders correctly when data is async 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2972,7 +2975,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
             <input
               aria-checked="true"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartMultiple1"
               name="lineChartMultiple1"
               type="checkbox"
@@ -2980,26 +2983,29 @@ exports[`LineChart renders correctly when data is async 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -3067,7 +3073,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
             <input
               aria-checked="true"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartMultiple2"
               name="lineChartMultiple2"
               type="checkbox"
@@ -3075,26 +3081,29 @@ exports[`LineChart renders correctly when data is async 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -3162,7 +3171,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
             <input
               aria-checked="true"
               aria-invalid="false"
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartMultiple3"
               name="lineChartMultiple3"
               type="checkbox"
@@ -3170,26 +3179,29 @@ exports[`LineChart renders correctly when data is async 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -4063,7 +4075,7 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -4072,52 +4084,52 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -4284,7 +4296,7 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
               aria-checked="false"
               aria-invalid="false"
               checked=""
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartSerie"
               name="lineChartSerie"
               type="checkbox"
@@ -4292,26 +4304,29 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -6622,7 +6637,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -6631,52 +6646,52 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -6843,7 +6858,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
               aria-checked="true"
               aria-invalid="false"
               checked=""
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartSerie"
               name="lineChartSerie"
               type="checkbox"
@@ -6851,26 +6866,29 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -8477,7 +8495,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -8486,52 +8504,52 @@ exports[`LineChart renders correctly with multiple series 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -8712,7 +8730,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
               aria-checked="true"
               aria-invalid="false"
               checked=""
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartMultiple1"
               name="lineChartMultiple1"
               type="checkbox"
@@ -8720,26 +8738,29 @@ exports[`LineChart renders correctly with multiple series 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -8808,7 +8829,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
               aria-checked="true"
               aria-invalid="false"
               checked=""
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartMultiple2"
               name="lineChartMultiple2"
               type="checkbox"
@@ -8816,26 +8837,29 @@ exports[`LineChart renders correctly with multiple series 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -8904,7 +8928,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
               aria-checked="true"
               aria-invalid="false"
               checked=""
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartMultiple3"
               name="lineChartMultiple3"
               type="checkbox"
@@ -8912,26 +8936,29 @@ exports[`LineChart renders correctly with multiple series 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>
@@ -10735,7 +10762,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -10744,52 +10771,52 @@ exports[`LineChart renders correctly with timeline data 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -10956,7 +10983,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
               aria-checked="true"
               aria-invalid="false"
               checked=""
-              class="cache-rg9483-CheckboxInput eqr7bqq2"
+              class="cache-1xbtwks-CheckboxInput eqr7bqq2"
               id="lineChartHours"
               name="lineChartHours"
               type="checkbox"
@@ -10964,26 +10991,29 @@ exports[`LineChart renders correctly with timeline data 1`] = `
             />
             <svg
               class="cache-1acemqq-StyledIcon eqr7bqq4"
+              fill="none"
               size="24"
               viewBox="0 0 24 24"
             >
               <g>
                 <rect
                   class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                  height="20"
+                  height="16"
                   rx="2px"
                   stroke-width="2"
-                  width="20"
-                  x="2"
-                  y="2"
+                  width="16"
+                  x="4"
+                  y="4"
                 />
                 <path
                   clip-rule="evenodd"
                   d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                   fill="white"
                   fill-rule="evenodd"
-                  height="14"
-                  width="14"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
                 />
               </g>
             </svg>

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -6126,7 +6126,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -6135,52 +6135,52 @@ exports[`List Should render correctly with loading with selectable 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -6390,7 +6390,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
             aria-checked="false"
             aria-invalid="false"
             aria-label="select all"
-            class="cache-rg9483-CheckboxInput eqr7bqq2"
+            class="cache-1xbtwks-CheckboxInput eqr7bqq2"
             disabled=""
             id="list-select-checkbox"
             name="list-select-checkbox"
@@ -6399,26 +6399,29 @@ exports[`List Should render correctly with loading with selectable 1`] = `
           />
           <svg
             class="cache-1acemqq-StyledIcon eqr7bqq4"
+            fill="none"
             size="24"
             viewBox="0 0 24 24"
           >
             <g>
               <rect
                 class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                height="20"
+                height="16"
                 rx="2px"
                 stroke-width="2"
-                width="20"
-                x="2"
-                y="2"
+                width="16"
+                x="4"
+                y="4"
               />
               <path
                 clip-rule="evenodd"
                 d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                 fill="white"
                 fill-rule="evenodd"
-                height="14"
-                width="14"
+                height="9"
+                width="12"
+                x="5"
+                y="4"
               />
             </g>
           </svg>
@@ -7657,7 +7660,7 @@ exports[`List Should render correctly with selectable 1`] = `
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -7666,52 +7669,52 @@ exports[`List Should render correctly with selectable 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -7882,7 +7885,7 @@ exports[`List Should render correctly with selectable 1`] = `
             aria-checked="false"
             aria-invalid="false"
             aria-label="select all"
-            class="cache-rg9483-CheckboxInput eqr7bqq2"
+            class="cache-1xbtwks-CheckboxInput eqr7bqq2"
             id="list-select-checkbox"
             name="list-select-checkbox"
             type="checkbox"
@@ -7890,26 +7893,29 @@ exports[`List Should render correctly with selectable 1`] = `
           />
           <svg
             class="cache-1acemqq-StyledIcon eqr7bqq4"
+            fill="none"
             size="24"
             viewBox="0 0 24 24"
           >
             <g>
               <rect
                 class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                height="20"
+                height="16"
                 rx="2px"
                 stroke-width="2"
-                width="20"
-                x="2"
-                y="2"
+                width="16"
+                x="4"
+                y="4"
               />
               <path
                 clip-rule="evenodd"
                 d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                 fill="white"
                 fill-rule="evenodd"
-                height="14"
-                width="14"
+                height="9"
+                width="12"
+                x="5"
+                y="4"
               />
             </g>
           </svg>
@@ -7981,7 +7987,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -7989,26 +7995,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8077,7 +8086,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8085,26 +8094,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8173,7 +8185,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8181,26 +8193,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8269,7 +8284,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8277,26 +8292,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8365,7 +8383,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8373,26 +8391,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8461,7 +8482,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8469,26 +8490,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8557,7 +8581,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8565,26 +8589,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8653,7 +8680,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8661,26 +8688,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8749,7 +8779,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8757,26 +8787,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -8845,7 +8878,7 @@ exports[`List Should render correctly with selectable 1`] = `
                 aria-checked="false"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -8853,26 +8886,29 @@ exports[`List Should render correctly with selectable 1`] = `
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -9132,7 +9168,7 @@ exports[`List Should render correctly with selectable then click on first row th
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -9141,52 +9177,52 @@ exports[`List Should render correctly with selectable then click on first row th
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -9357,7 +9393,7 @@ exports[`List Should render correctly with selectable then click on first row th
             aria-checked="true"
             aria-invalid="false"
             aria-label="select all"
-            class="cache-rg9483-CheckboxInput eqr7bqq2"
+            class="cache-1xbtwks-CheckboxInput eqr7bqq2"
             id="list-select-checkbox"
             name="list-select-checkbox"
             type="checkbox"
@@ -9365,26 +9401,29 @@ exports[`List Should render correctly with selectable then click on first row th
           />
           <svg
             class="cache-1acemqq-StyledIcon eqr7bqq4"
+            fill="none"
             size="24"
             viewBox="0 0 24 24"
           >
             <g>
               <rect
                 class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                height="20"
+                height="16"
                 rx="2px"
                 stroke-width="2"
-                width="20"
-                x="2"
-                y="2"
+                width="16"
+                x="4"
+                y="4"
               />
               <path
                 clip-rule="evenodd"
                 d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                 fill="white"
                 fill-rule="evenodd"
-                height="14"
-                width="14"
+                height="9"
+                width="12"
+                x="5"
+                y="4"
               />
             </g>
           </svg>
@@ -9455,7 +9494,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -9463,26 +9502,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -9550,7 +9592,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -9558,26 +9600,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -9645,7 +9690,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -9653,26 +9698,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -9740,7 +9788,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -9748,26 +9796,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -9835,7 +9886,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -9843,26 +9894,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -9930,7 +9984,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -9938,26 +9992,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -10025,7 +10082,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -10033,26 +10090,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -10120,7 +10180,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -10128,26 +10188,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -10215,7 +10278,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -10223,26 +10286,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -10310,7 +10376,7 @@ exports[`List Should render correctly with selectable then click on first row th
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="list-select-checkbox"
                 name="list-select-checkbox"
                 type="checkbox"
@@ -10318,26 +10384,29 @@ exports[`List Should render correctly with selectable then click on first row th
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -217,7 +217,7 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   display: none;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -226,52 +226,52 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -351,7 +351,7 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-rg9483-CheckboxInput eqr7bqq2"
+        class="cache-1xbtwks-CheckboxInput eqr7bqq2"
         id="checkbox"
         name="checkbox"
         type="checkbox"
@@ -359,26 +359,29 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
       />
       <svg
         class="cache-1acemqq-StyledIcon eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -612,7 +615,7 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   display: none;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -621,52 +624,52 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -747,7 +750,7 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
         aria-checked="true"
         aria-invalid="false"
         checked=""
-        class="cache-rg9483-CheckboxInput eqr7bqq2"
+        class="cache-1xbtwks-CheckboxInput eqr7bqq2"
         id="radio"
         name="radio"
         type="checkbox"
@@ -755,26 +758,29 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
       />
       <svg
         class="cache-1acemqq-StyledIcon eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -1008,7 +1014,7 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   display: none;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1017,52 +1023,52 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1142,7 +1148,7 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-rg9483-CheckboxInput eqr7bqq2"
+        class="cache-1xbtwks-CheckboxInput eqr7bqq2"
         disabled=""
         id="radio"
         name="radio"
@@ -1151,26 +1157,29 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
       />
       <svg
         class="cache-1acemqq-StyledIcon eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -1404,7 +1413,7 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   display: none;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1413,52 +1422,52 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1553,7 +1562,7 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
         aria-checked="false"
         aria-describedby="radio-hint"
         aria-invalid="true"
-        class="cache-rg9483-CheckboxInput eqr7bqq2"
+        class="cache-1xbtwks-CheckboxInput eqr7bqq2"
         id="radio"
         name="radio"
         type="checkbox"
@@ -1561,26 +1570,29 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
       />
       <svg
         class="cache-1acemqq-StyledIcon eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -1825,7 +1837,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   display: none;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -1834,52 +1846,52 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -1965,7 +1977,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
         <input
           aria-checked="false"
           aria-invalid="false"
-          class="cache-rg9483-CheckboxInput eqr7bqq2"
+          class="cache-1xbtwks-CheckboxInput eqr7bqq2"
           id="checkbox"
           name="checkbox"
           type="checkbox"
@@ -1973,26 +1985,29 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
         />
         <svg
           class="cache-1acemqq-StyledIcon eqr7bqq4"
+          fill="none"
           size="24"
           viewBox="0 0 24 24"
         >
           <g>
             <rect
               class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-              height="20"
+              height="16"
               rx="2px"
               stroke-width="2"
-              width="20"
-              x="2"
-              y="2"
+              width="16"
+              x="4"
+              y="4"
             />
             <path
               clip-rule="evenodd"
               d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
               fill="white"
               fill-rule="evenodd"
-              height="14"
-              width="14"
+              height="9"
+              width="12"
+              x="5"
+              y="4"
             />
           </g>
         </svg>
@@ -2227,7 +2242,7 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   display: none;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2236,52 +2251,52 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2361,7 +2376,7 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-rg9483-CheckboxInput eqr7bqq2"
+        class="cache-1xbtwks-CheckboxInput eqr7bqq2"
         disabled=""
         id="radio"
         name="radio"
@@ -2370,26 +2385,29 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
       />
       <svg
         class="cache-1acemqq-StyledIcon eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>
@@ -4048,7 +4066,7 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   color: #b5b7bd;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -4057,52 +4075,52 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -4182,7 +4200,7 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
       <input
         aria-checked="false"
         aria-invalid="false"
-        class="cache-rg9483-CheckboxInput eqr7bqq2"
+        class="cache-1xbtwks-CheckboxInput eqr7bqq2"
         id="checkbox"
         name="checkbox"
         type="checkbox"
@@ -4190,26 +4208,29 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
       />
       <svg
         class="cache-1acemqq-StyledIcon eqr7bqq4"
+        fill="none"
         size="24"
         viewBox="0 0 24 24"
       >
         <g>
           <rect
             class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-            height="20"
+            height="16"
             rx="2px"
             stroke-width="2"
-            width="20"
-            x="2"
-            y="2"
+            width="16"
+            x="4"
+            y="4"
           />
           <path
             clip-rule="evenodd"
             d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
             fill="white"
             fill-rule="evenodd"
-            height="14"
-            width="14"
+            height="9"
+            width="12"
+            x="5"
+            y="4"
           />
         </g>
       </svg>

--- a/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -2343,7 +2343,7 @@ exports[`Table Should render correctly with selectable then click on first row t
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput {
+.cache-1xbtwks-CheckboxInput {
   position: absolute;
   white-space: nowrap;
   height: 24px;
@@ -2352,52 +2352,52 @@ exports[`Table Should render correctly with selectable then click on first row t
   border-width: 0;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled) {
+.cache-1xbtwks-CheckboxInput:not(:disabled) {
   cursor: pointer;
 }
 
-.cache-rg9483-CheckboxInput:disabled {
+.cache-1xbtwks-CheckboxInput:disabled {
   cursor: not-allowed;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 {
   fill: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled):checked+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #521094;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
-.cache-rg9483-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='true']+.eqr7bqq4 .eqr7bqq6,
+.cache-1xbtwks-CheckboxInput:not(:disabled)[aria-invalid='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #b3144d;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 {
   background-color: #f1eefc;
   fill: #ffebf2;
-  outline: 2px solid #e5dbfd;
+  outline: 1px solid 0px 0px 0px 3px #5e127e40;
 }
 
-.cache-rg9483-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #3b1a61;
   fill: #e5dbfd;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 {
   background-color: #ffebf2;
   fill: #ffebf2;
-  outline: 2px solid #ffd3e3;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
 }
 
-.cache-rg9483-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
+.cache-1xbtwks-CheckboxInput[aria-invalid='true']:focus+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
@@ -2515,7 +2515,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select all"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-all-checkbox"
                 name="table-select-all-checkbox"
                 type="checkbox"
@@ -2523,26 +2523,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -2626,7 +2629,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -2634,26 +2637,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -2710,7 +2716,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -2718,26 +2724,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -2794,7 +2803,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -2802,26 +2811,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -2878,7 +2890,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -2886,26 +2898,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -2962,7 +2977,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -2970,26 +2985,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -3046,7 +3064,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -3054,26 +3072,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -3130,7 +3151,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -3138,26 +3159,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -3214,7 +3238,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -3222,26 +3246,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -3298,7 +3325,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -3306,26 +3333,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>
@@ -3382,7 +3412,7 @@ exports[`Table Should render correctly with selectable then click on first row t
                 aria-checked="true"
                 aria-invalid="false"
                 aria-label="select"
-                class="cache-rg9483-CheckboxInput eqr7bqq2"
+                class="cache-1xbtwks-CheckboxInput eqr7bqq2"
                 id="table-select-checkbox"
                 name="table-select-checkbox"
                 type="checkbox"
@@ -3390,26 +3420,29 @@ exports[`Table Should render correctly with selectable then click on first row t
               />
               <svg
                 class="cache-1acemqq-StyledIcon eqr7bqq4"
+                fill="none"
                 size="24"
                 viewBox="0 0 24 24"
               >
                 <g>
                   <rect
                     class="cache-1t9py5o-InnerCheckbox eqr7bqq6"
-                    height="20"
+                    height="16"
                     rx="2px"
                     stroke-width="2"
-                    width="20"
-                    x="2"
-                    y="2"
+                    width="16"
+                    x="4"
+                    y="4"
                   />
                   <path
                     clip-rule="evenodd"
                     d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
                     fill="white"
                     fill-rule="evenodd"
-                    height="14"
-                    width="14"
+                    height="9"
+                    width="12"
+                    x="5"
+                    y="4"
                   />
                 </g>
               </svg>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Checkbox appeared too big because of the svg, fixed it!

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2023-10-04 at 16 55 13](https://github.com/scaleway/ultraviolet/assets/15812968/2c59db95-d503-4ee7-840c-a28510175f2c) | ![Screenshot 2023-10-04 at 16 55 17](https://github.com/scaleway/ultraviolet/assets/15812968/c4063f1e-95a5-4841-b100-68a7f6a7159f) |
