### PR TITLE
fix(Banner): alignement issue when description is too little

### DIFF
--- a/.changeset/popular-years-own.md
+++ b/.changeset/popular-years-own.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fix `<Banner />` to have content centered aligned

--- a/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
@@ -87,7 +87,7 @@ exports[`Banner renders correctly with a button 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ymc80m-Stack {
+.cache-1yytme-Stack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,10 +100,10 @@ exports[`Banner renders correctly with a button 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -290,7 +290,7 @@ exports[`Banner renders correctly with a button 1`] = `
       style="flex: 1;"
     >
       <div
-        class="cache-ymc80m-Stack ehpbis70"
+        class="cache-1yytme-Stack ehpbis70"
         style="flex: 1;"
       >
         <p
@@ -420,7 +420,7 @@ exports[`Banner renders correctly with a link 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ymc80m-Stack {
+.cache-1yytme-Stack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -433,10 +433,10 @@ exports[`Banner renders correctly with a link 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -660,7 +660,7 @@ exports[`Banner renders correctly with a link 1`] = `
       style="flex: 1;"
     >
       <div
-        class="cache-ymc80m-Stack ehpbis70"
+        class="cache-1yytme-Stack ehpbis70"
         style="flex: 1;"
       >
         <p
@@ -805,7 +805,7 @@ exports[`Banner renders correctly with an image 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ymc80m-Stack {
+.cache-1yytme-Stack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -818,10 +818,10 @@ exports[`Banner renders correctly with an image 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -954,7 +954,7 @@ exports[`Banner renders correctly with an image 1`] = `
       style="flex: 1;"
     >
       <div
-        class="cache-ymc80m-Stack ehpbis70"
+        class="cache-1yytme-Stack ehpbis70"
         style="flex: 1;"
       >
         <p
@@ -1077,7 +1077,7 @@ exports[`Banner renders correctly with default values 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ymc80m-Stack {
+.cache-1yytme-Stack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1090,10 +1090,10 @@ exports[`Banner renders correctly with default values 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1226,7 +1226,7 @@ exports[`Banner renders correctly with default values 1`] = `
       style="flex: 1;"
     >
       <div
-        class="cache-ymc80m-Stack ehpbis70"
+        class="cache-1yytme-Stack ehpbis70"
         style="flex: 1;"
       >
         <p
@@ -1349,7 +1349,7 @@ exports[`Banner renders correctly with direction row 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ymc80m-Stack {
+.cache-1yytme-Stack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1362,10 +1362,10 @@ exports[`Banner renders correctly with direction row 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1498,7 +1498,7 @@ exports[`Banner renders correctly with direction row 1`] = `
       style="flex: 1;"
     >
       <div
-        class="cache-ymc80m-Stack ehpbis70"
+        class="cache-1yytme-Stack ehpbis70"
         style="flex: 1;"
       >
         <p
@@ -1621,7 +1621,7 @@ exports[`Banner renders correctly with size small 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ymc80m-Stack {
+.cache-1yytme-Stack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1634,10 +1634,10 @@ exports[`Banner renders correctly with size small 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1770,7 +1770,7 @@ exports[`Banner renders correctly with size small 1`] = `
       style="flex: 1;"
     >
       <div
-        class="cache-ymc80m-Stack ehpbis70"
+        class="cache-1yytme-Stack ehpbis70"
         style="flex: 1;"
       >
         <p
@@ -1892,7 +1892,7 @@ exports[`Banner renders correctly with type promotional 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ymc80m-Stack {
+.cache-1yytme-Stack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1905,10 +1905,10 @@ exports[`Banner renders correctly with type promotional 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -2041,7 +2041,7 @@ exports[`Banner renders correctly with type promotional 1`] = `
       style="flex: 1;"
     >
       <div
-        class="cache-ymc80m-Stack ehpbis70"
+        class="cache-1yytme-Stack ehpbis70"
         style="flex: 1;"
       >
         <p

--- a/packages/ui/src/components/Banner/index.tsx
+++ b/packages/ui/src/components/Banner/index.tsx
@@ -160,7 +160,7 @@ export const Banner = ({
         alignItems={direction === 'column' ? 'start' : 'center'}
         style={{ flex: 1 }}
       >
-        <Stack gap={0.5} style={{ flex: 1 }}>
+        <Stack gap={0.5} style={{ flex: 1 }} justifyContent="center">
           <Text
             as="p"
             variant={size === 'medium' ? 'headingSmall' : 'bodyStronger'}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix banner to vertically align in center description and title when content is too little.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="976" alt="Screenshot 2023-10-17 at 15 20 22" src="https://github.com/scaleway/ultraviolet/assets/15812968/2651b3e6-77fc-43b2-a39e-80013a5be4a8"> | <img width="980" alt="Screenshot 2023-10-17 at 15 20 32" src="https://github.com/scaleway/ultraviolet/assets/15812968/aaaaed23-a90e-4ec1-9675-cf1d3cc341c8"> |
