### PR TITLE
refactor: remove jsx element when not needed and imported others from react

### DIFF
--- a/.changeset/six-toys-hammer.md
+++ b/.changeset/six-toys-hammer.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/form': minor
+'@ultraviolet/ui': minor
+---
+
+Refactor global `JSX.Element` by importing it from `React`

--- a/packages/form/src/components/CheckboxField/index.tsx
+++ b/packages/form/src/components/CheckboxField/index.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from '@ultraviolet/ui'
 import type { FieldState } from 'final-form'
-import type { ComponentProps, JSX, ReactNode, Ref } from 'react'
+import type { ComponentProps, ReactNode, Ref } from 'react'
 import { forwardRef } from 'react'
 import { useFormField } from '../../hooks'
 import { useErrors } from '../../providers'
@@ -52,7 +52,7 @@ export const CheckboxField = forwardRef(
       'data-testid': dataTestId,
     }: CheckboxFieldProps,
     ref: Ref<HTMLInputElement>,
-  ): JSX.Element => {
+  ) => {
     const { getError } = useErrors()
 
     const { input, meta } = useFormField(name, {

--- a/packages/form/src/components/Form/index.tsx
+++ b/packages/form/src/components/Form/index.tsx
@@ -1,5 +1,5 @@
 import arrayMutators from 'final-form-arrays'
-import type { JSX, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import type {
   FormRenderProps,
   FormProps as ReactFinalFormProps,
@@ -45,7 +45,7 @@ export const Form = <FormValues,>({
   mutators,
   keepDirtyOnReinitialize,
   className,
-}: FormProps<FormValues>): JSX.Element => (
+}: FormProps<FormValues>) => (
   <ReactFinalForm
     initialValues={initialValues}
     validateOnBlur={validateOnBlur}

--- a/packages/form/src/components/RadioField/index.tsx
+++ b/packages/form/src/components/RadioField/index.tsx
@@ -1,6 +1,6 @@
 import { Radio } from '@ultraviolet/ui'
 import type { FieldState } from 'final-form'
-import type { ComponentProps, JSX } from 'react'
+import type { ComponentProps } from 'react'
 import { useFormField } from '../../hooks'
 import { useErrors } from '../../providers'
 import type { BaseFieldProps } from '../../types'
@@ -41,7 +41,7 @@ export const RadioField = ({
   validate,
   value,
   tooltip,
-}: RadioFieldProps): JSX.Element => {
+}: RadioFieldProps) => {
   const { getError } = useErrors()
 
   const { input, meta } = useFormField(name, {

--- a/packages/form/src/components/RadioGroupField/index.tsx
+++ b/packages/form/src/components/RadioGroupField/index.tsx
@@ -1,6 +1,6 @@
 import { RadioGroup } from '@ultraviolet/ui'
 import type { FieldState } from 'final-form'
-import type { ComponentProps, JSX } from 'react'
+import type { ComponentProps } from 'react'
 import { useFormField } from '../../hooks'
 import { useErrors } from '../../providers'
 import type { BaseFieldProps } from '../../types'
@@ -39,7 +39,7 @@ export const RadioGroupField = ({
   error: customError,
   helper,
   direction,
-}: RadioGroupFieldProps): JSX.Element => {
+}: RadioGroupFieldProps) => {
   const { getError } = useErrors()
 
   const { input, meta } = useFormField(name, {

--- a/packages/form/src/components/SelectableCardField/index.tsx
+++ b/packages/form/src/components/SelectableCardField/index.tsx
@@ -1,6 +1,6 @@
 import { SelectableCard } from '@ultraviolet/ui'
 import type { FieldState } from 'final-form'
-import type { ComponentProps, JSX } from 'react'
+import type { ComponentProps } from 'react'
 import { useFormField } from '../../hooks'
 import { useErrors } from '../../providers'
 import type { BaseFieldProps } from '../../types'
@@ -53,7 +53,7 @@ export const SelectableCardField = ({
   id,
   label,
   'data-testid': dataTestId,
-}: SelectableCardFieldProps): JSX.Element => {
+}: SelectableCardFieldProps) => {
   const { getError } = useErrors()
 
   const { input, meta } = useFormField(name, {

--- a/packages/form/src/components/Submit/index.tsx
+++ b/packages/form/src/components/Submit/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@ultraviolet/ui'
-import type { ComponentProps, JSX, ReactNode } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import { useFormState } from 'react-final-form'
 
@@ -29,7 +29,7 @@ export const Submit = ({
   tooltip,
   fullWidth,
   onClick,
-}: SubmitProps): JSX.Element => {
+}: SubmitProps) => {
   const { invalid, submitting, hasValidationErrors, dirtySinceLastSubmit } =
     useFormState({
       subscription: {

--- a/packages/form/src/components/TagInputField/index.tsx
+++ b/packages/form/src/components/TagInputField/index.tsx
@@ -1,5 +1,5 @@
 import { TagInput } from '@ultraviolet/ui'
-import type { ComponentProps, JSX } from 'react'
+import type { ComponentProps } from 'react'
 import { useFormField } from '../../hooks'
 import type { BaseFieldProps } from '../../types'
 
@@ -38,7 +38,7 @@ export const TagInputField = ({
   tags,
   validate,
   variant,
-}: TagInputFieldProps): JSX.Element => {
+}: TagInputFieldProps) => {
   const { input } = useFormField<TagInputProp>(name, {
     disabled,
     required,

--- a/packages/form/src/components/TextInputField/index.tsx
+++ b/packages/form/src/components/TextInputField/index.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@ultraviolet/ui'
 import type { FieldState } from 'final-form'
-import type { ComponentProps, JSX, Ref } from 'react'
+import type { ComponentProps, Ref } from 'react'
 import { forwardRef } from 'react'
 import { useFormField } from '../../hooks'
 import { useErrors } from '../../providers'
@@ -113,7 +113,7 @@ export const TextInputField = forwardRef(
       value,
     }: TextInputFieldProps,
     ref: Ref<HTMLInputElement>,
-  ): JSX.Element => {
+  ) => {
     const { getError } = useErrors()
 
     const { input, meta } = useFormField(name, {

--- a/packages/form/src/providers/ErrorContext/index.tsx
+++ b/packages/form/src/providers/ErrorContext/index.tsx
@@ -1,5 +1,5 @@
 import type { AnyObject } from 'final-form'
-import type { JSX, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { createContext, useCallback, useContext, useMemo } from 'react'
 import { useFormState } from 'react-final-form'
 import type { FormErrorFunctionParams, FormErrors } from '../../types'
@@ -19,10 +19,7 @@ type ErrorProviderProps = {
   errors: FormErrors
 }
 
-export const ErrorProvider = ({
-  children,
-  errors,
-}: ErrorProviderProps): JSX.Element => {
+export const ErrorProvider = ({ children, errors }: ErrorProviderProps) => {
   const { values } = useFormState()
 
   const getFirstError = useCallback(

--- a/packages/ui/src/components/BarStack/index.tsx
+++ b/packages/ui/src/components/BarStack/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import type { JSX, MouseEventHandler, ReactNode } from 'react'
+import type { MouseEventHandler, ReactNode } from 'react'
 import { useMemo } from 'react'
 import { Tooltip } from '../Tooltip'
 
@@ -174,7 +174,7 @@ export const BarStack = ({
   total,
   className,
   'data-testid': dataTestId,
-}: BarStackProps): JSX.Element => {
+}: BarStackProps) => {
   const computedTotal = useMemo(
     () => total ?? data.reduce((acc, { value }) => acc + value, 0),
     [total, data],

--- a/packages/ui/src/components/Carousel/index.tsx
+++ b/packages/ui/src/components/Carousel/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import type { JSX, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { useEffect, useRef, useState } from 'react'
 
 const StyledWrapper = styled.div`
@@ -68,7 +68,7 @@ type CarouselItemProps = {
 export const CarouselItem = ({
   children,
   width = '240px',
-}: CarouselItemProps): JSX.Element => (
+}: CarouselItemProps) => (
   <StyledBorderWrapper width={width} draggable="true">
     {children}
   </StyledBorderWrapper>
@@ -87,7 +87,7 @@ export const Carousel = ({
   children,
   className,
   'data-testid': dataTestId = 'scrollbar',
-}: CarouselProps): JSX.Element => {
+}: CarouselProps) => {
   const scrollRef = useRef<HTMLDivElement>(null)
   let intervalLeft: ReturnType<typeof setInterval>
   let intervalRight: ReturnType<typeof setInterval>

--- a/packages/ui/src/components/Meter/index.tsx
+++ b/packages/ui/src/components/Meter/index.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import type { JSX } from 'react'
 import { Text } from '../Text'
 
 const StyledStrength = styled(Text, {
@@ -57,7 +56,7 @@ export const Meter = ({
   className,
   'data-testid': dataTestId,
   id,
-}: PasswordStrengthMeterProps): JSX.Element => {
+}: PasswordStrengthMeterProps) => {
   const toValue = ((value + 1) / strength.length) * 100
   const width = `${toValue}%`
 

--- a/packages/ui/src/components/Pagination/index.tsx
+++ b/packages/ui/src/components/Pagination/index.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
 import { useCallback, useEffect, useMemo } from 'react'
-import type { JSX } from 'react'
 import { Button } from '../Button'
 import { getPageNumbers } from './getPageNumbers'
 
@@ -56,7 +55,7 @@ export const Pagination = ({
   pageTabCount = 5,
   className,
   'data-testid': dataTestId,
-}: PaginationProps): JSX.Element => {
+}: PaginationProps) => {
   const goToFirstPage = useCallback(() => {
     onChange(1)
   }, [onChange])

--- a/packages/ui/src/components/PasswordStrengthMeter/index.tsx
+++ b/packages/ui/src/components/PasswordStrengthMeter/index.tsx
@@ -1,6 +1,5 @@
 import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
-import type { JSX } from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { Text } from '../Text'
 
@@ -89,7 +88,7 @@ export const PasswordStrengthMeter = ({
   forbiddenInputs = DEFAULT_FORBIDDEN_WORDS,
   className,
   'data-testid': dataTestId,
-}: PasswordStrengthMeterProps): JSX.Element => {
+}: PasswordStrengthMeterProps) => {
   const [score, setScore] = useState<number>(0)
   const theme = useTheme()
   const [backgroundColor, setBackgroundColor] = useState<string>(

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { Icon } from '@ultraviolet/icons'
-import type { ComponentProps, JSX } from 'react'
+import type { ComponentProps } from 'react'
 import type { Color } from '../../theme'
 
 type Direction = 'horizontal' | 'vertical'
@@ -61,7 +61,7 @@ export const Separator = ({
   icon,
   className,
   'data-testid': dataTestId,
-}: SeparatorProps): JSX.Element =>
+}: SeparatorProps) =>
   icon ? (
     <StyledIconWrapper
       role="separator"

--- a/packages/ui/src/components/Status/index.tsx
+++ b/packages/ui/src/components/Status/index.tsx
@@ -1,6 +1,5 @@
 import type { Theme } from '@emotion/react'
 import styled from '@emotion/styled'
-import type { JSX } from 'react'
 import { ping } from '../../utils'
 import { Tooltip } from '../Tooltip'
 
@@ -69,7 +68,7 @@ export const Status = ({
   tooltip,
   sentiment,
   'data-testid': dataTestId,
-}: StatusProps): JSX.Element => (
+}: StatusProps) => (
   <Tooltip text={tooltip}>
     <Container className={className} data-testid={dataTestId}>
       {animated ? <StyledAnimatedCircle sentiment={sentiment} /> : null}

--- a/packages/ui/src/components/TagInput/index.tsx
+++ b/packages/ui/src/components/TagInput/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled'
 import type {
   ChangeEvent,
   ClipboardEventHandler,
-  JSX,
   KeyboardEventHandler,
 } from 'react'
 import { useEffect, useRef, useState } from 'react'
@@ -132,7 +131,7 @@ export const TagInput = ({
   variant = 'base',
   className,
   'data-testid': dataTestId,
-}: TagInputProps): JSX.Element => {
+}: TagInputProps) => {
   const [tagInputState, setTagInput] = useState(
     convertTagArrayToTagStateArray(tags ?? []),
   )

--- a/packages/ui/src/components/TagList/index.tsx
+++ b/packages/ui/src/components/TagList/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useState } from 'react'
-import type { ComponentProps, JSX } from 'react'
+import type { ComponentProps } from 'react'
 import { Popover } from '../Popover'
 import { Tag } from '../Tag'
 
@@ -75,7 +75,7 @@ export const TagList = ({
   copiedText,
   className,
   'data-testid': dataTestId,
-}: TagListProps): JSX.Element | null => {
+}: TagListProps) => {
   let tmpThreshold = threshold
   if (
     tags.length > 0 &&

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -6,7 +6,6 @@ import type {
   ChangeEvent,
   FocusEventHandler,
   InputHTMLAttributes,
-  JSX,
   KeyboardEventHandler,
   LabelHTMLAttributes,
   TextareaHTMLAttributes,
@@ -409,7 +408,7 @@ export const TextInput = forwardRef<
       max,
     },
     ref,
-  ): JSX.Element => {
+  ) => {
     const controlRef = useRef<HTMLInputElement>(null)
 
     const [visited, setVisited] = useState(false)

--- a/packages/ui/src/components/VerificationCode/index.tsx
+++ b/packages/ui/src/components/VerificationCode/index.tsx
@@ -3,7 +3,6 @@ import type {
   ChangeEvent,
   ClipboardEventHandler,
   FocusEventHandler,
-  JSX,
   KeyboardEventHandler,
 } from 'react'
 import { createRef, useId, useState } from 'react'
@@ -97,7 +96,7 @@ export const VerificationCode = ({
   type = 'number',
   'data-testid': dataTestId,
   'aria-label': ariaLabel = 'Verification code',
-}: VerificationCodeProps): JSX.Element => {
+}: VerificationCodeProps) => {
   const uniqueId = useId()
   const valuesArray = Object.assign(
     new Array(fields).fill(''),


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

I removed all useless `JSX.Element` when it is implicit for components and imported others from `React` directly as `JSX.Element` global is deprecated.
