### PR TITLE
fix: rollup file size limit

### DIFF
--- a/.changeset/shiny-dogs-confess.md
+++ b/.changeset/shiny-dogs-confess.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/illustrations': patch
+---
+
+Fix rollup file size limit

--- a/packages/illustrations/rollup.config.mjs
+++ b/packages/illustrations/rollup.config.mjs
@@ -79,7 +79,7 @@ export default [
         preferBuiltins: true,
       }),
       url({
-        limit: 63488,
+        limit: 1048576,
       }),
       svgr({ memo: true }),
       PROFILE &&
@@ -97,7 +97,7 @@ export default [
     plugins: [
       multiInput.default(),
       url({
-        limit: 63488,
+        limit: 1048576,
       }),
       dts({
         compilerOptions: {


### PR DESCRIPTION
Rollup file size limit is reach by some of them like documentDB breaking the export and usage.