### PR TITLE
fix(TagInput): placeholder to take full width

### DIFF
--- a/.changeset/nervous-ways-cover.md
+++ b/.changeset/nervous-ways-cover.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/form': patch
+'@ultraviolet/ui': patch
+---
+
+Fix TagInput placeholder to take full width

--- a/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -31,7 +31,14 @@ exports[`ToggleField should render correctly 1`] = `
   margin: 6px;
 }
 
-.cache-1v1w13z {
+.cache-xmhmf {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -39,19 +46,19 @@ exports[`ToggleField should render correctly 1`] = `
   background-color: #ffffff;
 }
 
-.cache-1v1w13z::-webkit-input-placeholder {
+.cache-xmhmf::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::-moz-placeholder {
+.cache-xmhmf::-moz-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z:-ms-input-placeholder {
+.cache-xmhmf:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::placeholder {
+.cache-xmhmf::placeholder {
   color: #727683;
 }
 
@@ -63,7 +70,7 @@ exports[`ToggleField should render correctly 1`] = `
     >
       <input
         aria-label="test"
-        class="cache-1v1w13z ea7vc6o0"
+        class="cache-xmhmf ea7vc6o0"
         name="test"
         placeholder="placeholder"
         type="text"
@@ -252,7 +259,14 @@ exports[`ToggleField should render correctly with default tags 1`] = `
   min-height: 16px;
 }
 
-.cache-1v1w13z {
+.cache-xmhmf {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -260,19 +274,19 @@ exports[`ToggleField should render correctly with default tags 1`] = `
   background-color: #ffffff;
 }
 
-.cache-1v1w13z::-webkit-input-placeholder {
+.cache-xmhmf::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::-moz-placeholder {
+.cache-xmhmf::-moz-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z:-ms-input-placeholder {
+.cache-xmhmf:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::placeholder {
+.cache-xmhmf::placeholder {
   color: #727683;
 }
 
@@ -334,7 +348,7 @@ exports[`ToggleField should render correctly with default tags 1`] = `
       </span>
       <input
         aria-label="test-tags"
-        class="cache-1v1w13z ea7vc6o0"
+        class="cache-xmhmf ea7vc6o0"
         name="test-tags"
         placeholder=""
         type="text"
@@ -482,7 +496,14 @@ exports[`ToggleField should render correctly with default tags on initialValues 
   min-height: 16px;
 }
 
-.cache-1v1w13z {
+.cache-xmhmf {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -490,19 +511,19 @@ exports[`ToggleField should render correctly with default tags on initialValues 
   background-color: #ffffff;
 }
 
-.cache-1v1w13z::-webkit-input-placeholder {
+.cache-xmhmf::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::-moz-placeholder {
+.cache-xmhmf::-moz-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z:-ms-input-placeholder {
+.cache-xmhmf:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::placeholder {
+.cache-xmhmf::placeholder {
   color: #727683;
 }
 
@@ -564,7 +585,7 @@ exports[`ToggleField should render correctly with default tags on initialValues 
       </span>
       <input
         aria-label="formTags"
-        class="cache-1v1w13z ea7vc6o0"
+        class="cache-xmhmf ea7vc6o0"
         name="formTags"
         placeholder=""
         type="text"
@@ -712,7 +733,14 @@ exports[`ToggleField should render correctly with default tags on initialValues 
   min-height: 16px;
 }
 
-.cache-1v1w13z {
+.cache-xmhmf {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -720,19 +748,19 @@ exports[`ToggleField should render correctly with default tags on initialValues 
   background-color: #ffffff;
 }
 
-.cache-1v1w13z::-webkit-input-placeholder {
+.cache-xmhmf::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::-moz-placeholder {
+.cache-xmhmf::-moz-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z:-ms-input-placeholder {
+.cache-xmhmf:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-1v1w13z::placeholder {
+.cache-xmhmf::placeholder {
   color: #727683;
 }
 
@@ -819,7 +847,7 @@ exports[`ToggleField should render correctly with default tags on initialValues 
       </span>
       <input
         aria-label="formTags"
-        class="cache-1v1w13z ea7vc6o0"
+        class="cache-xmhmf ea7vc6o0"
         name="formTags"
         placeholder=""
         type="text"

--- a/packages/ui/src/components/TagInput/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/components/TagInput/__stories__/Playground.stories.tsx
@@ -4,4 +4,6 @@ export const Playground = Template.bind({})
 
 Playground.args = {
   tags: ['default'],
+  placeholder:
+    'This is a very long placeholder to see what happen when it is too long',
 }

--- a/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -137,7 +137,14 @@ exports[`TagInput add tag from input 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -145,19 +152,19 @@ exports[`TagInput add tag from input 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -241,7 +248,7 @@ exports[`TagInput add tag from input 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       id="test"
       name="radio"
       placeholder=""
@@ -389,7 +396,14 @@ exports[`TagInput add tag from input with error 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -397,19 +411,19 @@ exports[`TagInput add tag from input with error 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -468,7 +482,7 @@ exports[`TagInput add tag from input with error 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       id="test"
       name="radio"
       placeholder=""
@@ -616,7 +630,14 @@ exports[`TagInput add tag on paste 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -624,19 +645,19 @@ exports[`TagInput add tag on paste 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -720,7 +741,7 @@ exports[`TagInput add tag on paste 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       id="test"
       name="radio"
       placeholder=""
@@ -868,7 +889,14 @@ exports[`TagInput add tag on paste with error 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -876,19 +904,19 @@ exports[`TagInput add tag on paste with error 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -947,7 +975,7 @@ exports[`TagInput add tag on paste with error 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       id="test"
       name="radio"
       placeholder=""
@@ -1095,7 +1123,14 @@ exports[`TagInput delete tag 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -1103,19 +1138,19 @@ exports[`TagInput delete tag 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -1149,7 +1184,7 @@ exports[`TagInput delete tag 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       id="test"
       name="radio"
       placeholder=""
@@ -1297,7 +1332,14 @@ exports[`TagInput delete tag with backspace 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -1305,19 +1347,19 @@ exports[`TagInput delete tag with backspace 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -1351,7 +1393,7 @@ exports[`TagInput delete tag with backspace 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       id="test"
       name="radio"
       placeholder=""
@@ -1509,7 +1551,14 @@ exports[`TagInput delete tag with error 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -1517,19 +1566,19 @@ exports[`TagInput delete tag with error 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -1605,7 +1654,7 @@ exports[`TagInput delete tag with error 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       id="test"
       name="radio"
       placeholder=""
@@ -2135,7 +2184,14 @@ exports[`TagInput renders correctly when variant = base 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -2143,19 +2199,19 @@ exports[`TagInput renders correctly when variant = base 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -2214,7 +2270,7 @@ exports[`TagInput renders correctly when variant = base 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder=""
       type="text"
@@ -2358,7 +2414,14 @@ exports[`TagInput renders correctly when variant = bordered 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -2366,19 +2429,19 @@ exports[`TagInput renders correctly when variant = bordered 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -2437,7 +2500,7 @@ exports[`TagInput renders correctly when variant = bordered 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder=""
       type="text"
@@ -2576,7 +2639,14 @@ exports[`TagInput renders correctly when variant = no-border 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -2584,19 +2654,19 @@ exports[`TagInput renders correctly when variant = no-border 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -2655,7 +2725,7 @@ exports[`TagInput renders correctly when variant = no-border 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder=""
       type="text"
@@ -2696,7 +2766,14 @@ exports[`TagInput renders correctly with base props 1`] = `
   margin: 6px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -2704,19 +2781,19 @@ exports[`TagInput renders correctly with base props 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -2725,7 +2802,7 @@ exports[`TagInput renders correctly with base props 1`] = `
   >
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder="TagInput..."
       type="text"
@@ -2872,7 +2949,14 @@ exports[`TagInput renders correctly with some tags 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -2880,19 +2964,19 @@ exports[`TagInput renders correctly with some tags 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -2951,7 +3035,7 @@ exports[`TagInput renders correctly with some tags 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder=""
       type="text"
@@ -3098,7 +3182,14 @@ exports[`TagInput renders correctly with some tags 2`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -3106,19 +3197,19 @@ exports[`TagInput renders correctly with some tags 2`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -3177,7 +3268,7 @@ exports[`TagInput renders correctly with some tags 2`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder=""
       type="text"
@@ -3324,7 +3415,14 @@ exports[`TagInput renders correctly with some tags as objects 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -3332,19 +3430,19 @@ exports[`TagInput renders correctly with some tags as objects 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -3403,7 +3501,7 @@ exports[`TagInput renders correctly with some tags as objects 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder=""
       type="text"
@@ -3550,7 +3648,14 @@ exports[`TagInput renders correctly with some tags objects 1`] = `
   min-height: 16px;
 }
 
-.cache-s0yqyh-StyledInput {
+.cache-1fexr8u-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   font-size: 16px;
   color: #3f4250;
   border: none;
@@ -3558,19 +3663,19 @@ exports[`TagInput renders correctly with some tags objects 1`] = `
   background-color: #ffffff;
 }
 
-.cache-s0yqyh-StyledInput::-webkit-input-placeholder {
+.cache-1fexr8u-StyledInput::-webkit-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::-moz-placeholder {
+.cache-1fexr8u-StyledInput::-moz-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput:-ms-input-placeholder {
+.cache-1fexr8u-StyledInput:-ms-input-placeholder {
   color: #727683;
 }
 
-.cache-s0yqyh-StyledInput::placeholder {
+.cache-1fexr8u-StyledInput::placeholder {
   color: #727683;
 }
 
@@ -3629,7 +3734,7 @@ exports[`TagInput renders correctly with some tags objects 1`] = `
     </span>
     <input
       aria-label="radio"
-      class="cache-s0yqyh-StyledInput ea7vc6o0"
+      class="cache-1fexr8u-StyledInput ea7vc6o0"
       name="radio"
       placeholder=""
       type="text"

--- a/packages/ui/src/components/TagInput/index.tsx
+++ b/packages/ui/src/components/TagInput/index.tsx
@@ -81,7 +81,9 @@ const TagInputContainer = styled('div', {
 `
 
 const StyledInput = styled.input`
-  font-size: 16px;
+  display: flex;
+  flex: 1;
+  font-size: ${({ theme }) => theme.typography.body.fontSize};
   color: ${({ theme: { colors } }) => colors.neutral.text};
   border: none;
   outline: none;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The input of TagInput was not taking full width when empty so the placeholder was not shown correctly when long.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1041" alt="Screenshot 2023-10-19 at 14 41 25" src="https://github.com/scaleway/ultraviolet/assets/15812968/bcf51d2d-d75c-4a6e-90b1-3ecc4fb45d32"> | <img width="1046" alt="Screenshot 2023-10-19 at 14 42 45" src="https://github.com/scaleway/ultraviolet/assets/15812968/699d12b2-287f-4032-9239-38908aecafae"> |
