### PR TITLE
fix(Popup): new props and remove animation when max height is set

### DIFF
--- a/.changeset/lovely-socks-yawn.md
+++ b/.changeset/lovely-socks-yawn.md
@@ -1,0 +1,15 @@
+---
+'@ultraviolet/ui': minor
+---
+
+Changes in component `<Popup />`:
+- Add new prop `maxHeight` and disable animation when set
+- Add new prop `disableAnimation` to disable animation on popup
+
+Changes in component `<MenuV2 />`:
+- Add new prop `maxHeight` and disable animation when set
+- Add new prop `maxWidth`
+
+Changes in component `<Popover />`:
+- Add new prop `maxHeight` and disable animation when set
+- Add new prop `maxWidth`

--- a/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`Menu renders with Menu.Item 1`] = `
   }
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup {
   background: #151a2d;
   color: #ffffff;
   border-radius: 4px;
@@ -325,7 +325,7 @@ exports[`Menu renders with Menu.Item 1`] = `
   padding: 0;
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
   content: ' ';
   position: absolute;
   top: -13px;
@@ -341,7 +341,7 @@ exports[`Menu renders with Menu.Item 1`] = `
   pointer-events: none;
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
   border-color: #ffffff transparent transparent transparent;
 }
 
@@ -420,7 +420,7 @@ exports[`Menu renders with Menu.Item 1`] = `
 }
 
 <div
-    class="e1jn11gg1 cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup e4h1g861"
+    class="e1jn11gg1 cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup e4h1g861"
     data-has-arrow="true"
     id="menu-:r4:"
     role="dialog"
@@ -483,7 +483,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   }
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup {
   background: #151a2d;
   color: #ffffff;
   border-radius: 4px;
@@ -507,7 +507,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   padding: 0;
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
   content: ' ';
   position: absolute;
   top: -13px;
@@ -523,7 +523,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   pointer-events: none;
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
   border-color: #ffffff transparent transparent transparent;
 }
 
@@ -593,7 +593,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
 }
 
 <div
-    class="e1jn11gg1 cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup e4h1g861"
+    class="e1jn11gg1 cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup e4h1g861"
     data-has-arrow="true"
     id="menu-:ra:"
     role="dialog"
@@ -665,7 +665,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   }
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup {
   background: #151a2d;
   color: #ffffff;
   border-radius: 4px;
@@ -689,7 +689,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   padding: 0;
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
   content: ' ';
   position: absolute;
   top: -13px;
@@ -705,7 +705,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   pointer-events: none;
 }
 
-.cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
+.cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup[data-has-arrow='true']::after {
   border-color: #ffffff transparent transparent transparent;
 }
 
@@ -789,7 +789,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
 }
 
 <div
-    class="e1jn11gg1 cache-ykgn1r-StyledTooltip-StyledTooltip-StyledPopup e4h1g861"
+    class="e1jn11gg1 cache-1irrcx7-StyledTooltip-StyledTooltip-StyledPopup e4h1g861"
     data-has-arrow="true"
     id="menu-:r7:"
     role="dialog"

--- a/packages/ui/src/components/MenuV2/index.tsx
+++ b/packages/ui/src/components/MenuV2/index.tsx
@@ -56,6 +56,8 @@ type MenuProps = {
   hasArrow?: boolean
   visible?: boolean
   'data-testid'?: string
+  maxHeight?: string
+  maxWidth?: string
 }
 
 const MenuList = styled(Stack)`
@@ -95,6 +97,8 @@ const FwdMenu = forwardRef(
       visible = false,
       className,
       'data-testid': dataTestId,
+      maxHeight,
+      maxWidth,
     }: MenuProps,
     ref: Ref<HTMLButtonElement | null>,
   ) => {
@@ -157,6 +161,8 @@ const FwdMenu = forwardRef(
         ref={popupRef}
         onClose={onClose}
         tabIndex={-1}
+        maxHeight={maxHeight}
+        maxWidth={maxWidth}
         text={
           <MenuList data-testid={dataTestId} className={className} role="menu">
             {typeof children === 'function'

--- a/packages/ui/src/components/Popover/index.tsx
+++ b/packages/ui/src/components/Popover/index.tsx
@@ -124,6 +124,8 @@ type PopoverProps = {
   onClose?: () => void
   className?: string
   'data-testid'?: string
+  maxWidth?: string
+  maxHeight?: string
 } & Pick<ComponentProps<typeof Popup>, 'placement'>
 
 /**
@@ -142,6 +144,8 @@ export const Popover = forwardRef(
       size = 'medium',
       onClose,
       className,
+      maxWidth,
+      maxHeight,
       'data-testid': dataTestId,
     }: PopoverProps,
     ref: Ref<HTMLDivElement>,
@@ -194,6 +198,8 @@ export const Popover = forwardRef(
         innerRef={innerRef}
         onClose={localOnClose}
         onKeyDown={onKeyDownSpace}
+        maxWidth={maxWidth}
+        maxHeight={maxHeight}
       >
         {children}
       </StyledPopup>

--- a/packages/ui/src/components/Popup/__tests__/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Popup/__tests__/__tests__/index.test.tsx
@@ -29,6 +29,34 @@ describe('Popup', () => {
     expect(PopupPortal).toBeVisible()
   })
 
+  test(`should display Popup on hover with no animation`, async () => {
+    renderWithTheme(
+      <Popup id="test" text="test success!" disableAnimation>
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+  })
+
+  test(`should display Popup on hover with maxHeight`, async () => {
+    renderWithTheme(
+      <Popup id="test" text="test success!" maxHeight="200px">
+        <p data-testid="children">Hover me</p>
+      </Popup>,
+    )
+
+    const input = screen.getByTestId('children')
+    await userEvent.hover(input)
+
+    const PopupPortal = screen.getByText('test success!')
+    expect(PopupPortal).toBeVisible()
+  })
+
   test(`should display Popup on hover with function children`, async () => {
     renderWithTheme(
       <Popup id="test" text="test success!">


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

On some browser setting a `maxHeight` and animation create a glitch making the popup blured until scrolled. To avoid this we remove animation on component having `maxHeight` set.

Changes in component `<Popup />`:
- Add new prop `maxHeight` and disable animation when set
- Add new prop `disableAnimation` to disable animation on popup

Changes in component `<MenuV2 />`:
- Add new prop `maxHeight` and disable animation when set
- Add new prop `maxWidth`

Changes in component `<Popover />`:
- Add new prop `maxHeight` and disable animation when set
- Add new prop `maxWidth`
