### PR TITLE
docs: fix stories description

### DIFF
--- a/packages/form/src/components/CheckboxGroupField/__stories__/Direction.stories.tsx
+++ b/packages/form/src/components/CheckboxGroupField/__stories__/Direction.stories.tsx
@@ -32,8 +32,9 @@ export const Direction: StoryFn<typeof CheckboxGroupField> = args => (
 
 Direction.parameters = {
   docs: {
-    storyDescription:
-      'Use the `direction` prop to change the direction of the group.',
+    description: {
+      story: 'Use the `direction` prop to change the direction of the group.',
+    },
   },
 }
 

--- a/packages/form/src/components/CheckboxGroupField/__stories__/Error.stories.tsx
+++ b/packages/form/src/components/CheckboxGroupField/__stories__/Error.stories.tsx
@@ -11,6 +11,6 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription: 'Use the `error` prop to set an error content.',
+    description: { story: 'Use the `error` prop to set an error content.' },
   },
 }

--- a/packages/form/src/components/CheckboxGroupField/__stories__/Helper.stories.tsx
+++ b/packages/form/src/components/CheckboxGroupField/__stories__/Helper.stories.tsx
@@ -10,6 +10,6 @@ Helper.args = {
 
 Helper.parameters = {
   docs: {
-    storyDescription: 'Use the `helper` prop to set an helper content.',
+    description: { story: 'Use the `helper` prop to set an helper content.' },
   },
 }

--- a/packages/form/src/components/CheckboxGroupField/__stories__/Required.stories.tsx
+++ b/packages/form/src/components/CheckboxGroupField/__stories__/Required.stories.tsx
@@ -34,8 +34,9 @@ export const Required: StoryFn<typeof CheckboxGroupField> = args => (
 
 Required.parameters = {
   docs: {
-    storyDescription:
-      'Use the `direction` prop to change the direction of the group.',
+    description: {
+      story: 'Use the `direction` prop to change the direction of the group.',
+    },
   },
 }
 

--- a/packages/form/src/components/ToggleGroupField/__stories__/Direction.stories.tsx
+++ b/packages/form/src/components/ToggleGroupField/__stories__/Direction.stories.tsx
@@ -4,8 +4,9 @@ export const Direction = Template.bind({})
 
 Direction.parameters = {
   docs: {
-    storyDescription:
-      'Use the `direction` prop to change the direction of the group.',
+    description: {
+      story: 'Use the `direction` prop to change the direction of the group.',
+    },
   },
 }
 

--- a/packages/form/src/components/ToggleGroupField/__stories__/Error.stories.tsx
+++ b/packages/form/src/components/ToggleGroupField/__stories__/Error.stories.tsx
@@ -8,6 +8,6 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription: 'Use the `error` prop to set an error content.',
+    description: { story: 'Use the `error` prop to set an error content.' },
   },
 }

