### PR TITLE
fix(MenuV2): focus when opening error

### DIFF
--- a/.changeset/sixty-gorillas-approve.md
+++ b/.changeset/sixty-gorillas-approve.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fix MenuV2 focus when opening it by replace `requestIdleCallback` by `setTimeout`

--- a/packages/ui/src/components/MenuV2/index.tsx
+++ b/packages/ui/src/components/MenuV2/index.tsx
@@ -114,12 +114,12 @@ const FwdMenu = forwardRef(
 
       // Focus the first item when the menu is opened
       if (!isVisible) {
-        requestIdleCallback(() => {
+        setTimeout(() => {
           // We have to wait for the popup to be inserted in the DOM
           if (popupRef.current?.firstChild?.firstChild instanceof HTMLElement) {
             popupRef.current.firstChild.firstChild.focus()
           }
-        })
+        }, 1)
       }
     }
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

`requestIdleCallback` isn't defined yet in stable Safari (https://caniuse.com/requestidlecallback), but we have to wait for the `popupRef` to be defined before focusing the content when opening a menu. This PR replaces `requestIdleCallback(cb)` by `setTimeout(cb, 1)`
