### PR TITLE
ci(Popover): add advanced unit testing with modal within popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,10 @@
   },
   "size-limit": [
     {
-      "path": ["packages/*/dist/**/*.js", "!packages/illustrations"],
+      "path": [
+        "packages/*/dist/**/*.js",
+        "!packages/illustrations"
+      ],
       "limit": "230 kB",
       "webpack": false,
       "brotli": true,


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

As we had some issues with popover and more generally nested component inside of it. I created a new advanced test, it has a Modal within a Popover and both have text input and select input with interaction with all of them. The goal is to check that neither the modal or the popover closes when we interact with it.
