### PR TITLE
fix(Popover): text to be correct color

### DIFF
--- a/.changeset/moody-items-lie.md
+++ b/.changeset/moody-items-lie.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/form': patch
+'@ultraviolet/ui': patch
+---
+
+Fix Popover component text to be correct color

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -73,6 +73,7 @@ const ContentWrapper = ({
         <Text
           variant="bodyStrong"
           as="h3"
+          sentiment="neutral"
           prominence={sentiment === 'neutral' ? 'strong' : 'stronger'}
         >
           {title}
@@ -91,6 +92,7 @@ const ContentWrapper = ({
         <Text
           variant="bodySmall"
           as="p"
+          sentiment="neutral"
           prominence={sentiment === 'neutral' ? 'strong' : 'stronger'}
         >
           {children}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Popover color was incorrect

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2023-10-18 at 11 37 48](https://github.com/scaleway/ultraviolet/assets/15812968/521515c8-e9ad-4fa5-9c19-3d1868b46d14) | ![Screenshot 2023-10-18 at 11 37 52](https://github.com/scaleway/ultraviolet/assets/15812968/b1cbb456-3b0b-4d2c-a0a2-4654d1ecdabd) |
