### PR TITLE
fix(ContentCard): to have title and subtitle vertically centered

### DIFF
--- a/.changeset/sweet-bees-joke.md
+++ b/.changeset/sweet-bees-joke.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/plus': patch
+---
+
+Fix `<ContentCard />` to have title and subtitle vertically centered aligned

--- a/packages/plus/src/components/ContentCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/ContentCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -106,10 +106,10 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -189,7 +189,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
           class="cache-nukfbn-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -310,7 +310,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -323,10 +323,10 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -412,7 +412,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
           class="cache-nukfbn-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -752,7 +752,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -765,10 +765,10 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -848,7 +848,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
           class="cache-fndo1g-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -970,7 +970,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -983,10 +983,10 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1072,7 +1072,7 @@ exports[`ContentCard renders correctly with all directions renders correctly dir
           class="cache-fndo1g-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -1413,7 +1413,7 @@ exports[`ContentCard renders correctly with children 1`] = `
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1426,10 +1426,10 @@ exports[`ContentCard renders correctly with children 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1509,7 +1509,7 @@ exports[`ContentCard renders correctly with children 1`] = `
           class="cache-nukfbn-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -1630,7 +1630,7 @@ exports[`ContentCard renders correctly with empty string title 1`] = `
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1643,10 +1643,10 @@ exports[`ContentCard renders correctly with empty string title 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1726,7 +1726,7 @@ exports[`ContentCard renders correctly with empty string title 1`] = `
           class="cache-nukfbn-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -1845,7 +1845,7 @@ exports[`ContentCard renders correctly with href 1`] = `
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1858,10 +1858,10 @@ exports[`ContentCard renders correctly with href 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1991,7 +1991,7 @@ exports[`ContentCard renders correctly with href 1`] = `
           class="cache-uaa52p-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -2129,7 +2129,7 @@ exports[`ContentCard renders correctly with href and direction row 1`] = `
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2142,10 +2142,10 @@ exports[`ContentCard renders correctly with href and direction row 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -2275,7 +2275,7 @@ exports[`ContentCard renders correctly with href and direction row 1`] = `
           class="cache-11lm1d2-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -2413,7 +2413,7 @@ exports[`ContentCard renders correctly with href and target 1`] = `
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2426,10 +2426,10 @@ exports[`ContentCard renders correctly with href and target 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -2559,7 +2559,7 @@ exports[`ContentCard renders correctly with href and target 1`] = `
           class="cache-uaa52p-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -2697,7 +2697,7 @@ exports[`ContentCard renders correctly with image, title, description, subtitle 
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2710,10 +2710,10 @@ exports[`ContentCard renders correctly with image, title, description, subtitle 
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -2824,7 +2824,7 @@ exports[`ContentCard renders correctly with image, title, description, subtitle 
         >
           test-file-stub
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -2956,7 +2956,7 @@ exports[`ContentCard renders correctly with onClick 1`] = `
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2969,10 +2969,10 @@ exports[`ContentCard renders correctly with onClick 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -3053,7 +3053,7 @@ exports[`ContentCard renders correctly with onClick 1`] = `
           class="cache-nukfbn-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"
@@ -3169,7 +3169,7 @@ exports[`ContentCard renders correctly with required title 1`] = `
   height: fit-content;
 }
 
-.cache-1t7ypwa {
+.cache-1qnzv4o {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3182,10 +3182,10 @@ exports[`ContentCard renders correctly with required title 1`] = `
   -webkit-box-align: normal;
   -ms-flex-align: normal;
   align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -3265,7 +3265,7 @@ exports[`ContentCard renders correctly with required title 1`] = `
           class="cache-nukfbn-SubContainer e2ipnt2"
         >
           <div
-            class="cache-1t7ypwa ehpbis70"
+            class="cache-1qnzv4o ehpbis70"
           >
             <div
               class="cache-16otux ehpbis70"

--- a/packages/plus/src/components/ContentCard/index.tsx
+++ b/packages/plus/src/components/ContentCard/index.tsx
@@ -188,7 +188,7 @@ export const ContentCard = forwardRef<
                 ref={subContainerRef}
               >
                 {icon ?? null}
-                <Stack gap={2}>
+                <Stack gap={2} justifyContent="center">
                   <Stack gap={0.5}>
                     <Stack>
                       {subtitle ? (


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Make the title / subtitle and description vertically centered, so when there is a title only the structure makes actual sense.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="976" alt="Screenshot 2023-11-09 at 10 26 11" src="https://github.com/scaleway/ultraviolet/assets/15812968/ebd3fb83-3826-4d85-8ca7-2c28742b3c00"> | <img width="985" alt="Screenshot 2023-11-09 at 10 26 16" src="https://github.com/scaleway/ultraviolet/assets/15812968/9f14d047-769a-4147-aea6-b830ebca633c"> |
| url  | <img width="970" alt="Screenshot 2023-11-09 at 10 26 25" src="https://github.com/scaleway/ultraviolet/assets/15812968/0f66335c-383f-4efc-a0dc-d6882f151667"> | <img width="970" alt="Screenshot 2023-11-09 at 10 26 32" src="https://github.com/scaleway/ultraviolet/assets/15812968/d0840f82-01db-4c3f-a2e3-aa4fda48aef5"> |
