### PR TITLE
fix(ui): textinput should pass min and max prop

### DIFF
--- a/.changeset/tasty-dolphins-peel.md
+++ b/.changeset/tasty-dolphins-peel.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': minor
+---
+
+fix(ui): text input should pass min and max prop to input tag

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -405,6 +405,8 @@ export const TextInput = forwardRef<
       value,
       wrap,
       inputProps,
+      min,
+      max,
     },
     ref,
   ): JSX.Element => {
@@ -595,6 +597,8 @@ export const TextInput = forwardRef<
             type={getType()}
             value={value}
             wrap={wrap}
+            min={min}
+            max={max}
             {...inputProps}
           />
           {hasLabel && (


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

min and max prop should be pass to input tag on TextInput

#### The following changes where made:

1. add min and max in input props
