### PR TITLE
fix(Carrousel): remove top and bottom padding

### DIFF
--- a/.changeset/ninety-goats-yell.md
+++ b/.changeset/ninety-goats-yell.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Remove carrousel top and bottom padding

--- a/packages/ui/src/components/Carousel/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Carousel/__tests__/__snapshots__/index.tsx.snap
@@ -22,7 +22,7 @@ exports[`Carousel renders correctly with default props 1`] = `
   z-index: auto;
 }
 
-.cache-1v1i1kq-StyledScrollableWrapper {
+.cache-vuvr7q-StyledScrollableWrapper {
   overflow-x: scroll;
   overflow-y: hidden;
   white-space: nowrap;
@@ -30,7 +30,7 @@ exports[`Carousel renders correctly with default props 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 16px 100px;
+  padding: 0 100px;
   gap: 16px;
 }
 
@@ -80,7 +80,7 @@ exports[`Carousel renders correctly with default props 1`] = `
       data-testid="scrollbar-before"
     />
     <div
-      class="cache-1v1i1kq-StyledScrollableWrapper e1id70w02"
+      class="cache-vuvr7q-StyledScrollableWrapper e1id70w02"
       data-testid="scrollbar-wrapper"
     >
       <div

--- a/packages/ui/src/components/Carousel/index.tsx
+++ b/packages/ui/src/components/Carousel/index.tsx
@@ -27,7 +27,7 @@ const StyledScrollableWrapper = styled.div`
   overflow-y: hidden;
   white-space: nowrap;
   display: flex;
-  padding: ${({ theme }) => theme.space['2']} 100px;
+  padding: 0 100px;
   gap: ${({ theme }) => theme.space['2']};
 `
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Carousel is having padding on top and bottom which is not a good behavior as it should be the parent container (Stack or Row) that defines the gap between components and not components themselfs.
