### PR TITLE
fix(ProductIcon): color not correctly applied on some icons

### DIFF
--- a/.changeset/green-toes-reflect.md
+++ b/.changeset/green-toes-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/icons': patch
+---
+
+Fix component `<ProductIcon />` on color applied

--- a/packages/icons/src/components/ProductIcon/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/icons/src/components/ProductIcon/__tests__/__snapshots__/index.tsx.snap
@@ -2,26 +2,32 @@
 
 exports[`ProductIcon should work with all names should work with abuse 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -65,26 +71,32 @@ exports[`ProductIcon should work with all names should work with abuse 1`] = `
 
 exports[`ProductIcon should work with all names should work with advancedSettings 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -128,26 +140,32 @@ exports[`ProductIcon should work with all names should work with advancedSetting
 
 exports[`ProductIcon should work with all names should work with apiGateway 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -191,26 +209,32 @@ exports[`ProductIcon should work with all names should work with apiGateway 1`] 
 
 exports[`ProductIcon should work with all names should work with appleSilicon 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -254,26 +278,32 @@ exports[`ProductIcon should work with all names should work with appleSilicon 1`
 
 exports[`ProductIcon should work with all names should work with application 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -317,26 +347,32 @@ exports[`ProductIcon should work with all names should work with application 1`]
 
 exports[`ProductIcon should work with all names should work with applicationLibrary 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -380,26 +416,32 @@ exports[`ProductIcon should work with all names should work with applicationLibr
 
 exports[`ProductIcon should work with all names should work with backends 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -443,26 +485,32 @@ exports[`ProductIcon should work with all names should work with backends 1`] = 
 
 exports[`ProductIcon should work with all names should work with basicSupport 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -506,26 +554,32 @@ exports[`ProductIcon should work with all names should work with basicSupport 1`
 
 exports[`ProductIcon should work with all names should work with billing 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -569,26 +623,32 @@ exports[`ProductIcon should work with all names should work with billing 1`] = `
 
 exports[`ProductIcon should work with all names should work with blockStorage 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -632,26 +692,32 @@ exports[`ProductIcon should work with all names should work with blockStorage 1`
 
 exports[`ProductIcon should work with all names should work with cb 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -695,26 +761,32 @@ exports[`ProductIcon should work with all names should work with cb 1`] = `
 
 exports[`ProductIcon should work with all names should work with cdn 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -758,26 +830,32 @@ exports[`ProductIcon should work with all names should work with cdn 1`] = `
 
 exports[`ProductIcon should work with all names should work with changelog 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -821,26 +899,32 @@ exports[`ProductIcon should work with all names should work with changelog 1`] =
 
 exports[`ProductIcon should work with all names should work with cli 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -884,26 +968,32 @@ exports[`ProductIcon should work with all names should work with cli 1`] = `
 
 exports[`ProductIcon should work with all names should work with cockpit 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -947,26 +1037,32 @@ exports[`ProductIcon should work with all names should work with cockpit 1`] = `
 
 exports[`ProductIcon should work with all names should work with console 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1010,26 +1106,32 @@ exports[`ProductIcon should work with all names should work with console 1`] = `
 
 exports[`ProductIcon should work with all names should work with containers 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1073,26 +1175,32 @@ exports[`ProductIcon should work with all names should work with containers 1`] 
 
 exports[`ProductIcon should work with all names should work with dedibox 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1136,26 +1244,32 @@ exports[`ProductIcon should work with all names should work with dedibox 1`] = `
 
 exports[`ProductIcon should work with all names should work with dedicatedServer 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1199,26 +1313,32 @@ exports[`ProductIcon should work with all names should work with dedicatedServer
 
 exports[`ProductIcon should work with all names should work with devices 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1262,26 +1382,32 @@ exports[`ProductIcon should work with all names should work with devices 1`] = `
 
 exports[`ProductIcon should work with all names should work with directConnect 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1325,26 +1451,32 @@ exports[`ProductIcon should work with all names should work with directConnect 1
 
 exports[`ProductIcon should work with all names should work with dns 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1388,26 +1520,32 @@ exports[`ProductIcon should work with all names should work with dns 1`] = `
 
 exports[`ProductIcon should work with all names should work with documentDB 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1451,26 +1589,32 @@ exports[`ProductIcon should work with all names should work with documentDB 1`] 
 
 exports[`ProductIcon should work with all names should work with documentation 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1514,26 +1658,32 @@ exports[`ProductIcon should work with all names should work with documentation 1
 
 exports[`ProductIcon should work with all names should work with domains 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1577,26 +1727,32 @@ exports[`ProductIcon should work with all names should work with domains 1`] = `
 
 exports[`ProductIcon should work with all names should work with elasticMetal 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1640,26 +1796,32 @@ exports[`ProductIcon should work with all names should work with elasticMetal 1`
 
 exports[`ProductIcon should work with all names should work with file 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1703,26 +1865,32 @@ exports[`ProductIcon should work with all names should work with file 1`] = `
 
 exports[`ProductIcon should work with all names should work with flexibleIp 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1766,26 +1934,32 @@ exports[`ProductIcon should work with all names should work with flexibleIp 1`] 
 
 exports[`ProductIcon should work with all names should work with folder 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1829,26 +2003,32 @@ exports[`ProductIcon should work with all names should work with folder 1`] = `
 
 exports[`ProductIcon should work with all names should work with frontends 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1892,26 +2072,32 @@ exports[`ProductIcon should work with all names should work with frontends 1`] =
 
 exports[`ProductIcon should work with all names should work with functions 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -1955,26 +2141,32 @@ exports[`ProductIcon should work with all names should work with functions 1`] =
 
 exports[`ProductIcon should work with all names should work with goldSupport 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2018,26 +2210,32 @@ exports[`ProductIcon should work with all names should work with goldSupport 1`]
 
 exports[`ProductIcon should work with all names should work with hubNetworks 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2081,26 +2279,32 @@ exports[`ProductIcon should work with all names should work with hubNetworks 1`]
 
 exports[`ProductIcon should work with all names should work with hubRoutes 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2144,26 +2348,32 @@ exports[`ProductIcon should work with all names should work with hubRoutes 1`] =
 
 exports[`ProductIcon should work with all names should work with iam 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2207,26 +2417,32 @@ exports[`ProductIcon should work with all names should work with iam 1`] = `
 
 exports[`ProductIcon should work with all names should work with images 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2270,26 +2486,32 @@ exports[`ProductIcon should work with all names should work with images 1`] = `
 
 exports[`ProductIcon should work with all names should work with instance 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2333,26 +2555,32 @@ exports[`ProductIcon should work with all names should work with instance 1`] = 
 
 exports[`ProductIcon should work with all names should work with instanceEnterprise 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2396,26 +2624,32 @@ exports[`ProductIcon should work with all names should work with instanceEnterpr
 
 exports[`ProductIcon should work with all names should work with instanceGpu 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2459,26 +2693,32 @@ exports[`ProductIcon should work with all names should work with instanceGpu 1`]
 
 exports[`ProductIcon should work with all names should work with iot 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2522,26 +2762,32 @@ exports[`ProductIcon should work with all names should work with iot 1`] = `
 
 exports[`ProductIcon should work with all names should work with iotEdge 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2585,26 +2831,32 @@ exports[`ProductIcon should work with all names should work with iotEdge 1`] = `
 
 exports[`ProductIcon should work with all names should work with ipFailover 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2648,26 +2900,32 @@ exports[`ProductIcon should work with all names should work with ipFailover 1`] 
 
 exports[`ProductIcon should work with all names should work with ipfs 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2711,26 +2969,32 @@ exports[`ProductIcon should work with all names should work with ipfs 1`] = `
 
 exports[`ProductIcon should work with all names should work with ipfsNaming 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2774,26 +3038,32 @@ exports[`ProductIcon should work with all names should work with ipfsNaming 1`] 
 
 exports[`ProductIcon should work with all names should work with k8sKosmos 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2837,26 +3107,32 @@ exports[`ProductIcon should work with all names should work with k8sKosmos 1`] =
 
 exports[`ProductIcon should work with all names should work with kubernetes 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2900,26 +3176,32 @@ exports[`ProductIcon should work with all names should work with kubernetes 1`] 
 
 exports[`ProductIcon should work with all names should work with lb 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -2963,26 +3245,32 @@ exports[`ProductIcon should work with all names should work with lb 1`] = `
 
 exports[`ProductIcon should work with all names should work with lifeCycleRules 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3026,26 +3314,32 @@ exports[`ProductIcon should work with all names should work with lifeCycleRules 
 
 exports[`ProductIcon should work with all names should work with macMiniM2 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3089,26 +3383,32 @@ exports[`ProductIcon should work with all names should work with macMiniM2 1`] =
 
 exports[`ProductIcon should work with all names should work with multiUser 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3152,26 +3452,32 @@ exports[`ProductIcon should work with all names should work with multiUser 1`] =
 
 exports[`ProductIcon should work with all names should work with nats 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3215,26 +3521,32 @@ exports[`ProductIcon should work with all names should work with nats 1`] = `
 
 exports[`ProductIcon should work with all names should work with objectStorage 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3278,26 +3590,32 @@ exports[`ProductIcon should work with all names should work with objectStorage 1
 
 exports[`ProductIcon should work with all names should work with packer 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3341,26 +3659,32 @@ exports[`ProductIcon should work with all names should work with packer 1`] = `
 
 exports[`ProductIcon should work with all names should work with placementGroup 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3404,26 +3728,32 @@ exports[`ProductIcon should work with all names should work with placementGroup 
 
 exports[`ProductIcon should work with all names should work with platinumSupport 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3467,26 +3797,32 @@ exports[`ProductIcon should work with all names should work with platinumSupport
 
 exports[`ProductIcon should work with all names should work with policy 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3530,26 +3866,32 @@ exports[`ProductIcon should work with all names should work with policy 1`] = `
 
 exports[`ProductIcon should work with all names should work with pool 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3593,26 +3935,32 @@ exports[`ProductIcon should work with all names should work with pool 1`] = `
 
 exports[`ProductIcon should work with all names should work with postgreSqlAndMySql 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3656,26 +4004,32 @@ exports[`ProductIcon should work with all names should work with postgreSqlAndMy
 
 exports[`ProductIcon should work with all names should work with privateNetwork 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3719,26 +4073,32 @@ exports[`ProductIcon should work with all names should work with privateNetwork 
 
 exports[`ProductIcon should work with all names should work with publicGateway 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3782,26 +4142,32 @@ exports[`ProductIcon should work with all names should work with publicGateway 1
 
 exports[`ProductIcon should work with all names should work with queueing 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3845,26 +4211,32 @@ exports[`ProductIcon should work with all names should work with queueing 1`] = 
 
 exports[`ProductIcon should work with all names should work with rabbitMQ 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3908,26 +4280,32 @@ exports[`ProductIcon should work with all names should work with rabbitMQ 1`] = 
 
 exports[`ProductIcon should work with all names should work with rdb 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -3971,26 +4349,32 @@ exports[`ProductIcon should work with all names should work with rdb 1`] = `
 
 exports[`ProductIcon should work with all names should work with redis 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4034,26 +4418,32 @@ exports[`ProductIcon should work with all names should work with redis 1`] = `
 
 exports[`ProductIcon should work with all names should work with registry 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4097,26 +4487,32 @@ exports[`ProductIcon should work with all names should work with registry 1`] = 
 
 exports[`ProductIcon should work with all names should work with rocket 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4160,26 +4556,32 @@ exports[`ProductIcon should work with all names should work with rocket 1`] = `
 
 exports[`ProductIcon should work with all names should work with secretManager 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4223,26 +4625,32 @@ exports[`ProductIcon should work with all names should work with secretManager 1
 
 exports[`ProductIcon should work with all names should work with securityGroup 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4286,26 +4694,32 @@ exports[`ProductIcon should work with all names should work with securityGroup 1
 
 exports[`ProductIcon should work with all names should work with sepa 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4349,26 +4763,32 @@ exports[`ProductIcon should work with all names should work with sepa 1`] = `
 
 exports[`ProductIcon should work with all names should work with server 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4412,26 +4832,32 @@ exports[`ProductIcon should work with all names should work with server 1`] = `
 
 exports[`ProductIcon should work with all names should work with serverlessDB 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4475,26 +4901,32 @@ exports[`ProductIcon should work with all names should work with serverlessDB 1`
 
 exports[`ProductIcon should work with all names should work with serverlessJobs 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4538,26 +4970,32 @@ exports[`ProductIcon should work with all names should work with serverlessJobs 
 
 exports[`ProductIcon should work with all names should work with silverSupport 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4601,26 +5039,32 @@ exports[`ProductIcon should work with all names should work with silverSupport 1
 
 exports[`ProductIcon should work with all names should work with sms 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4664,26 +5108,32 @@ exports[`ProductIcon should work with all names should work with sms 1`] = `
 
 exports[`ProductIcon should work with all names should work with smtp 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4727,26 +5177,32 @@ exports[`ProductIcon should work with all names should work with smtp 1`] = `
 
 exports[`ProductIcon should work with all names should work with snapshots 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4790,26 +5246,32 @@ exports[`ProductIcon should work with all names should work with snapshots 1`] =
 
 exports[`ProductIcon should work with all names should work with sns 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4853,26 +5315,32 @@ exports[`ProductIcon should work with all names should work with sns 1`] = `
 
 exports[`ProductIcon should work with all names should work with sqs 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4916,26 +5384,32 @@ exports[`ProductIcon should work with all names should work with sqs 1`] = `
 
 exports[`ProductIcon should work with all names should work with sslCertificates 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -4979,26 +5453,32 @@ exports[`ProductIcon should work with all names should work with sslCertificates
 
 exports[`ProductIcon should work with all names should work with support 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5042,26 +5522,32 @@ exports[`ProductIcon should work with all names should work with support 1`] = `
 
 exports[`ProductIcon should work with all names should work with terraform 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5105,26 +5591,32 @@ exports[`ProductIcon should work with all names should work with terraform 1`] =
 
 exports[`ProductIcon should work with all names should work with transactionalEmail 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5168,26 +5660,32 @@ exports[`ProductIcon should work with all names should work with transactionalEm
 
 exports[`ProductIcon should work with all names should work with tutorial 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5231,26 +5729,32 @@ exports[`ProductIcon should work with all names should work with tutorial 1`] = 
 
 exports[`ProductIcon should work with all names should work with user 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5294,26 +5798,32 @@ exports[`ProductIcon should work with all names should work with user 1`] = `
 
 exports[`ProductIcon should work with all names should work with verifyCard 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5357,26 +5867,32 @@ exports[`ProductIcon should work with all names should work with verifyCard 1`] 
 
 exports[`ProductIcon should work with all names should work with video 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5420,26 +5936,32 @@ exports[`ProductIcon should work with all names should work with video 1`] = `
 
 exports[`ProductIcon should work with all names should work with volume 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5483,26 +6005,32 @@ exports[`ProductIcon should work with all names should work with volume 1`] = `
 
 exports[`ProductIcon should work with all names should work with vpc 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5546,26 +6074,32 @@ exports[`ProductIcon should work with all names should work with vpc 1`] = `
 
 exports[`ProductIcon should work with all names should work with webhosting 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5609,26 +6143,32 @@ exports[`ProductIcon should work with all names should work with webhosting 1`] 
 
 exports[`ProductIcon should work with all names should work with zone 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5672,26 +6212,32 @@ exports[`ProductIcon should work with all names should work with zone 1`] = `
 
 exports[`ProductIcon should work with all sizes should work with large 1`] = `
 <DocumentFragment>
-  .cache-a9amwn-StyledIcon {
+  .cache-1cn9fyi-StyledIcon {
   width: 48px;
   min-width: 48px;
   height: 48px;
 }
 
-.cache-a9amwn-StyledIcon path[fill].fill {
+.cache-1cn9fyi-StyledIcon path[fill].fill,
+.cache-1cn9fyi-StyledIcon g[fill].fill>*,
+.cache-1cn9fyi-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-a9amwn-StyledIcon path[fill].fillStrong {
+.cache-1cn9fyi-StyledIcon path[fill].fillStrong,
+.cache-1cn9fyi-StyledIcon g[fill].fillStrong>*,
+.cache-1cn9fyi-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-a9amwn-StyledIcon path[fill].fillWeak {
+.cache-1cn9fyi-StyledIcon path[fill].fillWeak,
+.cache-1cn9fyi-StyledIcon g[fill].fillWeak>*,
+.cache-1cn9fyi-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-a9amwn-StyledIcon euby9wl0"
+    class="cache-1cn9fyi-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5735,26 +6281,32 @@ exports[`ProductIcon should work with all sizes should work with large 1`] = `
 
 exports[`ProductIcon should work with all sizes should work with medium 1`] = `
 <DocumentFragment>
-  .cache-789o5t-StyledIcon {
+  .cache-7ewfw6-StyledIcon {
   width: 40px;
   min-width: 40px;
   height: 40px;
 }
 
-.cache-789o5t-StyledIcon path[fill].fill {
+.cache-7ewfw6-StyledIcon path[fill].fill,
+.cache-7ewfw6-StyledIcon g[fill].fill>*,
+.cache-7ewfw6-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-789o5t-StyledIcon path[fill].fillStrong {
+.cache-7ewfw6-StyledIcon path[fill].fillStrong,
+.cache-7ewfw6-StyledIcon g[fill].fillStrong>*,
+.cache-7ewfw6-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-789o5t-StyledIcon path[fill].fillWeak {
+.cache-7ewfw6-StyledIcon path[fill].fillWeak,
+.cache-7ewfw6-StyledIcon g[fill].fillWeak>*,
+.cache-7ewfw6-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-789o5t-StyledIcon euby9wl0"
+    class="cache-7ewfw6-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5798,26 +6350,32 @@ exports[`ProductIcon should work with all sizes should work with medium 1`] = `
 
 exports[`ProductIcon should work with all sizes should work with small 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5861,26 +6419,32 @@ exports[`ProductIcon should work with all sizes should work with small 1`] = `
 
 exports[`ProductIcon should work with all sizes should work with xlarge 1`] = `
 <DocumentFragment>
-  .cache-14l1rlw-StyledIcon {
+  .cache-hy5q6k-StyledIcon {
   width: 64px;
   min-width: 64px;
   height: 64px;
 }
 
-.cache-14l1rlw-StyledIcon path[fill].fill {
+.cache-hy5q6k-StyledIcon path[fill].fill,
+.cache-hy5q6k-StyledIcon g[fill].fill>*,
+.cache-hy5q6k-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-14l1rlw-StyledIcon path[fill].fillStrong {
+.cache-hy5q6k-StyledIcon path[fill].fillStrong,
+.cache-hy5q6k-StyledIcon g[fill].fillStrong>*,
+.cache-hy5q6k-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-14l1rlw-StyledIcon path[fill].fillWeak {
+.cache-hy5q6k-StyledIcon path[fill].fillWeak,
+.cache-hy5q6k-StyledIcon g[fill].fillWeak>*,
+.cache-hy5q6k-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-14l1rlw-StyledIcon euby9wl0"
+    class="cache-hy5q6k-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5924,26 +6488,32 @@ exports[`ProductIcon should work with all sizes should work with xlarge 1`] = `
 
 exports[`ProductIcon should work with all variants should work with danger 1`] = `
 <DocumentFragment>
-  .cache-1cdgtpf-StyledIcon {
+  .cache-1a6tz7p-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-1cdgtpf-StyledIcon path[fill].fill {
+.cache-1a6tz7p-StyledIcon path[fill].fill,
+.cache-1a6tz7p-StyledIcon g[fill].fill>*,
+.cache-1a6tz7p-StyledIcon g.fill>* {
   fill: #ffebf2;
 }
 
-.cache-1cdgtpf-StyledIcon path[fill].fillStrong {
+.cache-1a6tz7p-StyledIcon path[fill].fillStrong,
+.cache-1a6tz7p-StyledIcon g[fill].fillStrong>*,
+.cache-1a6tz7p-StyledIcon g.fillStrong>* {
   fill: #ffebf2;
 }
 
-.cache-1cdgtpf-StyledIcon path[fill].fillWeak {
+.cache-1a6tz7p-StyledIcon path[fill].fillWeak,
+.cache-1a6tz7p-StyledIcon g[fill].fillWeak>*,
+.cache-1a6tz7p-StyledIcon g.fillWeak>* {
   fill: #e51963;
 }
 
 <svg
-    class="cache-1cdgtpf-StyledIcon euby9wl0"
+    class="cache-1a6tz7p-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -5987,26 +6557,32 @@ exports[`ProductIcon should work with all variants should work with danger 1`] =
 
 exports[`ProductIcon should work with all variants should work with primary 1`] = `
 <DocumentFragment>
-  .cache-17omgca-StyledIcon {
+  .cache-yif6bn-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-17omgca-StyledIcon path[fill].fill {
+.cache-yif6bn-StyledIcon path[fill].fill,
+.cache-yif6bn-StyledIcon g[fill].fill>*,
+.cache-yif6bn-StyledIcon g.fill>* {
   fill: #521094;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillStrong {
+.cache-yif6bn-StyledIcon path[fill].fillStrong,
+.cache-yif6bn-StyledIcon g[fill].fillStrong>*,
+.cache-yif6bn-StyledIcon g.fillStrong>* {
   fill: #a060f6;
 }
 
-.cache-17omgca-StyledIcon path[fill].fillWeak {
+.cache-yif6bn-StyledIcon path[fill].fillWeak,
+.cache-yif6bn-StyledIcon g[fill].fillWeak>*,
+.cache-yif6bn-StyledIcon g.fillWeak>* {
   fill: #f1eefc;
 }
 
 <svg
-    class="cache-17omgca-StyledIcon euby9wl0"
+    class="cache-yif6bn-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -6050,26 +6626,32 @@ exports[`ProductIcon should work with all variants should work with primary 1`] 
 
 exports[`ProductIcon should work with all variants should work with warning 1`] = `
 <DocumentFragment>
-  .cache-x0r4g8-StyledIcon {
+  .cache-1fvi5o-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-x0r4g8-StyledIcon path[fill].fill {
+.cache-1fvi5o-StyledIcon path[fill].fill,
+.cache-1fvi5o-StyledIcon g[fill].fill>*,
+.cache-1fvi5o-StyledIcon g.fill>* {
   fill: #7c5400;
 }
 
-.cache-x0r4g8-StyledIcon path[fill].fillStrong {
+.cache-1fvi5o-StyledIcon path[fill].fillStrong,
+.cache-1fvi5o-StyledIcon g[fill].fillStrong>*,
+.cache-1fvi5o-StyledIcon g.fillStrong>* {
   fill: #7c5400;
 }
 
-.cache-x0r4g8-StyledIcon path[fill].fillWeak {
+.cache-1fvi5o-StyledIcon path[fill].fillWeak,
+.cache-1fvi5o-StyledIcon g[fill].fillWeak>*,
+.cache-1fvi5o-StyledIcon g.fillWeak>* {
   fill: #fbc600;
 }
 
 <svg
-    class="cache-x0r4g8-StyledIcon euby9wl0"
+    class="cache-1fvi5o-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g
@@ -6113,26 +6695,32 @@ exports[`ProductIcon should work with all variants should work with warning 1`] 
 
 exports[`ProductIcon should work with disabled 1`] = `
 <DocumentFragment>
-  .cache-1b130b9-StyledIcon {
+  .cache-ovorz1-StyledIcon {
   width: 32px;
   min-width: 32px;
   height: 32px;
 }
 
-.cache-1b130b9-StyledIcon path[fill].fill {
+.cache-ovorz1-StyledIcon path[fill].fill,
+.cache-ovorz1-StyledIcon g[fill].fill>*,
+.cache-ovorz1-StyledIcon g.fill>* {
   fill: #d9dadd;
 }
 
-.cache-1b130b9-StyledIcon path[fill].fillStrong {
+.cache-ovorz1-StyledIcon path[fill].fillStrong,
+.cache-ovorz1-StyledIcon g[fill].fillStrong>*,
+.cache-ovorz1-StyledIcon g.fillStrong>* {
   fill: #d9dadd;
 }
 
-.cache-1b130b9-StyledIcon path[fill].fillWeak {
+.cache-ovorz1-StyledIcon path[fill].fillWeak,
+.cache-ovorz1-StyledIcon g[fill].fillWeak>*,
+.cache-ovorz1-StyledIcon g.fillWeak>* {
   fill: #f3f3f4;
 }
 
 <svg
-    class="cache-1b130b9-StyledIcon euby9wl0"
+    class="cache-ovorz1-StyledIcon euby9wl0"
     viewBox="0 0 64 64"
   >
     <g

--- a/packages/icons/src/components/ProductIcon/index.tsx
+++ b/packages/icons/src/components/ProductIcon/index.tsx
@@ -27,7 +27,9 @@ const StyledIcon = styled('svg', {
     height: ${({ size }) => `${SIZES[size]}px`};
   }
 
-  path[fill].fill {
+  path[fill].fill,
+  g[fill].fill > *,
+  g.fill > * {
     fill: ${({ theme, variant, disabled }) =>
       `${
         theme.colors.other.icon.product[variant][
@@ -36,7 +38,9 @@ const StyledIcon = styled('svg', {
       }`};
   }
 
-  path[fill].fillStrong {
+  path[fill].fillStrong,
+  g[fill].fillStrong > *,
+  g.fillStrong > * {
     fill: ${({ theme, variant, disabled }) =>
       `${
         theme.colors.other.icon.product[variant][
@@ -45,7 +49,9 @@ const StyledIcon = styled('svg', {
       }`};
   }
 
-  path[fill].fillWeak {
+  path[fill].fillWeak,
+  g[fill].fillWeak > *,
+  g.fillWeak > * {
     fill: ${({ theme, variant, disabled }) =>
       `${
         theme.colors.other.icon.product[variant][


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Some ProductIcon where not working properly because the className is applied on `<g />` and not on `<path />`. I fixed the CSS selector to apply the style on all children `<path />` when `<g />` has the className.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2023-10-13 at 11 03 49](https://github.com/scaleway/ultraviolet/assets/15812968/70327fdc-315a-4673-ba4f-4f8873188991) | ![Screenshot 2023-10-13 at 11 03 54](https://github.com/scaleway/ultraviolet/assets/15812968/fa059890-9c2a-444a-b58c-5bf898f05070) |
| url  | ![Screenshot 2023-10-13 at 11 04 06](https://github.com/scaleway/ultraviolet/assets/15812968/c46a9cc5-fcb3-402b-ba5d-bf49714500e0) | ![Screenshot 2023-10-13 at 11 04 12](https://github.com/scaleway/ultraviolet/assets/15812968/26dfe5d0-01dc-4237-bc8e-2342b1c8d138) |
| url  | ![Screenshot 2023-10-13 at 11 04 18](https://github.com/scaleway/ultraviolet/assets/15812968/8dfd329b-ce6f-4dd7-af17-410979d79bf2) | ![Screenshot 2023-10-13 at 11 04 22](https://github.com/scaleway/ultraviolet/assets/15812968/954d4601-224b-43af-b1fd-a4a9b81db064) |
