### PR TITLE
fix(Popover): set a default color in content to avoid inherit from parent

### DIFF
--- a/.changeset/strong-pumpkins-buy.md
+++ b/.changeset/strong-pumpkins-buy.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fix popover color inherited from parent

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -55,6 +55,11 @@ const StyledPopup = styled(Popup, {
   }}
 `
 
+// This is to avoid having text inherit color from popup (which is white on white background)
+const StyledStack = styled(Stack)`
+  color: ${({ theme }) => theme.colors.neutral.text};
+`
+
 type ContentWrapperProps = Pick<
   PopoverProps,
   'title' | 'onClose' | 'sentiment' | 'children'
@@ -73,7 +78,7 @@ const ContentWrapper = ({
   }, [])
 
   return (
-    <Stack gap={1}>
+    <StyledStack gap={1}>
       <Stack direction="row" justifyContent="space-between">
         <Text
           variant="bodyStrong"
@@ -105,7 +110,7 @@ const ContentWrapper = ({
       ) : (
         children
       )}
-    </Stack>
+    </StyledStack>
   )
 }
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The color inside the popover is inherited from parents which makes the next white. To avoid this I forced the color to be text neutral.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2023-10-25 at 14 10 38](https://github.com/scaleway/ultraviolet/assets/15812968/27d90721-d82a-491b-ae11-02132fc0fe17) | ![Screenshot 2023-10-25 at 14 10 51](https://github.com/scaleway/ultraviolet/assets/15812968/252cb533-51d4-4642-8860-8f43136fa350) |