--- a/packages/form/src/components/ToggleGroupField/__stories__/Helper.stories.tsx
+++ b/packages/form/src/components/ToggleGroupField/__stories__/Helper.stories.tsx
@@ -8,6 +8,6 @@ Helper.args = {
 
 Helper.parameters = {
   docs: {
-    storyDescription: 'Use the `helper` prop to set an helper content.',
+    description: { story: 'Use the `helper` prop to set an helper content.' },
   },
 }

--- a/packages/form/src/components/ToggleGroupField/__stories__/Required.stories.tsx
+++ b/packages/form/src/components/ToggleGroupField/__stories__/Required.stories.tsx
@@ -35,8 +35,10 @@ export const Required: StoryFn<typeof ToggleGroupField> = args => (
 
 Required.parameters = {
   docs: {
-    storyDescription:
-      'Use the `required` prop to change make the whole group a required field.',
+    description: {
+      story:
+        'Use the `required` prop to change make the whole group a required field.',
+    },
   },
 }
 

--- a/packages/icons/src/components/Icon/__stories__/Color.stories.tsx
+++ b/packages/icons/src/components/Icon/__stories__/Color.stories.tsx
@@ -10,7 +10,7 @@ export const Color = (args: ComponentProps<typeof Icon>) =>
 
 Color.parameters = {
   docs: {
-    storyDescription: 'Set size using `size` property.',
+    description: { story: 'Set size using `size` property.' },
   },
 }
 

--- a/packages/icons/src/components/Icon/__stories__/Name.stories.tsx
+++ b/packages/icons/src/components/Icon/__stories__/Name.stories.tsx
@@ -13,7 +13,7 @@ export const Name = (args: ComponentProps<typeof Icon>) =>
 
 Name.parameters = {
   docs: {
-    storyDescription: 'Set desired icon using `name` property.',
+    description: { story: 'Set desired icon using `name` property.' },
   },
 }
 

--- a/packages/icons/src/components/Icon/__stories__/Size.stories.tsx
+++ b/packages/icons/src/components/Icon/__stories__/Size.stories.tsx
@@ -10,7 +10,7 @@ export const Size = (args: ComponentProps<typeof Icon>) =>
 
 Size.parameters = {
   docs: {
-    storyDescription: 'Set size using `size` property.',
+    description: { story: 'Set size using `size` property.' },
   },
 }
 

--- a/packages/icons/src/components/Icon/__stories__/UnknownOrUndefined.stories.tsx
+++ b/packages/icons/src/components/Icon/__stories__/UnknownOrUndefined.stories.tsx
@@ -11,8 +11,10 @@ export const UnknownOrUndefined = (args: ComponentProps<typeof Icon>) => [
 
 UnknownOrUndefined.parameters = {
   docs: {
-    storyDescription:
-      'If name is `undefined` or not found warning is sent and default circle icon is displayed.',
+    description: {
+      story:
+        'If name is `undefined` or not found warning is sent and default circle icon is displayed.',
+    },
   },
 }
 

--- a/packages/ui/src/components/ActionBar/__stories__/Ranks.stories.tsx
+++ b/packages/ui/src/components/ActionBar/__stories__/Ranks.stories.tsx
@@ -8,7 +8,9 @@ Ranks.args = {
 
 Ranks.parameters = {
   docs: {
-    storyDescription:
-      'You can choose the order of multiple `ActionBar` by using the `rank` prop.',
+    description: {
+      story:
+        'You can choose the order of multiple `ActionBar` by using the `rank` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Alert/__stories__/Button.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Button.stories.tsx
@@ -12,7 +12,9 @@ Button.args = {
 
 Button.parameters = {
   docs: {
-    storyDescription:
-      'Using `Button` prop you can add a custom Button and use `onClickButton` prop to handle the click event.',
+    description: {
+      story:
+        'Using `Button` prop you can add a custom Button and use `onClickButton` prop to handle the click event.',
+    },
   },
 }

--- a/packages/ui/src/components/Alert/__stories__/Closable.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Closable.stories.tsx
@@ -13,7 +13,9 @@ Closable.args = {
 
 Closable.parameters = {
   docs: {
-    storyDescription:
-      'If the children is long the content will be displayed as a column instead of a row.',
+    description: {
+      story:
+        'If the children is long the content will be displayed as a column instead of a row.',
+    },
   },
 }

--- a/packages/ui/src/components/Alert/__stories__/LongChildren.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/LongChildren.stories.tsx
@@ -14,7 +14,9 @@ LongChildren.args = {
 
 LongChildren.parameters = {
   docs: {
-    storyDescription:
-      'If the children is long the content will be displayed as a column instead of a row.',
+    description: {
+      story:
+        'If the children is long the content will be displayed as a column instead of a row.',
+    },
   },
 }

--- a/packages/ui/src/components/Alert/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Sentiments.stories.tsx
@@ -27,7 +27,9 @@ Sentiments.decorators = [
 
 Sentiments.parameters = {
   docs: {
-    storyDescription:
-      'Using `sentiment` prop you can change the sentiment of the component. Each sentiment has a default icon set.',
+    description: {
+      story:
+        'Using `sentiment` prop you can change the sentiment of the component. Each sentiment has a default icon set.',
+    },
   },
 }

--- a/packages/ui/src/components/Alert/__stories__/Title.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Title.stories.tsx
@@ -10,7 +10,9 @@ Title.args = {
 
 Title.parameters = {
   docs: {
-    storyDescription:
-      'Using `title` prop you can add a custom title to the notification.',
+    description: {
+      story:
+        'Using `title` prop you can add a custom title to the notification.',
+    },
   },
 }

--- a/packages/ui/src/components/Avatar/__stories__/BackgroundColor.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/BackgroundColor.stories.tsx
@@ -9,7 +9,9 @@ BackgroundColor.args = {
 
 BackgroundColor.parameters = {
   docs: {
-    storyDescription:
-      'You can set the background color when using text by setting `textBgColor` prop',
+    description: {
+      story:
+        'You can set the background color when using text by setting `textBgColor` prop',
+    },
   },
 }

--- a/packages/ui/src/components/Avatar/__stories__/Image.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/Image.stories.tsx
@@ -5,8 +5,10 @@ export const Image = Template.bind({})
 
 Image.parameters = {
   docs: {
-    storyDescription:
-      'You can change the default image by using the `image` prop. It work as `src` on a img tag.',
+    description: {
+      story:
+        'You can change the default image by using the `image` prop. It work as `src` on a img tag.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Avatar/__stories__/Lock.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/Lock.stories.tsx
@@ -18,7 +18,9 @@ Lock.decorators = [
 
 Lock.parameters = {
   docs: {
-    storyDescription:
-      'You can set the component to be locked by using `lock` prop when `text` is specified.',
+    description: {
+      story:
+        'You can set the component to be locked by using `lock` prop when `text` is specified.',
+    },
   },
 }

--- a/packages/ui/src/components/Avatar/__stories__/Size.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/Size.stories.tsx
@@ -10,7 +10,9 @@ Size.args = {
 
 Size.parameters = {
   docs: {
-    storyDescription:
-      'You can change the default Size by using the `Size` prop. It work as `src` on a img tag.',
+    description: {
+      story:
+        'You can change the default Size by using the `Size` prop. It work as `src` on a img tag.',
+    },
   },
 }

--- a/packages/ui/src/components/Avatar/__stories__/Text.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/Text.stories.tsx
@@ -18,7 +18,9 @@ Text.decorators = [
 
 Text.parameters = {
   docs: {
-    storyDescription:
-      'Instead of having an image you can put a text and it will take the best acronym to displayYou can change the default Text by using the `Text` prop. It work as `src` on a img tag.',
+    description: {
+      story:
+        'Instead of having an image you can put a text and it will take the best acronym to displayYou can change the default Text by using the `Text` prop. It work as `src` on a img tag.',
+    },
   },
 }

--- a/packages/ui/src/components/Avatar/__stories__/TextColor.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/TextColor.stories.tsx
@@ -9,6 +9,8 @@ TextColor.args = {
 
 TextColor.parameters = {
   docs: {
-    storyDescription: 'You can set the text color by setting `textColor` prop',
+    description: {
+      story: 'You can set the text color by setting `textColor` prop',
+    },
   },
 }

--- a/packages/ui/src/components/Avatar/__stories__/TextSize.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/TextSize.stories.tsx
@@ -29,7 +29,9 @@ TextSize.decorators = [
 
 TextSize.parameters = {
   docs: {
-    storyDescription:
-      'Additionally you can set the size of the text by using `textSize` prop. Don&lsquo;t forget to set the `size` prop to make your text fit into the component.',
+    description: {
+      story:
+        'Additionally you can set the size of the text by using `textSize` prop. Don&lsquo;t forget to set the `size` prop to make your text fit into the component.',
+    },
   },
 }

--- a/packages/ui/src/components/Badge/__stories__/Prominences.stories.tsx
+++ b/packages/ui/src/components/Badge/__stories__/Prominences.stories.tsx
@@ -24,8 +24,10 @@ export const Prominences: StoryFn = props => (
 
 Prominences.parameters = {
   docs: {
-    storyDescription:
-      'Prominence is defined by property `prominence`, this parameter will change color degree of badge.',
+    description: {
+      story:
+        'Prominence is defined by property `prominence`, this parameter will change color degree of badge.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Badge/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/Badge/__stories__/Sentiments.stories.tsx
@@ -14,8 +14,10 @@ export const Sentiments: StoryFn = props => (
 
 Sentiments.parameters = {
   docs: {
-    storyDescription:
-      'Sentiment defines different colors of your component. You can define it using `sentiment` property.',
+    description: {
+      story:
+        'Sentiment defines different colors of your component. You can define it using `sentiment` property.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Badge/__stories__/Sizes.stories.tsx
+++ b/packages/ui/src/components/Badge/__stories__/Sizes.stories.tsx
@@ -18,7 +18,9 @@ export const Sizes: StoryFn = props => (
 
 Sizes.parameters = {
   docs: {
-    storyDescription: 'You can define size of a badge using `size` property.',
+    description: {
+      story: 'You can define size of a badge using `size` property.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Banner/__stories__/Directions.stories.tsx
+++ b/packages/ui/src/components/Banner/__stories__/Directions.stories.tsx
@@ -30,8 +30,10 @@ export const Directions: StoryFn = args => (
 
 Directions.parameters = {
   docs: {
-    storyDescription:
-      'You can define the direction of the Banner using the `direction` property.',
+    description: {
+      story:
+        'You can define the direction of the Banner using the `direction` property.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Banner/__stories__/Sizes.stories.tsx
+++ b/packages/ui/src/components/Banner/__stories__/Sizes.stories.tsx
@@ -56,7 +56,9 @@ export const Sizes: StoryFn = args => (
 
 Sizes.parameters = {
   docs: {
-    storyDescription: 'You can define size of a Banner using `size` property.',
+    description: {
+      story: 'You can define size of a Banner using `size` property.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Banner/__stories__/Variants.stories.tsx
+++ b/packages/ui/src/components/Banner/__stories__/Variants.stories.tsx
@@ -30,8 +30,9 @@ export const Variants: StoryFn = args => (
 
 Variants.parameters = {
   docs: {
-    storyDescription:
-      'We have two different variant of Banner: intro and promotional.',
+    description: {
+      story: 'We have two different variant of Banner: intro and promotional.',
+    },
   },
 }
 

--- a/packages/ui/src/components/BarChart/__stories__/FormattedValuesAndTooltip.stories.tsx
+++ b/packages/ui/src/components/BarChart/__stories__/FormattedValuesAndTooltip.stories.tsx
@@ -21,7 +21,9 @@ export const FormattedValuesAndTooltip: StoryFn<typeof BarChart> = props => (
 
 FormattedValuesAndTooltip.parameters = {
   docs: {
-    storyDescription:
-      'Use `axisFormatters` and `tooltipFunction` to customize the axis and tooltip.',
+    description: {
+      story:
+        'Use `axisFormatters` and `tooltipFunction` to customize the axis and tooltip.',
+    },
   },
 }

--- a/packages/ui/src/components/BarChart/__stories__/MultiSeries.stories.tsx
+++ b/packages/ui/src/components/BarChart/__stories__/MultiSeries.stories.tsx
@@ -21,7 +21,9 @@ export const MultiSeries: StoryFn<typeof BarChart> = props => (
 
 MultiSeries.parameters = {
   docs: {
-    storyDescription:
-      'You can specify multiple `keys` to render multiple series at once.',
+    description: {
+      story:
+        'You can specify multiple `keys` to render multiple series at once.',
+    },
   },
 }

--- a/packages/ui/src/components/BarChart/__stories__/PositiveNegative.stories.tsx
+++ b/packages/ui/src/components/BarChart/__stories__/PositiveNegative.stories.tsx
@@ -44,6 +44,6 @@ export const PositiveNegative: StoryFn<typeof BarChart> = props => {
 
 PositiveNegative.parameters = {
   docs: {
-    storyDescription: 'Use `chartProps` to customize the chart.',
+    description: { story: 'Use `chartProps` to customize the chart.' },
   },
 }

--- a/packages/ui/src/components/Breadcrumbs/__stories__/OnClick.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/OnClick.stories.tsx
@@ -23,7 +23,9 @@ export const OnClick: StoryFn<ComponentProps<typeof Breadcrumbs>> = props => {
 
 OnClick.parameters = {
   docs: {
-    storyDescription:
-      'You can make `Breadcrumbs.Item` clickable with `onClick` handler which pass `(event, stepClicked)` params. You can also disabled the onClick handler by using `disabled` prop',
+    description: {
+      story:
+        'You can make `Breadcrumbs.Item` clickable with `onClick` handler which pass `(event, stepClicked)` params. You can also disabled the onClick handler by using `disabled` prop',
+    },
   },
 }

--- a/packages/ui/src/components/Breadcrumbs/__stories__/Selected.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/Selected.stories.tsx
@@ -4,8 +4,10 @@ export const Selected = Template.bind({})
 
 Selected.parameters = {
   docs: {
-    storyDescription:
-      'Selected is automatically determined as the last element. One can be specified using `selected` prop.',
+    description: {
+      story:
+        'Selected is automatically determined as the last element. One can be specified using `selected` prop.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Breadcrumbs/__stories__/To.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/To.stories.tsx
@@ -12,7 +12,9 @@ export const To: StoryFn<ComponentProps<typeof Breadcrumbs>> = props => (
 
 To.parameters = {
   docs: {
-    storyDescription:
-      'You can make `Breadcrumbs.Item` content be render as `a` tag with `to` prop. For relative url the `linkComponent` from your theme configuration is used.',
+    description: {
+      story:
+        'You can make `Breadcrumbs.Item` content be render as `a` tag with `to` prop. For relative url the `linkComponent` from your theme configuration is used.',
+    },
   },
 }

--- a/packages/ui/src/components/Bullet/__stories__/Icon.stories.tsx
+++ b/packages/ui/src/components/Bullet/__stories__/Icon.stories.tsx
@@ -11,8 +11,10 @@ export const Icon: StoryFn = props => (
 
 Icon.parameters = {
   docs: {
-    storyDescription:
-      'Set `icon` using icon property. Sentiment and size props affect icon.',
+    description: {
+      story:
+        'Set `icon` using icon property. Sentiment and size props affect icon.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Bullet/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/Bullet/__stories__/Sentiments.stories.tsx
@@ -33,8 +33,10 @@ export const Sentiments: StoryFn = props => (
 
 Sentiments.parameters = {
   docs: {
-    storyDescription:
-      'Sentiment defines different colors of your component. You can define it using `Sentiment` property.',
+    description: {
+      story:
+        'Sentiment defines different colors of your component. You can define it using `Sentiment` property.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Bullet/__stories__/Sizes.stories.tsx
+++ b/packages/ui/src/components/Bullet/__stories__/Sizes.stories.tsx
@@ -13,7 +13,9 @@ export const Sizes: StoryFn = props => (
 
 Sizes.parameters = {
   docs: {
-    storyDescription: 'You can define size of a badge using `size` property.',
+    description: {
+      story: 'You can define size of a badge using `size` property.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Bullet/__stories__/Text.stories.tsx
+++ b/packages/ui/src/components/Bullet/__stories__/Text.stories.tsx
@@ -5,8 +5,10 @@ export const Text: StoryFn = props => <Bullet {...props} text="A" />
 
 Text.parameters = {
   docs: {
-    storyDescription:
-      'Set `text` using text property. Sentiment and size props affect text.',
+    description: {
+      story:
+        'Set `text` using text property. Sentiment and size props affect text.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Bullet/__stories__/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Bullet/__stories__/Tooltip.stories.tsx
@@ -9,6 +9,6 @@ Tooltip.args = {
 
 Tooltip.parameters = {
   docs: {
-    storyDescription: 'Add a `tooltip` using tooltip property',
+    description: { story: 'Add a `tooltip` using tooltip property' },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/AsLink.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/AsLink.stories.tsx
@@ -23,7 +23,9 @@ export const AsLink: StoryFn<typeof Button> = args => (
 
 AsLink.parameters = {
   docs: {
-    storyDescription:
-      'Provide an `href` to turn the button as an anchor element. Adding `href` also allow to add `download` and `target` properties. `name` prop is not allowed in a anchor element.',
+    description: {
+      story:
+        'Provide an `href` to turn the button as an anchor element. Adding `href` also allow to add `download` and `target` properties. `name` prop is not allowed in a anchor element.',
+    },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/Disabled.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/Disabled.stories.tsx
@@ -9,7 +9,9 @@ Disabled.args = {
 
 Disabled.parameters = {
   docs: {
-    storyDescription:
-      'You can use the prop `disable` to disable a Button. Please note that `isLoading` prop also disable the button.',
+    description: {
+      story:
+        'You can use the prop `disable` to disable a Button. Please note that `isLoading` prop also disable the button.',
+    },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/FullWidth.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/FullWidth.stories.tsx
@@ -9,6 +9,8 @@ FullWidth.args = {
 
 FullWidth.parameters = {
   docs: {
-    storyDescription: '`fullWidth` prop makes you button have a `100%` width.',
+    description: {
+      story: '`fullWidth` prop makes you button have a `100%` width.',
+    },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/IconOnly.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/IconOnly.stories.tsx
@@ -11,6 +11,6 @@ IconOnly.args = {
 
 IconOnly.parameters = {
   docs: {
-    storyDescription: '`children` element is not required',
+    description: { story: '`children` element is not required' },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/IconPosition.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/IconPosition.stories.tsx
@@ -15,7 +15,8 @@ export const IconPosition: StoryFn<typeof Button> = args => (
 
 IconPosition.parameters = {
   docs: {
-    storyDescription:
-      'You can change the icon/loader using the prop `iconPosition`.',
+    description: {
+      story: 'You can change the icon/loader using the prop `iconPosition`.',
+    },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/IsLoading.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/IsLoading.stories.tsx
@@ -9,7 +9,9 @@ IsLoading.args = {
 
 IsLoading.parameters = {
   docs: {
-    storyDescription:
-      'You can use the prop `isLoading`, it will disable the button and add (or replace icon) a `Loader` component. The `iconPosition` prop also impacts Loader position.',
+    description: {
+      story:
+        'You can use the prop `isLoading`, it will disable the button and add (or replace icon) a `Loader` component. The `iconPosition` prop also impacts Loader position.',
+    },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/Size.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/Size.stories.tsx
@@ -14,6 +14,8 @@ export const Size: StoryFn<typeof Button> = args => (
 
 Size.parameters = {
   docs: {
-    storyDescription: 'You can change the button size using the prop `size`.',
+    description: {
+      story: 'You can change the button size using the prop `size`.',
+    },
   },
 }

--- a/packages/ui/src/components/Button/__stories__/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/Tooltip.stories.tsx
@@ -9,7 +9,9 @@ Tooltip.args = {
 
 Tooltip.parameters = {
   docs: {
-    storyDescription:
-      'You can add a prop "tooltip" which wrap the Button inside a Tooltip component, the optional ref will be applied to the button. For more advanced tooltip usage, we recommand to wrap manually the Button using the Tooltip component.',
+    description: {
+      story:
+        'You can add a prop "tooltip" which wrap the Button inside a Tooltip component, the optional ref will be applied to the button. For more advanced tooltip usage, we recommand to wrap manually the Button using the Tooltip component.',
+    },
   },
 }

--- a/packages/ui/src/components/Card/__stories__/AdvancedHeader.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/AdvancedHeader.stories.tsx
@@ -29,7 +29,9 @@ export const AdvancedHeader: StoryFn = args => {
 
 AdvancedHeader.parameters = {
   docs: {
-    storyDescription:
-      'Header can be a `string` but also a component if you need more complex header. Keep in mind that when you\'re using a custom component you need to use `<Text variant="heading" as="h2">` to be consistent with non-custom Card headers.',
+    description: {
+      story:
+        'Header can be a `string` but also a component if you need more complex header. Keep in mind that when you\'re using a custom component you need to use `<Text variant="heading" as="h2">` to be consistent with non-custom Card headers.',
+    },
   },
 }

--- a/packages/ui/src/components/Card/__stories__/Disabled.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/Disabled.stories.tsx
@@ -19,6 +19,8 @@ export const Disabled: StoryFn = args => (
 
 Disabled.parameters = {
   docs: {
-    storyDescription: 'You can disable a Card by passing the `disabled` prop.',
+    description: {
+      story: 'You can disable a Card by passing the `disabled` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Card/__stories__/Header.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/Header.stories.tsx
@@ -8,7 +8,9 @@ Header.args = {
 
 Header.parameters = {
   docs: {
-    storyDescription:
-      'You can pass a `string` to the `header` prop to display a simple header.',
+    description: {
+      story:
+        'You can pass a `string` to the `header` prop to display a simple header.',
+    },
   },
 }

--- a/packages/ui/src/components/Card/__stories__/IsActive.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/IsActive.stories.tsx
@@ -45,7 +45,8 @@ export const IsActive: StoryFn = args => {
 
 IsActive.parameters = {
   docs: {
-    storyDescription:
-      'You can highlight a Card by passing the `isActive` prop.',
+    description: {
+      story: 'You can highlight a Card by passing the `isActive` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Checkbox/__stories__/Checked.stories.tsx
+++ b/packages/ui/src/components/Checkbox/__stories__/Checked.stories.tsx
@@ -19,7 +19,9 @@ export const Checked: StoryFn = args => (
 
 Checked.parameters = {
   docs: {
-    storyDescription:
-      'Checkbox can have two state `checked` or `indeterminate` defined by prop `checked`.',
+    description: {
+      story:
+        'Checkbox can have two state `checked` or `indeterminate` defined by prop `checked`.',
+    },
   },
 }

--- a/packages/ui/src/components/Checkbox/__stories__/Errors.stories.tsx
+++ b/packages/ui/src/components/Checkbox/__stories__/Errors.stories.tsx
@@ -10,7 +10,8 @@ Errors.args = {
 }
 Errors.parameters = {
   docs: {
-    storyDescription:
-      'Set validation with error message using `error` property.',
+    description: {
+      story: 'Set validation with error message using `error` property.',
+    },
   },
 }

--- a/packages/ui/src/components/Checkbox/__stories__/Value.stories.tsx
+++ b/packages/ui/src/components/Checkbox/__stories__/Value.stories.tsx
@@ -17,6 +17,6 @@ export const Value: StoryFn = args => (
 
 Value.parameters = {
   docs: {
-    storyDescription: 'Set value using `value` property.',
+    description: { story: 'Set value using `value` property.' },
   },
 }

--- a/packages/ui/src/components/CheckboxGroup/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/CheckboxGroup/__stories__/Controlled.stories.tsx
@@ -36,7 +36,9 @@ export const Controlled: StoryFn = () => {
 
 Controlled.parameters = {
   docs: {
-    storyDescription:
-      'CheckboxGroup only work as a controlled component. You need to pass `onChange` callback to control it.',
+    description: {
+      story:
+        'CheckboxGroup only work as a controlled component. You need to pass `onChange` callback to control it.',
+    },
   },
 }

--- a/packages/ui/src/components/CheckboxGroup/__stories__/Direction.stories.tsx
+++ b/packages/ui/src/components/CheckboxGroup/__stories__/Direction.stories.tsx
@@ -8,7 +8,8 @@ Direction.args = {
 
 Direction.parameters = {
   docs: {
-    storyDescription:
-      'Use the `direction` prop to change the direction of the group.',
+    description: {
+      story: 'Use the `direction` prop to change the direction of the group.',
+    },
   },
 }

--- a/packages/ui/src/components/CheckboxGroup/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/CheckboxGroup/__stories__/Error.stories.tsx
@@ -8,6 +8,6 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription: 'Use the `error` prop to set an error content.',
+    description: { story: 'Use the `error` prop to set an error content.' },
   },
 }

--- a/packages/ui/src/components/CheckboxGroup/__stories__/Helper.stories.tsx
+++ b/packages/ui/src/components/CheckboxGroup/__stories__/Helper.stories.tsx
@@ -8,6 +8,6 @@ Helper.args = {
 
 Helper.parameters = {
   docs: {
-    storyDescription: 'Use the `helper` prop to set an helper content.',
+    description: { story: 'Use the `helper` prop to set an helper content.' },
   },
 }

--- a/packages/ui/src/components/DateInput/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/Controlled.stories.tsx
@@ -20,7 +20,9 @@ export const Controlled: StoryFn<ComponentProps<typeof DateInput>> = args => {
 
 Controlled.parameters = {
   docs: {
-    storyDescription:
-      'Most of the time, you need a [controlled component](https://reactjs.org/docs/forms.html#controlled-components). By passing `value` and `onChange` prop you can control it.',
+    description: {
+      story:
+        'Most of the time, you need a [controlled component](https://reactjs.org/docs/forms.html#controlled-components). By passing `value` and `onChange` prop you can control it.',
+    },
   },
 }

--- a/packages/ui/src/components/DateInput/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/Error.stories.tsx
@@ -4,8 +4,9 @@ export const Error = Template.bind({})
 
 Error.parameters = {
   docs: {
-    storyDescription:
-      'Use `error` prop to style the input when the field is invalid.',
+    description: {
+      story: 'Use `error` prop to style the input when the field is invalid.',
+    },
   },
 }
 

--- a/packages/ui/src/components/DateInput/__stories__/I18n.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/I18n.stories.tsx
@@ -39,7 +39,9 @@ export const I18n: StoryFn<ComponentProps<typeof DateInput>> = args => {
 
 I18n.parameters = {
   docs: {
-    storyDescription:
-      'If you use our `useI18n` hook you can easily handle localization change on the input by getting `currentLocale` returned by the hook.',
+    description: {
+      story:
+        'If you use our `useI18n` hook you can easily handle localization change on the input by getting `currentLocale` returned by the hook.',
+    },
   },
 }

--- a/packages/ui/src/components/DateInput/__stories__/Localized.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/Localized.stories.tsx
@@ -16,8 +16,10 @@ export const Localized = (props: ComponentProps<typeof DateInput>) =>
 
 Localized.parameters = {
   docs: {
-    storyDescription:
-      'You can import locale from `date-fns/locale` package and pass it as `locale` prop to localize the input.',
+    description: {
+      story:
+        'You can import locale from `date-fns/locale` package and pass it as `locale` prop to localize the input.',
+    },
   },
 }
 

--- a/packages/ui/src/components/DateInput/__stories__/MinMax.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/MinMax.stories.tsx
@@ -4,8 +4,9 @@ export const MinMax = Template.bind({})
 
 MinMax.parameters = {
   docs: {
-    storyDescription:
-      'With `minDate` and `maxDate` you can define limits of the input',
+    description: {
+      story: 'With `minDate` and `maxDate` you can define limits of the input',
+    },
   },
 }
 

--- a/packages/ui/src/components/DateInput/__stories__/Uncontrolled.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/Uncontrolled.stories.tsx
@@ -8,7 +8,9 @@ export const Uncontrolled: StoryFn<
 
 Uncontrolled.parameters = {
   docs: {
-    storyDescription:
-      'DateInput can be used as an [uncontrolled component](https://reactjs.org/docs/uncontrolled-components.html).',
+    description: {
+      story:
+        'DateInput can be used as an [uncontrolled component](https://reactjs.org/docs/uncontrolled-components.html).',
+    },
   },
 }

--- a/packages/ui/src/components/Link/__stories__/Size.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/Size.stories.tsx
@@ -14,7 +14,7 @@ export const Size = (props: ComponentProps<typeof Link>) =>
 
 Size.parameters = {
   docs: {
-    storyDescription: 'Edit `size` prop to change the size of the text',
+    description: { story: 'Edit `size` prop to change the size of the text' },
   },
 }
 

--- a/packages/ui/src/components/Link/__stories__/Target.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/Target.stories.tsx
@@ -4,8 +4,10 @@ export const Target = Template.bind({})
 
 Target.parameters = {
   docs: {
-    storyDescription:
-      'Edit the `target` prop to specify the target you want for your link. By using `_blank`, an icon is added to show that it is an external link',
+    description: {
+      story:
+        'Edit the `target` prop to specify the target you want for your link. By using `_blank`, an icon is added to show that it is an external link',
+    },
   },
 }
 

--- a/packages/ui/src/components/List/__stories__/Columns.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Columns.stories.tsx
@@ -6,7 +6,9 @@ Columns.args = Template.args
 
 Columns.parameters = {
   docs: {
-    storyDescription:
-      'By default List divides width equally available space between rows. To force the `width` of a column you can specify by specify a width (px, em, percent).\n\nThe `label` of a column represents the text of a column in list header.\n\nYou can also `sort` columns, please check the `Ordering` story.',
+    description: {
+      story:
+        'By default List divides width equally available space between rows. To force the `width` of a column you can specify by specify a width (px, em, percent).\n\nThe `label` of a column represents the text of a column in list header.\n\nYou can also `sort` columns, please check the `Ordering` story.',
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/Context.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Context.stories.tsx
@@ -40,7 +40,8 @@ export const Context: StoryFn = args => {
 
 Context.parameters = {
   docs: {
-    storyDescription: `You can use \`List.useListContext\` to get this hydrated properties about the list:
+    description: {
+      story: `You can use \`List.useListContext\` to get this hydrated properties about the list:
 
 - expandedRowIds : [Object] Expanded rows (key is row id, value is a boolean, true mean the related row is expanded)
 - expandRow : [Function] expand a row by providing its id
@@ -55,5 +56,6 @@ Context.parameters = {
   - \`false\` means no row is selected
   - \`true\` means all rows are selected
   - \`indeterminate\` means rows are partially selected`,
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/Example.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Example.stories.tsx
@@ -94,7 +94,9 @@ export const Example: StoryFn = args => {
 
 Example.parameters = {
   docs: {
-    storyDescription:
-      'This example is a demo of the List with the following features : `selectable rows`, `expandable row`, `sortable data`',
+    description: {
+      story:
+        'This example is a demo of the List with the following features : `selectable rows`, `expandable row`, `sortable data`',
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/Expandable.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Expandable.stories.tsx
@@ -25,7 +25,9 @@ Expandable.args = {
 
 Expandable.parameters = {
   docs: {
-    storyDescription:
-      'The Row supports the prop `expandable` which expect a ReactNode. This content will be visible if user click on the row.\n\nProviding `disabled` on the row will prevent the expanding on click.',
+    description: {
+      story:
+        'The Row supports the prop `expandable` which expect a ReactNode. This content will be visible if user click on the row.\n\nProviding `disabled` on the row will prevent the expanding on click.',
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/ExpandableAutocollapse.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/ExpandableAutocollapse.stories.tsx
@@ -18,7 +18,9 @@ ExpandableAutocollapse.args = {
 
 ExpandableAutocollapse.parameters = {
   docs: {
-    storyDescription:
-      'By adding the prop `autoCollapse` on the `List`, expanding a row will collapse other rows current expanded.',
+    description: {
+      story:
+        'By adding the prop `autoCollapse` on the `List`, expanding a row will collapse other rows current expanded.',
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/Loading.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Loading.stories.tsx
@@ -9,7 +9,9 @@ Loading.args = {
 
 Loading.parameters = {
   docs: {
-    storyDescription:
-      'By adding the prop `loading` on the `List`, 5 loading rows will be displayed instead of the provided children prop.',
+    description: {
+      story:
+        'By adding the prop `loading` on the `List`, 5 loading rows will be displayed instead of the provided children prop.',
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/Ordering.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Ordering.stories.tsx
@@ -63,7 +63,9 @@ export const Ordering: StoryFn = args => {
 
 Ordering.parameters = {
   docs: {
-    storyDescription:
-      'You can indicate that a column is ordered by providing `isOrdered`, `orderDirection`. `onOrder` callback provides the opposite of current order as param for an easier sorting (DESC if currently ASC, otherwhile ASC)',
+    description: {
+      story:
+        'You can indicate that a column is ordered by providing `isOrdered`, `orderDirection`. `onOrder` callback provides the opposite of current order as param for an easier sorting (DESC if currently ASC, otherwhile ASC)',
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/PreventClick.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/PreventClick.stories.tsx
@@ -22,7 +22,9 @@ PreventClick.args = {
 
 PreventClick.parameters = {
   docs: {
-    storyDescription:
-      'By adding the prop `preventClick` on the `Cell`, you can limit any event propagation to go outside the cell. It can be used for prevent button to interfere with row expand onClick.',
+    description: {
+      story:
+        'By adding the prop `preventClick` on the `Cell`, you can limit any event propagation to go outside the cell. It can be used for prevent button to interfere with row expand onClick.',
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/Selectable.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Selectable.stories.tsx
@@ -65,7 +65,9 @@ Selectable.args = {
 
 Selectable.parameters = {
   docs: {
-    storyDescription:
-      "By adding the prop `selectable` on the `List` a new column will be automatically added to allow user to select a row, each row is identified by its prop `id`.\n\nYou can use the utility `List.SelectBar` to quickly get selectedItems providing the `data` and the data's property key used to provite the `id` of each `List.Row`.\n\nFor other usages about selected items, check our `Context` example.\n\nA disabled Row `disabled` cannot be selected.\n\nProviding the prop `selectDisabled` prevents the row to be selected (it can be a boolean or a string to give user a disable reason shown as a tooltip).",
+    description: {
+      story:
+        "By adding the prop `selectable` on the `List` a new column will be automatically added to allow user to select a row, each row is identified by its prop `id`.\n\nYou can use the utility `List.SelectBar` to quickly get selectedItems providing the `data` and the data's property key used to provite the `id` of each `List.Row`.\n\nFor other usages about selected items, check our `Context` example.\n\nA disabled Row `disabled` cannot be selected.\n\nProviding the prop `selectDisabled` prevents the row to be selected (it can be a boolean or a string to give user a disable reason shown as a tooltip).",
+    },
   },
 }

--- a/packages/ui/src/components/List/__stories__/Sentiment.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Sentiment.stories.tsx
@@ -38,7 +38,9 @@ Sentiments.args = {
 
 Sentiments.parameters = {
   docs: {
-    storyDescription:
-      'You can provide the prop `sentiment` of a `Row`. Default value is `neutral`. `Row` prop `disabled` overide sentiment.',
+    description: {
+      story:
+        'You can provide the prop `sentiment` of a `Row`. Default value is `neutral`. `Row` prop `disabled` overide sentiment.',
+    },
   },
 }

--- a/packages/ui/src/components/Loader/__stories__/Active.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/Active.stories.tsx
@@ -8,7 +8,9 @@ Active.args = {
 
 Active.parameters = {
   docs: {
-    storyDescription:
-      'You can set the `active` prop to indicate to set the indicator active.',
+    description: {
+      story:
+        'You can set the `active` prop to indicate to set the indicator active.',
+    },
   },
 }

--- a/packages/ui/src/components/Loader/__stories__/Colors.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/Colors.stories.tsx
@@ -12,7 +12,8 @@ export const Colors: StoryFn = props => (
 
 Colors.parameters = {
   docs: {
-    storyDescription:
-      'You can set the color of the component with the `color` prop.',
+    description: {
+      story: 'You can set the color of the component with the `color` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Loader/__stories__/Percentages.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/Percentages.stories.tsx
@@ -11,7 +11,9 @@ export const Percentages: StoryFn = props => (
 
 Percentages.parameters = {
   docs: {
-    storyDescription:
-      'You can set the percentage of completion with the `percentage` prop.',
+    description: {
+      story:
+        'You can set the percentage of completion with the `percentage` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Loader/__stories__/Sizes.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/Sizes.stories.tsx
@@ -11,7 +11,8 @@ export const Sizes: StoryFn = props => (
 
 Sizes.parameters = {
   docs: {
-    storyDescription:
-      'You can set the size of the component with the `size` prop.',
+    description: {
+      story: 'You can set the size of the component with the `size` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Loader/__stories__/StrokeWidth.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/StrokeWidth.stories.tsx
@@ -11,7 +11,8 @@ export const StrokeWidth: StoryFn = props => (
 
 StrokeWidth.parameters = {
   docs: {
-    storyDescription:
-      'You can also set the stroke width with the `strokeWidth` prop.',
+    description: {
+      story: 'You can also set the stroke width with the `strokeWidth` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Loader/__stories__/Text.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/Text.stories.tsx
@@ -16,7 +16,9 @@ export const Text: StoryFn = props => (
 
 Text.parameters = {
   docs: {
-    storyDescription:
-      'You can pass a text which will be inlined in the center of the circle with the `text` prop.',
+    description: {
+      story:
+        'You can pass a text which will be inlined in the center of the circle with the `text` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Loader/__stories__/TrailColor.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/TrailColor.stories.tsx
@@ -12,7 +12,9 @@ export const TrailColor: StoryFn = props => (
 
 TrailColor.parameters = {
   docs: {
-    storyDescription:
-      'You can set the trail color (background) of the component by using the `trailColor` prop. You can use theme color or a custom one.',
+    description: {
+      story:
+        'You can set the trail color (background) of the component by using the `trailColor` prop. You can use theme color or a custom one.',
+    },
   },
 }

--- a/packages/ui/src/components/Menu/__stories__/Borderless.stories.tsx
+++ b/packages/ui/src/components/Menu/__stories__/Borderless.stories.tsx
@@ -26,7 +26,9 @@ export const Borderless: StoryFn<typeof Menu> = () => (
 
 Borderless.parameters = {
   docs: {
-    storyDescription: 'Property `borderless` removes border of the menu item.',
+    description: {
+      story: 'Property `borderless` removes border of the menu item.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Menu/__stories__/FunctionDisclosure.stories.tsx
+++ b/packages/ui/src/components/Menu/__stories__/FunctionDisclosure.stories.tsx
@@ -19,8 +19,10 @@ export const FunctionDisclosure: StoryFn<typeof Menu> = () => {
 
 FunctionDisclosure.parameters = {
   docs: {
-    storyDescription:
-      'You can specify a function as disclosure and get popover props as argument',
+    description: {
+      story:
+        'You can specify a function as disclosure and get popover props as argument',
+    },
   },
 }
 

--- a/packages/ui/src/components/Menu/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/Menu/__stories__/Sentiments.stories.tsx
@@ -22,10 +22,12 @@ export const Sentiments: StoryFn<typeof Menu> = () => (
 
 Sentiments.parameters = {
   docs: {
-    storyDescription: `A set of sentiment you can add on MenuItem (neutral, danger). You can use either props on MenuItem :
+    description: {
+      story: `A set of sentiment you can add on MenuItem (neutral, danger). You can use either props on MenuItem :
 - \`onClick\` to define menu actions.
 - \`to\` to define as a \`React Router Link\`.
 - \`href\` to define as a native link \`a\`.`,
+    },
   },
 }
 

--- a/packages/ui/src/components/Menu/__stories__/WithModal.stories.tsx
+++ b/packages/ui/src/components/Menu/__stories__/WithModal.stories.tsx
@@ -28,7 +28,7 @@ export const WithModal: StoryFn<typeof Menu> = () => {
 
 WithModal.parameters = {
   docs: {
-    storyDescription: 'This show how to use a modal on MenuItem.',
+    description: { story: 'This show how to use a modal on MenuItem.' },
   },
 }
 

--- a/packages/ui/src/components/MenuV2/__stories__/Borderless.stories.tsx
+++ b/packages/ui/src/components/MenuV2/__stories__/Borderless.stories.tsx
@@ -26,7 +26,9 @@ export const Borderless: StoryFn<typeof MenuV2> = () => (
 
 Borderless.parameters = {
   docs: {
-    storyDescription: 'Property `borderless` removes border of the menu item.',
+    description: {
+      story: 'Property `borderless` removes border of the menu item.',
+    },
   },
 }
 

--- a/packages/ui/src/components/MenuV2/__stories__/FunctionDisclosure.stories.tsx
+++ b/packages/ui/src/components/MenuV2/__stories__/FunctionDisclosure.stories.tsx
@@ -17,8 +17,10 @@ export const FunctionDisclosure: StoryFn<typeof MenuV2> = () => {
 
 FunctionDisclosure.parameters = {
   docs: {
-    storyDescription:
-      'You can specify a function as disclosure and get popover props as argument',
+    description: {
+      story:
+        'You can specify a function as disclosure and get popover props as argument',
+    },
   },
 }
 

--- a/packages/ui/src/components/MenuV2/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/MenuV2/__stories__/Sentiments.stories.tsx
@@ -24,10 +24,12 @@ export const Sentiments: StoryFn<typeof MenuV2> = () => (
 
 Sentiments.parameters = {
   docs: {
-    storyDescription: `A set of sentiment you can add on MenuV2Item (neutral, danger). You can use either props on MenuItem :
+    description: {
+      story: `A set of sentiment you can add on MenuV2Item (neutral, danger). You can use either props on MenuItem :
 - \`onClick\` to define menu actions.
 - \`to\` to define as a \`React Router Link\`.
 - \`href\` to define as a native link \`a\`.`,
+    },
   },
 }
 

--- a/packages/ui/src/components/MenuV2/__stories__/WithModal.stories.tsx
+++ b/packages/ui/src/components/MenuV2/__stories__/WithModal.stories.tsx
@@ -28,7 +28,7 @@ export const WithModal: StoryFn<typeof MenuV2> = () => {
 
 WithModal.parameters = {
   docs: {
-    storyDescription: 'This show how to use a modal on MenuItem.',
+    description: { story: 'This show how to use a modal on MenuItem.' },
   },
 }
 

--- a/packages/ui/src/components/Modal/__stories__/HideOnClickOutside.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/HideOnClickOutside.stories.tsx
@@ -15,7 +15,9 @@ export const HideOnClickOutside: StoryFn = props => (
 
 HideOnClickOutside.parameters = {
   docs: {
-    storyDescription:
-      'To close or keep modal on click outside, specify `hideOnClickOutside`',
+    description: {
+      story:
+        'To close or keep modal on click outside, specify `hideOnClickOutside`',
+    },
   },
 }

--- a/packages/ui/src/components/Modal/__stories__/HideOnEsc.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/HideOnEsc.stories.tsx
@@ -14,7 +14,9 @@ export const HideOnEsc: StoryFn = props => (
 )
 HideOnEsc.parameters = {
   docs: {
-    storyDescription:
-      'To hide or keep modal on ESC key, specify `hideOnEsc`Here is a list of all the HideOnEsc values we support',
+    description: {
+      story:
+        'To hide or keep modal on ESC key, specify `hideOnEsc`Here is a list of all the HideOnEsc values we support',
+    },
   },
 }

--- a/packages/ui/src/components/Modal/__stories__/IsClosable.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/IsClosable.stories.tsx
@@ -21,6 +21,8 @@ export const IsClosable: StoryFn = props => (
 
 IsClosable.parameters = {
   docs: {
-    storyDescription: 'To hide close button at the top, specify `isClosable`',
+    description: {
+      story: 'To hide close button at the top, specify `isClosable`',
+    },
   },
 }

--- a/packages/ui/src/components/Modal/__stories__/Placement.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/Placement.stories.tsx
@@ -21,6 +21,8 @@ export const Placement: StoryFn = props => (
 
 Placement.parameters = {
   docs: {
-    storyDescription: 'Here is a list of all the placement values we support',
+    description: {
+      story: 'Here is a list of all the placement values we support',
+    },
   },
 }

--- a/packages/ui/src/components/Modal/__stories__/PreventBodyScroll.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/PreventBodyScroll.stories.tsx
@@ -28,7 +28,9 @@ export const PreventBodyScroll: StoryFn = props => (
 
 PreventBodyScroll.parameters = {
   docs: {
-    storyDescription:
-      'To prevent body scroll outside of the modal, use `preventBodyScroll`',
+    description: {
+      story:
+        'To prevent body scroll outside of the modal, use `preventBodyScroll`',
+    },
   },
 }

--- a/packages/ui/src/components/Modal/__stories__/Size.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/Size.stories.tsx
@@ -21,6 +21,6 @@ export const Size: StoryFn = props => (
 
 Size.parameters = {
   docs: {
-    storyDescription: 'Here is a list of all the width values we support',
+    description: { story: 'Here is a list of all the width values we support' },
   },
 }

--- a/packages/ui/src/components/Modal/__stories__/WithLotsOfContent.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/WithLotsOfContent.stories.tsx
@@ -26,6 +26,8 @@ export const WithLotsOfContent: StoryFn = props => (
 )
 WithLotsOfContent.parameters = {
   docs: {
-    storyDescription: 'Having a lot of content automatically adds a scroll',
+    description: {
+      story: 'Having a lot of content automatically adds a scroll',
+    },
   },
 }

--- a/packages/ui/src/components/Notice/__stories__/ComplexChildren.stories.tsx
+++ b/packages/ui/src/components/Notice/__stories__/ComplexChildren.stories.tsx
@@ -16,6 +16,6 @@ export const ComplexChildren = (args: ComponentProps<typeof Notice>) => (
 
 ComplexChildren.parameters = {
   docs: {
-    storyDescription: 'You can also pass complex children',
+    description: { story: 'You can also pass complex children' },
   },
 }

--- a/packages/ui/src/components/NumberInput/__stories__/DefaultValue.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/DefaultValue.stories.tsx
@@ -10,7 +10,9 @@ DefaultValue.args = {
 
 DefaultValue.parameters = {
   docs: {
-    storyDescription:
-      'If you use this component as an uncontrolled component you can use the prop `defaultValue` to define the initial value. If defaultValue is not in minValue/maxValue range it will be set to closest valid value.',
+    description: {
+      story:
+        'If you use this component as an uncontrolled component you can use the prop `defaultValue` to define the initial value. If defaultValue is not in minValue/maxValue range it will be set to closest valid value.',
+    },
   },
 }

--- a/packages/ui/src/components/NumberInput/__stories__/DisabledTooltip.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/DisabledTooltip.stories.tsx
@@ -10,7 +10,9 @@ DisabledTooltip.args = {
 
 DisabledTooltip.parameters = {
   docs: {
-    storyDescription:
-      'You can add a tooltip on left and rights button by using `disabledTooltip` prop. Try to hover on the "-" and "+".',
+    description: {
+      story:
+        'You can add a tooltip on left and rights button by using `disabledTooltip` prop. Try to hover on the "-" and "+".',
+    },
   },
 }

--- a/packages/ui/src/components/NumberInput/__stories__/Placeholder.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/Placeholder.stories.tsx
@@ -8,7 +8,9 @@ Placeholder.args = {
 
 Placeholder.parameters = {
   docs: {
-    storyDescription:
-      'You can change the placeholder inside the input by passing a string to the `placeholder` prop.',
+    description: {
+      story:
+        'You can change the placeholder inside the input by passing a string to the `placeholder` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/NumberInput/__stories__/Steps.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/Steps.stories.tsx
@@ -10,7 +10,9 @@ Steps.args = {
 
 Steps.parameters = {
   docs: {
-    storyDescription:
-      'You can change step size of your `NumberInput` component. If you set it to 10 for example, your `NumberInput` will increase & decrease by steps of 10.',
+    description: {
+      story:
+        'You can change step size of your `NumberInput` component. If you set it to 10 for example, your `NumberInput` will increase & decrease by steps of 10.',
+    },
   },
 }

--- a/packages/ui/src/components/NumberInput/__stories__/Text.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/Text.stories.tsx
@@ -9,7 +9,9 @@ Text.args = {
 
 Text.parameters = {
   docs: {
-    storyDescription:
-      'You can change text inside NumberInput by using `text` prop. You can pass directly a text or a component.',
+    description: {
+      story:
+        'You can change text inside NumberInput by using `text` prop. You can pass directly a text or a component.',
+    },
   },
 }

--- a/packages/ui/src/components/PasswordStrengthMeter/__stories__/ForbiddenInputs.stories.tsx
+++ b/packages/ui/src/components/PasswordStrengthMeter/__stories__/ForbiddenInputs.stories.tsx
@@ -34,8 +34,10 @@ export const ForbiddenInputs = () => {
 
 ForbiddenInputs.parameters = {
   docs: {
-    storyDescription: `__forbiddenInputs__ properties can be used to specify which word shouldn't be used for a password. That way you can force user to avoid using sensitive data such as: their email, login, name, etc.
+    description: {
+      story: `__forbiddenInputs__ properties can be used to specify which word shouldn't be used for a password. That way you can force user to avoid using sensitive data such as: their email, login, name, etc.
 
 In this example try to type __qwerty__, the score should be really low as the word has been "banned" using __forbiddenInputs__ properties.`,
+    },
   },
 }

--- a/packages/ui/src/components/ProgressBar/__stories__/Cap.stories.tsx
+++ b/packages/ui/src/components/ProgressBar/__stories__/Cap.stories.tsx
@@ -18,7 +18,9 @@ Cap.decorators = [
 
 Cap.parameters = {
   docs: {
-    storyDescription:
-      'Value will be capped out above 0 and below 100, so you&apos;re safe to pass an even greater/lower value',
+    description: {
+      story:
+        'Value will be capped out above 0 and below 100, so you&apos;re safe to pass an even greater/lower value',
+    },
   },
 }

--- a/packages/ui/src/components/ProgressBar/__stories__/Progress.stories.tsx
+++ b/packages/ui/src/components/ProgressBar/__stories__/Progress.stories.tsx
@@ -8,7 +8,8 @@ Progress.args = {
 
 Progress.parameters = {
   docs: {
-    storyDescription:
-      'Progress is used to show a loading state of the component.',
+    description: {
+      story: 'Progress is used to show a loading state of the component.',
+    },
   },
 }

--- a/packages/ui/src/components/ProgressBar/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/ProgressBar/__stories__/Sentiments.stories.tsx
@@ -24,6 +24,6 @@ Sentiments.decorators = [
 
 Sentiments.parameters = {
   docs: {
-    storyDescription: 'Set sentiment using `sentiment` prop.',
+    description: { story: 'Set sentiment using `sentiment` prop.' },
   },
 }

--- a/packages/ui/src/components/Radio/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/Radio/__stories__/Controlled.stories.tsx
@@ -32,7 +32,9 @@ export const Controlled: StoryFn = args => {
 }
 Controlled.parameters = {
   docs: {
-    storyDescription:
-      'Radio only work as a controlled component. You need to pass `onChange` callback to control it.',
+    description: {
+      story:
+        'Radio only work as a controlled component. You need to pass `onChange` callback to control it.',
+    },
   },
 }

--- a/packages/ui/src/components/Radio/__stories__/Disabled.stories.tsx
+++ b/packages/ui/src/components/Radio/__stories__/Disabled.stories.tsx
@@ -34,6 +34,6 @@ export const Disabled: StoryFn = args => {
 
 Disabled.parameters = {
   docs: {
-    storyDescription: 'Set activation using `disabled` property.',
+    description: { story: 'Set activation using `disabled` property.' },
   },
 }

--- a/packages/ui/src/components/Radio/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/Radio/__stories__/Error.stories.tsx
@@ -34,7 +34,8 @@ export const Error: StoryFn = args => {
 
 Error.parameters = {
   docs: {
-    storyDescription:
-      'Set validation with error message using `error` property.',
+    description: {
+      story: 'Set validation with error message using `error` property.',
+    },
   },
 }

--- a/packages/ui/src/components/Radio/__stories__/Helper.stories.tsx
+++ b/packages/ui/src/components/Radio/__stories__/Helper.stories.tsx
@@ -14,6 +14,6 @@ export const Helper: StoryFn = args => (
 
 Helper.parameters = {
   docs: {
-    storyDescription: 'Add an helper text using `helper` property.',
+    description: { story: 'Add an helper text using `helper` property.' },
   },
 }

--- a/packages/ui/src/components/RadioGroup/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/Controlled.stories.tsx
@@ -23,7 +23,9 @@ export const Controlled: StoryFn = args => {
 
 Controlled.parameters = {
   docs: {
-    storyDescription:
-      'RadioGroup only work as a controlled component. You need to pass `onChange` callback to control it.',
+    description: {
+      story:
+        'RadioGroup only work as a controlled component. You need to pass `onChange` callback to control it.',
+    },
   },
 }

--- a/packages/ui/src/components/RadioGroup/__stories__/Direction.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/Direction.stories.tsx
@@ -8,7 +8,8 @@ Direction.args = {
 
 Direction.parameters = {
   docs: {
-    storyDescription:
-      'Use the `direction` prop to change the direction of the group.',
+    description: {
+      story: 'Use the `direction` prop to change the direction of the group.',
+    },
   },
 }

--- a/packages/ui/src/components/RadioGroup/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/Error.stories.tsx
@@ -10,6 +10,6 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription: 'Use the `error` prop to set an error content.',
+    description: { story: 'Use the `error` prop to set an error content.' },
   },
 }

--- a/packages/ui/src/components/RadioGroup/__stories__/Helper.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/Helper.stories.tsx
@@ -10,6 +10,6 @@ Helper.args = {
 
 Helper.parameters = {
   docs: {
-    storyDescription: 'Use the `helper` prop to set an helper content.',
+    description: { story: 'Use the `helper` prop to set an helper content.' },
   },
 }

--- a/packages/ui/src/components/Row/__stories__/AlignItems.stories.tsx
+++ b/packages/ui/src/components/Row/__stories__/AlignItems.stories.tsx
@@ -34,7 +34,8 @@ export const AlignItems: StoryFn = args => (
 
 AlignItems.parameters = {
   docs: {
-    storyDescription:
-      'You can use the prop `alignItems` to align each row elements',
+    description: {
+      story: 'You can use the prop `alignItems` to align each row elements',
+    },
   },
 }

--- a/packages/ui/src/components/Row/__stories__/Gap.stories.tsx
+++ b/packages/ui/src/components/Row/__stories__/Gap.stories.tsx
@@ -8,7 +8,9 @@ Gap.args = {
 
 Gap.parameters = {
   docs: {
-    storyDescription:
-      'You can use the prop `gap` to separate each element/column. `gap` is a theme space unit.',
+    description: {
+      story:
+        'You can use the prop `gap` to separate each element/column. `gap` is a theme space unit.',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Animated.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Animated.stories.tsx
@@ -46,7 +46,8 @@ export const Animated: StoryFn<typeof SelectInput> = ({ ...props }) => {
 
 Animated.parameters = {
   docs: {
-    storyDescription: `THis shows how to use \`animationOnChange\`, \`animation\` and \`animationDuration\` on SelectInput.
+    description: {
+      story: `This shows how to use \`animationOnChange\`, \`animation\` and \`animationDuration\` on SelectInput.
 The animation will be played when the value changes. Animation start when you select new value but also if you change the value of SelectInput with an external way (check example with button).
 
 #### Available animations
@@ -54,6 +55,7 @@ The animation will be played when the value changes. Animation start when you se
 ${Object.keys(animations)
   .map(animation => `\`${animation}\``)
   .join(' ')}`,
+    },
   },
 }
 

--- a/packages/ui/src/components/SelectInput/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Controlled.stories.tsx
@@ -30,6 +30,6 @@ export const Controlled: StoryFn<typeof SelectInput> = ({ ...props }) => {
 
 Controlled.parameters = {
   docs: {
-    storyDescription: 'This shows how to use Controlled SelectInput.',
+    description: { story: 'This shows how to use Controlled SelectInput.' },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/CustomOptions.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/CustomOptions.stories.tsx
@@ -22,6 +22,8 @@ CustomOptions.args = {
 }
 CustomOptions.parameters = {
   docs: {
-    storyDescription: 'This shows how to customize options in a SelectInput.',
+    description: {
+      story: 'This shows how to customize options in a SelectInput.',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Disabled.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Disabled.stories.tsx
@@ -13,6 +13,6 @@ Disabled.args = {
 }
 Disabled.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `disabled` on SelectInput.',
+    description: { story: 'This shows how to use `disabled` on SelectInput.' },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Group.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Group.stories.tsx
@@ -53,7 +53,9 @@ Group.decorators = [
 
 Group.parameters = {
   docs: {
-    storyDescription:
-      'By using the `options` prop you can regroup options by category/group (not possible when using JSX).',
+    description: {
+      story:
+        'By using the `options` prop you can regroup options by category/group (not possible when using JSX).',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/IsClearable.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/IsClearable.stories.tsx
@@ -13,6 +13,8 @@ IsClearable.args = {
 }
 IsClearable.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `isClearable` on SelectInput.',
+    description: {
+      story: 'This shows how to use `isClearable` on SelectInput.',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/KnownIssues.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/KnownIssues.stories.tsx
@@ -4,7 +4,8 @@ export const KnownIssues = Template.bind({})
 
 KnownIssues.parameters = {
   docs: {
-    storyDescription: `#### SelectInput doesn’t keep focus on selected option
+    description: {
+      story: `#### SelectInput doesn’t keep focus on selected option
 
 SelectInput is based on the \`react-select\` library. To keep the focus on the selected option you need to use \`options\` prop with a memoized value or a memoized \`children\`
 
@@ -12,5 +13,6 @@ SelectInput is based on the \`react-select\` library. To keep the focus on the s
 
 Use @ts-expect-error if needed.
 `,
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/LoadingDemo.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/LoadingDemo.stories.tsx
@@ -14,6 +14,6 @@ LoadingDemo.args = {
 }
 LoadingDemo.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `isLoading` on SelectInput',
+    description: { story: 'This shows how to use `isLoading` on SelectInput' },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Multi.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Multi.stories.tsx
@@ -16,6 +16,6 @@ Multi.args = {
 }
 Multi.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `isMulti`on SelectInput.',
+    description: { story: 'This shows how to use `isMulti`on SelectInput.' },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/MultiDisabled.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/MultiDisabled.stories.tsx
@@ -14,7 +14,8 @@ MultiDisabled.args = {
 }
 MultiDisabled.parameters = {
   docs: {
-    storyDescription:
-      'This shows how to use `disabled` on `isMulti` SelectInput.',
+    description: {
+      story: 'This shows how to use `disabled` on `isMulti` SelectInput.',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/NoLabel.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/NoLabel.stories.tsx
@@ -12,6 +12,8 @@ NoLabel.args = {
 }
 NoLabel.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `noTopLabel` in SelectInput.',
+    description: {
+      story: 'This shows how to use `noTopLabel` in SelectInput.',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/OptionDisabled.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/OptionDisabled.stories.tsx
@@ -13,6 +13,8 @@ OptionDisabled.args = {
 }
 OptionDisabled.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `disabled` on SelectInput.Option.',
+    description: {
+      story: 'This shows how to use `disabled` on SelectInput.Option.',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Required.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Required.stories.tsx
@@ -12,6 +12,6 @@ Required.args = {
 }
 Required.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `required` on SelectInput',
+    description: { story: 'This shows how to use `required` on SelectInput' },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Searchable.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Searchable.stories.tsx
@@ -12,6 +12,8 @@ Searchable.args = {
 }
 Searchable.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `isSearchable` on SelectInput.',
+    description: {
+      story: 'This shows how to use `isSearchable` on SelectInput.',
+    },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Time.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Time.stories.tsx
@@ -12,6 +12,6 @@ Time.args = {
 }
 Time.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `time` on SelectInput',
+    description: { story: 'This shows how to use `time` on SelectInput' },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/TimeError.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/TimeError.stories.tsx
@@ -13,6 +13,6 @@ TimeError.args = {
 }
 TimeError.parameters = {
   docs: {
-    storyDescription: 'This shows how to use `time-error` on SelectInput',
+    description: { story: 'This shows how to use `time-error` on SelectInput' },
   },
 }

--- a/packages/ui/src/components/SelectInput/__stories__/Uncontrolled.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/Uncontrolled.stories.tsx
@@ -12,6 +12,6 @@ Uncontrolled.args = {
 }
 Uncontrolled.parameters = {
   docs: {
-    storyDescription: 'This shows how to use Uncontrolled SelectInput.',
+    description: { story: 'This shows how to use Uncontrolled SelectInput.' },
   },
 }

--- a/packages/ui/src/components/SelectableCard/__stories__/Children.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/Children.stories.tsx
@@ -98,8 +98,10 @@ export const Children: StoryFn = args => {
 }
 Children.parameters = {
   docs: {
-    storyDescription:
-      'If your children is more than just a text you can use given function with parameters `checked` and `disabled` to customize you child style according to SelectableCard state.',
+    description: {
+      story:
+        'If your children is more than just a text you can use given function with parameters `checked` and `disabled` to customize you child style according to SelectableCard state.',
+    },
   },
 }
 Children.decorators = [

--- a/packages/ui/src/components/SelectableCard/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/Error.stories.tsx
@@ -35,8 +35,9 @@ export const Error: StoryFn = args => {
 
 Error.parameters = {
   docs: {
-    storyDescription:
-      'Use `isError` prop to display SelectableCard with a error style.',
+    description: {
+      story: 'Use `isError` prop to display SelectableCard with a error style.',
+    },
   },
 }
 

--- a/packages/ui/src/components/SelectableCard/__stories__/ShowTick.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/ShowTick.stories.tsx
@@ -63,8 +63,10 @@ export const ShowTick: StoryFn = args => {
 
 ShowTick.parameters = {
   docs: {
-    storyDescription:
-      'Depending on your need you may want to display radio or checkbox tick. It can easily be done by using prop `showTick`.',
+    description: {
+      story:
+        'Depending on your need you may want to display radio or checkbox tick. It can easily be done by using prop `showTick`.',
+    },
   },
 }
 ShowTick.decorators = [

--- a/packages/ui/src/components/SelectableCard/__stories__/Type.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/Type.stories.tsx
@@ -59,8 +59,10 @@ export const Type: StoryFn = args => {
 
 Type.parameters = {
   docs: {
-    storyDescription:
-      'Two types exists for this component, it can either be a checkbox or a radio.',
+    description: {
+      story:
+        'Two types exists for this component, it can either be a checkbox or a radio.',
+    },
   },
 }
 Type.decorators = [

--- a/packages/ui/src/components/Stack/__stories__/AlignItems.stories.tsx
+++ b/packages/ui/src/components/Stack/__stories__/AlignItems.stories.tsx
@@ -5,8 +5,10 @@ export const AlignItems = Template.bind({})
 
 AlignItems.parameters = {
   docs: {
-    storyDescription:
-      'The prop `alignItems` supports every value of css property `align-items`',
+    description: {
+      story:
+        'The prop `alignItems` supports every value of css property `align-items`',
+    },
   },
 }
 

--- a/packages/ui/src/components/Stack/__stories__/Direction.stories.tsx
+++ b/packages/ui/src/components/Stack/__stories__/Direction.stories.tsx
@@ -5,8 +5,10 @@ export const Direction = Template.bind({})
 
 Direction.parameters = {
   docs: {
-    storyDescription:
-      'prop `Direction` allows the stack to behave as a column [DEFAULT] or a row',
+    description: {
+      story:
+        'prop `Direction` allows the stack to behave as a column [DEFAULT] or a row',
+    },
   },
 }
 

--- a/packages/ui/src/components/Stack/__stories__/Gap.stories.tsx
+++ b/packages/ui/src/components/Stack/__stories__/Gap.stories.tsx
@@ -5,8 +5,10 @@ export const Gap = Template.bind({})
 
 Gap.parameters = {
   docs: {
-    storyDescription:
-      'prop `Gap` define the spacing between each child based on theme.space. Default value : 0/none',
+    description: {
+      story:
+        'prop `Gap` define the spacing between each child based on theme.space. Default value : 0/none',
+    },
   },
 }
 

--- a/packages/ui/src/components/Stack/__stories__/JustifyContent.stories.tsx
+++ b/packages/ui/src/components/Stack/__stories__/JustifyContent.stories.tsx
@@ -5,8 +5,10 @@ export const JustifyContent = Template.bind({})
 
 JustifyContent.parameters = {
   docs: {
-    storyDescription:
-      'prop `justifyContent` support every value of css property `justify-content`',
+    description: {
+      story:
+        'prop `justifyContent` support every value of css property `justify-content`',
+    },
   },
 }
 

--- a/packages/ui/src/components/Status/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/Status/__stories__/Sentiments.stories.tsx
@@ -12,7 +12,7 @@ export const Sentiments: StoryFn<typeof Menu> = props => (
 
 Sentiments.parameters = {
   docs: {
-    storyDescription: 'Set `sentiment` using sentiment property.',
+    description: { story: 'Set `sentiment` using sentiment property.' },
   },
 }
 

--- a/packages/ui/src/components/Status/__stories__/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Status/__stories__/Tooltip.stories.tsx
@@ -3,7 +3,7 @@ import { Template } from './Template.stories'
 export const Tooltip = Template.bind({})
 Tooltip.parameters = {
   docs: {
-    storyDescription: 'Add a `tooltip` using tooltip property',
+    description: { story: 'Add a `tooltip` using tooltip property' },
   },
 }
 Tooltip.args = {

--- a/packages/ui/src/components/Stepper/__stories__/WithAnimation.stories.tsx
+++ b/packages/ui/src/components/Stepper/__stories__/WithAnimation.stories.tsx
@@ -4,8 +4,9 @@ export const WithAnimation = Template.bind({})
 
 WithAnimation.parameters = {
   docs: {
-    storyDescription:
-      'Stepper Component with animation by passing `animated={true}` ',
+    description: {
+      story: 'Stepper Component with animation by passing `animated={true}` ',
+    },
   },
 }
 

--- a/packages/ui/src/components/Table/__stories__/ColumnWidth.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/ColumnWidth.stories.tsx
@@ -29,7 +29,9 @@ ColumnWidth.args = {
 
 ColumnWidth.parameters = {
   docs: {
-    storyDescription:
-      'Since Table is based on native HTML Table, column width will behave the same, however you can specify `width`, `minWidth` and/or `maxWidth` to a column, value are based on css value.',
+    description: {
+      story:
+        'Since Table is based on native HTML Table, column width will behave the same, however you can specify `width`, `minWidth` and/or `maxWidth` to a column, value are based on css value.',
+    },
   },
 }

--- a/packages/ui/src/components/Table/__stories__/Context.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/Context.stories.tsx
@@ -38,7 +38,8 @@ export const Context: StoryFn = args => {
 
 Context.parameters = {
   docs: {
-    storyDescription: `You can use \`Table.useTableContext\` to get this hydrated properties about the table:
+    description: {
+      story: `You can use \`Table.useTableContext\` to get this hydrated properties about the table:
 
 - selectedRowIds : [Object] Selected rows (key is row id, value is a boolean, true mean the related row is selected)
 - selectRow : [Function] select a row by providing its id
@@ -49,5 +50,6 @@ Context.parameters = {
   - \`false\` means no row is selected
   - \`true\` means all rows are selected
   - \`indeterminate\` means rows are partially selected`,
+    },
   },
 }

--- a/packages/ui/src/components/Table/__stories__/Loading.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/Loading.stories.tsx
@@ -9,7 +9,9 @@ Loading.args = {
 
 Loading.parameters = {
   docs: {
-    storyDescription:
-      'By adding the prop `loading` on the `Table`, 5 loading rows will be displayed instead of the provided children prop.',
+    description: {
+      story:
+        'By adding the prop `loading` on the `Table`, 5 loading rows will be displayed instead of the provided children prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Table/__stories__/Selectable.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/Selectable.stories.tsx
@@ -58,7 +58,9 @@ Selectable.args = {
 
 Selectable.parameters = {
   docs: {
-    storyDescription:
-      "By adding the prop `selectable` on the `Table` a new column will be automatically added to allow user to select a row, each row is identified by its prop `id`.\n\nYou can use the utility `Table.SelectBar` to quickly get selectedItems providing the `data` and the data's property key used to provite the `id` of each `Table.Row`.\n\nFor other usages about selected items, check our `Context` example.\n\nProviding the prop `selectDisabled` prevents the row to be selected (it can be a boolean or a string to give user a disable reason shown as a tooltip).",
+    description: {
+      story:
+        "By adding the prop `selectable` on the `Table` a new column will be automatically added to allow user to select a row, each row is identified by its prop `id`.\n\nYou can use the utility `Table.SelectBar` to quickly get selectedItems providing the `data` and the data's property key used to provite the `id` of each `Table.Row`.\n\nFor other usages about selected items, check our `Context` example.\n\nProviding the prop `selectDisabled` prevents the row to be selected (it can be a boolean or a string to give user a disable reason shown as a tooltip).",
+    },
   },
 }

--- a/packages/ui/src/components/Table/__stories__/Spanning.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/Spanning.stories.tsx
@@ -49,7 +49,9 @@ export const Spanning: StoryFn = args => (
 
 Spanning.parameters = {
   docs: {
-    storyDescription:
-      'You can use the html table `colSpan` and `rowSpan` property on a Cell.',
+    description: {
+      story:
+        'You can use the html table `colSpan` and `rowSpan` property on a Cell.',
+    },
   },
 }

--- a/packages/ui/src/components/Table/__stories__/Style.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/Style.stories.tsx
@@ -43,7 +43,9 @@ export const Style: StoryFn = args => (
 
 Style.parameters = {
   docs: {
-    storyDescription:
-      'You can customize the Table with two props `stripped` and `bordered`.',
+    description: {
+      story:
+        'You can customize the Table with two props `stripped` and `bordered`.',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/DisableResize.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/DisableResize.stories.tsx
@@ -10,7 +10,8 @@ DisableResize.args = {
 
 DisableResize.parameters = {
   docs: {
-    storyDescription:
-      'Disable resize in multiline mode using `resizable` prop.',
+    description: {
+      story: 'Disable resize in multiline mode using `resizable` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Disabled.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Disabled.stories.tsx
@@ -9,6 +9,8 @@ Disabled.args = {
 
 Disabled.parameters = {
   docs: {
-    storyDescription: 'Mark `TextInput` as disabled using `disabled` property.',
+    description: {
+      story: 'Mark `TextInput` as disabled using `disabled` property.',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Error.stories.tsx
@@ -9,6 +9,6 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription: 'Fill `TextInput` error using `error` property.',
+    description: { story: 'Fill `TextInput` error using `error` property.' },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/ForceEdit.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/ForceEdit.stories.tsx
@@ -9,7 +9,9 @@ ForceEdit.args = {
 
 ForceEdit.parameters = {
   docs: {
-    storyDescription:
-      'It is possible to force edit mode (label at the top) using `edit` property. The principal use-case is to be compatible with browser autocomplete.',
+    description: {
+      story:
+        'It is possible to force edit mode (label at the top) using `edit` property. The principal use-case is to be compatible with browser autocomplete.',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Multiline.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Multiline.stories.tsx
@@ -9,6 +9,6 @@ Multiline.args = {
 
 Multiline.parameters = {
   docs: {
-    storyDescription: 'Enable multiline mode using `multiline` property.',
+    description: { story: 'Enable multiline mode using `multiline` property.' },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/NoLabel.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/NoLabel.stories.tsx
@@ -10,7 +10,9 @@ NoLabel.args = {
 
 NoLabel.parameters = {
   docs: {
-    storyDescription:
-      'You can hide the label and but it in `aria-label` attribute of the input by passing `noTopLabel` to the component',
+    description: {
+      story:
+        'You can hide the label and but it in `aria-label` attribute of the input by passing `noTopLabel` to the component',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Notice.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Notice.stories.tsx
@@ -9,7 +9,9 @@ Notice.args = {
 
 Notice.parameters = {
   docs: {
-    storyDescription:
-      'Display an information under `TextInput` using `notice` property.',
+    description: {
+      story:
+        'Display an information under `TextInput` using `notice` property.',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Placeholder.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Placeholder.stories.tsx
@@ -9,7 +9,9 @@ Placeholder.args = {
 
 Placeholder.parameters = {
   docs: {
-    storyDescription:
-      'Set a placeholder using `placeholder` property. It is only visible if the `TextInput` has been visited (an input is considered as visited after the first focus).',
+    description: {
+      story:
+        'Set a placeholder using `placeholder` property. It is only visible if the `TextInput` has been visited (an input is considered as visited after the first focus).',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Randomize.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Randomize.stories.tsx
@@ -9,6 +9,6 @@ Randomize.args = {
 
 Randomize.parameters = {
   docs: {
-    storyDescription: 'Set `random` prop adds a randomize button.',
+    description: { story: 'Set `random` prop adds a randomize button.' },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/ReadOnly.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/ReadOnly.stories.tsx
@@ -10,7 +10,8 @@ ReadOnly.args = {
 
 ReadOnly.parameters = {
   docs: {
-    storyDescription:
-      'Mark `TextInput` as read only using `readOnly` property.',
+    description: {
+      story: 'Mark `TextInput` as read only using `readOnly` property.',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Required.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Required.stories.tsx
@@ -9,6 +9,6 @@ Required.args = {
 
 Required.parameters = {
   docs: {
-    storyDescription: 'Add a required mark using `required` property.',
+    description: { story: 'Add a required mark using `required` property.' },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Sizes.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Sizes.stories.tsx
@@ -17,7 +17,7 @@ export const Sizes: StoryFn = props => (
 
 Sizes.parameters = {
   docs: {
-    storyDescription: 'Set size using `size` property.',
+    description: { story: 'Set size using `size` property.' },
   },
 }
 

--- a/packages/ui/src/components/TextInput/__stories__/TabIndex.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/TabIndex.stories.tsx
@@ -9,6 +9,8 @@ TabIndex.args = {
 
 TabIndex.parameters = {
   docs: {
-    storyDescription: 'Can disable tabulation on field with `tabIndex="-1"`',
+    description: {
+      story: 'Can disable tabulation on field with `tabIndex="-1"`',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/ToggleablePassword.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/ToggleablePassword.stories.tsx
@@ -10,7 +10,9 @@ ToggleablePassword.args = {
 
 ToggleablePassword.parameters = {
   docs: {
-    storyDescription:
-      'Set type to `toggleable-password` adds a eye toggle to display typed password **This behaviour is dangerous, use it only when the user fills a new password.**',
+    description: {
+      story:
+        'Set type to `toggleable-password` adds a eye toggle to display typed password **This behaviour is dangerous, use it only when the user fills a new password.**',
+    },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Unit.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Unit.stories.tsx
@@ -10,6 +10,6 @@ Unit.args = {
 
 Unit.parameters = {
   docs: {
-    storyDescription: 'Specify a unit using `unit` prop.',
+    description: { story: 'Specify a unit using `unit` prop.' },
   },
 }

--- a/packages/ui/src/components/TextInput/__stories__/Valid.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/Valid.stories.tsx
@@ -9,6 +9,6 @@ Valid.args = {
 
 Valid.parameters = {
   docs: {
-    storyDescription: 'Add a check mark using `valid` property.',
+    description: { story: 'Add a check mark using `valid` property.' },
   },
 }

--- a/packages/ui/src/components/TimeInput/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/Controlled.stories.tsx
@@ -27,7 +27,9 @@ export const Controlled: StoryFn = ({ value: defaultValue = DEFAULT_VAL }) => {
 
 Controlled.parameters = {
   docs: {
-    storyDescription:
-      'Most of the time, you need a [controlled component](https://reactjs.org/docs/forms.html).',
+    description: {
+      story:
+        'Most of the time, you need a [controlled component](https://reactjs.org/docs/forms.html).',
+    },
   },
 }

--- a/packages/ui/src/components/TimeInput/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/Error.stories.tsx
@@ -9,6 +9,6 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription: 'Fill `TimeInput` error using `error` property.',
+    description: { story: 'Fill `TimeInput` error using `error` property.' },
   },
 }

--- a/packages/ui/src/components/TimeInput/__stories__/Required.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/Required.stories.tsx
@@ -8,6 +8,6 @@ Required.args = {
 
 Required.parameters = {
   docs: {
-    storyDescription: 'Add a required mark using `required` property.',
+    description: { story: 'Add a required mark using `required` property.' },
   },
 }

--- a/packages/ui/src/components/TimeInput/__stories__/Schedule.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/Schedule.stories.tsx
@@ -17,8 +17,10 @@ export const Schedule: StoryFn = props => (
 
 Schedule.parameters = {
   docs: {
-    storyDescription:
-      'You can adjust the time between options with the `schedule` props. `hours`, `half` and `quarter` are available. By default, the `hours` option is selected.',
+    description: {
+      story:
+        'You can adjust the time between options with the `schedule` props. `hours`, `half` and `quarter` are available. By default, the `hours` option is selected.',
+    },
   },
 }
 

--- a/packages/ui/src/components/Toggle/__stories__/ComplexLabel.stories.tsx
+++ b/packages/ui/src/components/Toggle/__stories__/ComplexLabel.stories.tsx
@@ -25,7 +25,9 @@ ComplexLabel.args = {
 
 ComplexLabel.parameters = {
   docs: {
-    storyDescription:
-      'Toggle can accept a more complex label than just a text, it allows your to customize even more the look of the toggle.',
+    description: {
+      story:
+        'Toggle can accept a more complex label than just a text, it allows your to customize even more the look of the toggle.',
+    },
   },
 }

--- a/packages/ui/src/components/Toggle/__stories__/Helper.stories.tsx
+++ b/packages/ui/src/components/Toggle/__stories__/Helper.stories.tsx
@@ -8,6 +8,6 @@ Helper.args = {
 
 Helper.parameters = {
   docs: {
-    storyDescription: 'Add an helper text using helper property.',
+    description: { story: 'Add an helper text using helper property.' },
   },
 }

--- a/packages/ui/src/components/Toggle/__stories__/LabelPosition.stories.tsx
+++ b/packages/ui/src/components/Toggle/__stories__/LabelPosition.stories.tsx
@@ -10,7 +10,9 @@ LabelPosition.args = {
 
 LabelPosition.parameters = {
   docs: {
-    storyDescription:
-      'Easily change the position of the label by passing `labelPosition` prop.',
+    description: {
+      story:
+        'Easily change the position of the label by passing `labelPosition` prop.',
+    },
   },
 }

--- a/packages/ui/src/components/Toggle/__stories__/Sizes.stories.tsx
+++ b/packages/ui/src/components/Toggle/__stories__/Sizes.stories.tsx
@@ -18,7 +18,9 @@ export const Sizes: StoryFn = props => (
 
 Sizes.parameters = {
   docs: {
-    storyDescription: 'You can define size of a Toggle using `size` property.',
+    description: {
+      story: 'You can define size of a Toggle using `size` property.',
+    },
   },
 }
 

--- a/packages/ui/src/components/ToggleGroup/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/__stories__/Controlled.stories.tsx
@@ -38,7 +38,9 @@ export const Controlled: StoryFn = args => {
 
 Controlled.parameters = {
   docs: {
-    storyDescription:
-      'ToggleGroup only work as a controlled component. You need to pass `onChange` callback to control it.',
+    description: {
+      story:
+        'ToggleGroup only work as a controlled component. You need to pass `onChange` callback to control it.',
+    },
   },
 }

--- a/packages/ui/src/components/ToggleGroup/__stories__/Direction.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/__stories__/Direction.stories.tsx
@@ -8,7 +8,8 @@ Direction.args = {
 
 Direction.parameters = {
   docs: {
-    storyDescription:
-      'Use the `direction` prop to change the direction of the group.',
+    description: {
+      story: 'Use the `direction` prop to change the direction of the group.',
+    },
   },
 }

--- a/packages/ui/src/components/ToggleGroup/__stories__/Errors.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/__stories__/Errors.stories.tsx
@@ -9,6 +9,6 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription: 'Use the `error` prop to set an error content.',
+    description: { story: 'Use the `error` prop to set an error content.' },
   },
 }

--- a/packages/ui/src/components/ToggleGroup/__stories__/Helper.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/__stories__/Helper.stories.tsx
@@ -8,6 +8,6 @@ Helper.args = {
 
 Helper.parameters = {
   docs: {
-    storyDescription: 'Use the `helper` prop to set an helper content.',
+    description: { story: 'Use the `helper` prop to set an helper content.' },
   },
 }

--- a/packages/ui/src/components/ToggleGroup/__stories__/Required.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/__stories__/Required.stories.tsx
@@ -8,7 +8,8 @@ Required.args = {
 
 Required.parameters = {
   docs: {
-    storyDescription:
-      'Use the `Required` prop to change the Required of the group.',
+    description: {
+      story: 'Use the `Required` prop to change the Required of the group.',
+    },
   },
 }

--- a/packages/ui/src/components/VerificationCode/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/Error.stories.tsx
@@ -7,7 +7,9 @@ Error.args = {
 
 Error.parameters = {
   docs: {
-    storyDescription:
-      'You can use `error` prop to indicate an error with the current value',
+    description: {
+      story:
+        'You can use `error` prop to indicate an error with the current value',
+    },
   },
 }

--- a/packages/ui/src/components/VerificationCode/__stories__/Fields.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/Fields.stories.tsx
@@ -7,7 +7,9 @@ Fields.args = {
 
 Fields.parameters = {
   docs: {
-    storyDescription:
-      'use `fields` prop to set the amount of field case you want to have',
+    description: {
+      story:
+        'use `fields` prop to set the amount of field case you want to have',
+    },
   },
 }

--- a/packages/ui/src/components/VerificationCode/__stories__/InitialValue.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/InitialValue.stories.tsx
@@ -7,7 +7,9 @@ InitialValue.args = {
 
 InitialValue.parameters = {
   docs: {
-    storyDescription:
-      'use `initialValue` prop to set the initial value of a VerificationCode component',
+    description: {
+      story:
+        'use `initialValue` prop to set the initial value of a VerificationCode component',
+    },
   },
 }

--- a/packages/ui/src/components/VerificationCode/__stories__/OnComplete.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/OnComplete.stories.tsx
@@ -11,7 +11,9 @@ export const OnComplete: StoryFn<typeof VerificationCode> = args => {
 
 OnComplete.parameters = {
   docs: {
-    storyDescription:
-      'You can use `onComplete` prop to react on a completed code typing',
+    description: {
+      story:
+        'You can use `onComplete` prop to react on a completed code typing',
+    },
   },
 }

--- a/packages/ui/src/components/VerificationCode/__stories__/Placeholder.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/Placeholder.stories.tsx
@@ -7,7 +7,9 @@ Placeholder.args = {
 
 Placeholder.parameters = {
   docs: {
-    storyDescription:
-      'use `placeholder` prop to set the placeholder of a VerificationCode component',
+    description: {
+      story:
+        'use `placeholder` prop to set the placeholder of a VerificationCode component',
+    },
   },
 }

--- a/packages/ui/src/components/VerificationCode/__stories__/Type.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/Type.stories.tsx
@@ -7,6 +7,6 @@ Type.args = {
 
 Type.parameters = {
   docs: {
-    storyDescription: 'use `type` prop to allow letter',
+    description: { story: 'use `type` prop to allow letter' },
   },
 }


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

The description in each stories is not working properly due to new format from Storybook V7:
> In 5.3 you customized a story description with the docs.storyDescription parameter. This has been deprecated, and support will be removed in 7.0.
>
> Source: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#70-breaking-changes

```ts
// Old
MyComponent.parameters = {
  docs: {
    storyDescription: 'My component description'
  },
}

// New
MyComponent.parameters = {
  docs: {
    description: {
      story: `My component description`,
    },
  },
}
```
