### PR TITLE
feat(GlobalAlert): new component and update of Link

### DIFF
--- a/.changeset/stupid-glasses-film.md
+++ b/.changeset/stupid-glasses-film.md
@@ -6,3 +6,4 @@
 - New prop `variant` for `<Link />` component:
   - `variant="standalone"` (default): renders a standalone link without underline
   - `variant="inline"`: renders an inline link with underline
+- Added hover color from tokens for `<Link />` component

--- a/.changeset/stupid-glasses-film.md
+++ b/.changeset/stupid-glasses-film.md
@@ -1,0 +1,8 @@
+---
+'@ultraviolet/ui': minor
+---
+
+- New `<GlobalAlert />` component
+- New prop `variant` for `<Link />` component:
+  - `variant="standalone"` (default): renders a standalone link without underline
+  - `variant="inline"`: renders an inline link with underline

--- a/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
@@ -488,7 +488,7 @@ exports[`Banner renders correctly with a link 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1ivdqr7-StyledLink {
+.cache-bt0hmr-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -526,45 +526,45 @@ exports[`Banner renders correctly with a link 1`] = `
   text-case: none;
 }
 
-.cache-1ivdqr7-StyledLink .e1afnb7a2 {
+.cache-bt0hmr-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ivdqr7-StyledLink>* {
+.cache-bt0hmr-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ivdqr7-StyledLink:hover,
-.cache-1ivdqr7-StyledLink:focus {
+.cache-bt0hmr-StyledLink:hover,
+.cache-bt0hmr-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1ivdqr7-StyledLink:hover .e1afnb7a2,
-.cache-1ivdqr7-StyledLink:focus .e1afnb7a2 {
+.cache-bt0hmr-StyledLink:hover .e1afnb7a2,
+.cache-bt0hmr-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ivdqr7-StyledLink[data-variant='inline'] {
+.cache-bt0hmr-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ivdqr7-StyledLink:hover::after,
-.cache-1ivdqr7-StyledLink:focus::after {
+.cache-bt0hmr-StyledLink:hover::after,
+.cache-bt0hmr-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1ivdqr7-StyledLink:active {
+.cache-bt0hmr-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -682,7 +682,7 @@ exports[`Banner renders correctly with a link 1`] = `
         class="cache-1hgmfcr-Stack ehpbis70"
       >
         <a
-          class="cache-1ivdqr7-StyledLink e1afnb7a0"
+          class="cache-bt0hmr-StyledLink e1afnb7a0"
           data-variant="standalone"
           href=""
           prominence="default"

--- a/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
@@ -488,7 +488,7 @@ exports[`Banner renders correctly with a link 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-7ce6t2-StyledLink {
+.cache-1ivdqr7-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -526,17 +526,17 @@ exports[`Banner renders correctly with a link 1`] = `
   text-case: none;
 }
 
-.cache-7ce6t2-StyledLink .e1afnb7a2 {
+.cache-1ivdqr7-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-7ce6t2-StyledLink>* {
+.cache-1ivdqr7-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-7ce6t2-StyledLink:hover,
-.cache-7ce6t2-StyledLink:focus {
+.cache-1ivdqr7-StyledLink:hover,
+.cache-1ivdqr7-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -545,20 +545,26 @@ exports[`Banner renders correctly with a link 1`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-7ce6t2-StyledLink:hover .e1afnb7a2,
-.cache-7ce6t2-StyledLink:focus .e1afnb7a2 {
+.cache-1ivdqr7-StyledLink:hover .e1afnb7a2,
+.cache-1ivdqr7-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-7ce6t2-StyledLink:hover::after,
-.cache-7ce6t2-StyledLink:focus::after {
+.cache-1ivdqr7-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ivdqr7-StyledLink:hover::after,
+.cache-1ivdqr7-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-7ce6t2-StyledLink:active {
+.cache-1ivdqr7-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -676,7 +682,8 @@ exports[`Banner renders correctly with a link 1`] = `
         class="cache-1hgmfcr-Stack ehpbis70"
       >
         <a
-          class="cache-7ce6t2-StyledLink e1afnb7a0"
+          class="cache-1ivdqr7-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href=""
           prominence="default"
           rel="noopener noreferrer"

--- a/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
   margin: 0 8px;
 }
 
-.cache-1rk3jb4-StyledLink {
+.cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -63,45 +63,45 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -116,7 +116,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          class="cache-1erdb2u-StyledLink e1afnb7a0"
           data-variant="standalone"
           href="/step1"
         >
@@ -128,7 +128,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          class="cache-1erdb2u-StyledLink e1afnb7a0"
           data-variant="standalone"
           href="/step1/step2"
         >
@@ -196,7 +196,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
   margin: 0 8px;
 }
 
-.cache-1rk3jb4-StyledLink {
+.cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -234,45 +234,45 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -305,7 +305,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          class="cache-1erdb2u-StyledLink e1afnb7a0"
           data-variant="standalone"
           href="/step1"
         >
@@ -317,7 +317,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          class="cache-1erdb2u-StyledLink e1afnb7a0"
           data-variant="standalone"
           href="/step1/step2"
         >
@@ -361,7 +361,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
   margin: 0 8px;
 }
 
-.cache-1rk3jb4-StyledLink {
+.cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -399,45 +399,45 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -452,7 +452,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          class="cache-1erdb2u-StyledLink e1afnb7a0"
           data-variant="standalone"
           href="/step1"
         >
@@ -465,7 +465,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          class="cache-1erdb2u-StyledLink e1afnb7a0"
           data-variant="standalone"
           href="/step1/step2"
         >

--- a/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
   margin: 0 8px;
 }
 
-.cache-1tigebz-StyledLink {
+.cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -63,17 +63,17 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -82,20 +82,26 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -110,7 +116,8 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1tigebz-StyledLink e1afnb7a0"
+          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href="/step1"
         >
           Step 1
@@ -121,7 +128,8 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1tigebz-StyledLink e1afnb7a0"
+          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href="/step1/step2"
         >
           I'm a very long... long long step
@@ -188,7 +196,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
   margin: 0 8px;
 }
 
-.cache-1tigebz-StyledLink {
+.cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -226,17 +234,17 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -245,20 +253,26 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -291,7 +305,8 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1tigebz-StyledLink e1afnb7a0"
+          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href="/step1"
         >
           Step 1
@@ -302,7 +317,8 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1tigebz-StyledLink e1afnb7a0"
+          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href="/step1/step2"
         >
           I'm a very long... long long step
@@ -345,7 +361,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
   margin: 0 8px;
 }
 
-.cache-1tigebz-StyledLink {
+.cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -383,17 +399,17 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -402,20 +418,26 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -430,7 +452,8 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1tigebz-StyledLink e1afnb7a0"
+          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href="/step1"
         >
           Step 1
@@ -442,7 +465,8 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
         class="cache-rtqykd-ItemContainer ej0p0s40"
       >
         <a
-          class="cache-1tigebz-StyledLink e1afnb7a0"
+          class="cache-1rk3jb4-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href="/step1/step2"
         >
           I'm a very long... long long step

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from '../Tooltip'
 type SENTIMENT = (typeof SENTIMENTS)[number]
 
 // SIZE
-const SIZE_HEIGHT = {
+export const SIZE_HEIGHT = {
   large: 48,
   medium: 40,
   small: 32,

--- a/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.tsx.snap
@@ -639,7 +639,7 @@ exports[`EmptySpace should work with learn more 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-ihv4h0-StyledLink {
+.cache-1ptg5vw-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -677,17 +677,17 @@ exports[`EmptySpace should work with learn more 1`] = `
   text-case: none;
 }
 
-.cache-ihv4h0-StyledLink .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-ihv4h0-StyledLink>* {
+.cache-1ptg5vw-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-ihv4h0-StyledLink:hover,
-.cache-ihv4h0-StyledLink:focus {
+.cache-1ptg5vw-StyledLink:hover,
+.cache-1ptg5vw-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -696,20 +696,26 @@ exports[`EmptySpace should work with learn more 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:hover .e1afnb7a2,
-.cache-ihv4h0-StyledLink:focus .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
+.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-ihv4h0-StyledLink:hover::after,
-.cache-ihv4h0-StyledLink:focus::after {
+.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ptg5vw-StyledLink:hover::after,
+.cache-1ptg5vw-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:active {
+.cache-1ptg5vw-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -748,7 +754,8 @@ exports[`EmptySpace should work with learn more 1`] = `
           class="cache-4lkpn5-Stack ehpbis70"
         />
         <a
-          class="cache-ihv4h0-StyledLink e1afnb7a0"
+          class="cache-1ptg5vw-StyledLink e1afnb7a0"
+          data-variant="standalone"
           href="https://scaleway.com"
         >
           Learn more

--- a/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.tsx.snap
@@ -639,7 +639,7 @@ exports[`EmptySpace should work with learn more 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1ptg5vw-StyledLink {
+.cache-jzq3t2-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -677,45 +677,45 @@ exports[`EmptySpace should work with learn more 1`] = `
   text-case: none;
 }
 
-.cache-1ptg5vw-StyledLink .e1afnb7a2 {
+.cache-jzq3t2-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ptg5vw-StyledLink>* {
+.cache-jzq3t2-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ptg5vw-StyledLink:hover,
-.cache-1ptg5vw-StyledLink:focus {
+.cache-jzq3t2-StyledLink:hover,
+.cache-jzq3t2-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
-.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
+.cache-jzq3t2-StyledLink:hover .e1afnb7a2,
+.cache-jzq3t2-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+.cache-jzq3t2-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ptg5vw-StyledLink:hover::after,
-.cache-1ptg5vw-StyledLink:focus::after {
+.cache-jzq3t2-StyledLink:hover::after,
+.cache-jzq3t2-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1ptg5vw-StyledLink:active {
+.cache-jzq3t2-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -754,7 +754,7 @@ exports[`EmptySpace should work with learn more 1`] = `
           class="cache-4lkpn5-Stack ehpbis70"
         />
         <a
-          class="cache-1ptg5vw-StyledLink e1afnb7a0"
+          class="cache-jzq3t2-StyledLink e1afnb7a0"
           data-variant="standalone"
           href="https://scaleway.com"
         >

--- a/packages/ui/src/components/GlobalAlert/GlobalAlertLink.tsx
+++ b/packages/ui/src/components/GlobalAlert/GlobalAlertLink.tsx
@@ -1,0 +1,38 @@
+import { useTheme } from '@emotion/react'
+import type { ComponentProps } from 'react'
+import { Link } from '../Link'
+
+export const GlobalAlertLink = ({
+  children,
+  href,
+  target,
+  download,
+  rel,
+  className,
+  onClick,
+  'aria-label': ariaLabel,
+  oneLine = false,
+  'data-testid': dataTestId,
+}: Omit<ComponentProps<typeof Link>, 'sentiment' | 'prominence' | 'size'>) => {
+  const { theme } = useTheme()
+
+  return (
+    <Link
+      href={href}
+      target={target}
+      download={download}
+      sentiment="neutral"
+      prominence={theme === 'light' ? 'stronger' : 'strong'}
+      size="small"
+      variant="inline"
+      rel={rel}
+      className={className}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      oneLine={oneLine}
+      data-testid={dataTestId}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/packages/ui/src/components/GlobalAlert/__stories__/Button.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Button.stories.tsx
@@ -1,0 +1,19 @@
+import { Template } from './Template.stories'
+
+export const Button = Template.bind({})
+
+Button.args = {
+  children: 'Your trial has expired. Upgrade your plan to continue',
+  variant: 'info',
+  buttonText: 'Upgrade',
+  onClickButton: () => {},
+}
+
+Button.parameters = {
+  docs: {
+    description: {
+      story:
+        'You can add a button to the alert by using the `buttonText` and `onClickButton` props.',
+    },
+  },
+}

--- a/packages/ui/src/components/GlobalAlert/__stories__/Closable.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Closable.stories.tsx
@@ -1,0 +1,18 @@
+import { Template } from './Template.stories'
+
+export const Closable = Template.bind({})
+
+Closable.args = {
+  children: 'Your trial has expired. Upgrade your plan to continue',
+  variant: 'danger',
+  closable: false,
+}
+
+Closable.parameters = {
+  docs: {
+    description: {
+      story:
+        'You can remove the close button by using the `closable` prop if you want the alert to be persistent.',
+    },
+  },
+}

--- a/packages/ui/src/components/GlobalAlert/__stories__/Link.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Link.stories.tsx
@@ -6,11 +6,11 @@ import { GlobalAlert } from '../index'
 export const Link = (props: ComponentProps<typeof GlobalAlert>) => (
   <Stack gap={1}>
     <GlobalAlert {...props} variant="danger">
-      The credit card registered in your account expires soon.{' '}
+      The credit card registered in your account expires soon.&nbsp;
       <GlobalAlert.Link href="scaleway.com">
         Update your payment method
-      </GlobalAlert.Link>{' '}
-      to keep using your resources.
+      </GlobalAlert.Link>
+      &nbsp; to keep using your resources.
     </GlobalAlert>
   </Stack>
 )

--- a/packages/ui/src/components/GlobalAlert/__stories__/Link.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Link.stories.tsx
@@ -1,0 +1,24 @@
+import type { Decorator } from '@storybook/react'
+import type { ComponentProps } from 'react'
+import { Stack } from '../../Stack'
+import { GlobalAlert } from '../index'
+
+export const Link = (props: ComponentProps<typeof GlobalAlert>) => (
+  <Stack gap={1}>
+    <GlobalAlert {...props} variant="danger">
+      The credit card registered in your account expires soon.{' '}
+      <GlobalAlert.Link href="scaleway.com">
+        Update your payment method
+      </GlobalAlert.Link>{' '}
+      to keep using your resources.
+    </GlobalAlert>
+  </Stack>
+)
+
+Link.decorators = [
+  StoryComponent => (
+    <Stack gap={2}>
+      <StoryComponent />
+    </Stack>
+  ),
+] as Decorator[]

--- a/packages/ui/src/components/GlobalAlert/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Playground.stories.tsx
@@ -3,7 +3,6 @@ import { Template } from './Template.stories'
 export const Playground = Template.bind({})
 
 Playground.args = {
-  children: 'This is an alert content.',
-  title: 'Alert',
-  sentiment: 'info',
+  children: 'Your trial has expired. Upgrade your plan to continue',
+  variant: 'info',
 }

--- a/packages/ui/src/components/GlobalAlert/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Playground.stories.tsx
@@ -1,0 +1,9 @@
+import { Template } from './Template.stories'
+
+export const Playground = Template.bind({})
+
+Playground.args = {
+  children: 'This is an alert content.',
+  title: 'Alert',
+  sentiment: 'info',
+}

--- a/packages/ui/src/components/GlobalAlert/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Template.stories.tsx
@@ -1,0 +1,6 @@
+import type { StoryFn } from '@storybook/react'
+import { GlobalAlert } from '..'
+
+export const Template: StoryFn<typeof GlobalAlert> = args => (
+  <GlobalAlert {...args} />
+)

--- a/packages/ui/src/components/GlobalAlert/__stories__/Variants.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Variants.stories.tsx
@@ -1,0 +1,28 @@
+import type { Decorator } from '@storybook/react'
+import type { ComponentProps } from 'react'
+import { Stack } from '../../Stack'
+import { GlobalAlert } from '../index'
+
+export const Variants = (props: ComponentProps<typeof GlobalAlert>) =>
+  (['info', 'danger', 'promotional'] as const).map(variant => (
+    <GlobalAlert {...props} key={variant} variant={variant}>
+      This is a global alert with the {variant} variant
+    </GlobalAlert>
+  ))
+
+Variants.decorators = [
+  StoryComponent => (
+    <Stack gap={2}>
+      <StoryComponent />
+    </Stack>
+  ),
+] as Decorator[]
+
+Variants.parameters = {
+  docs: {
+    description: {
+      story:
+        'Using `sentiment` prop you can change the sentiment of the component. Each sentiment has a default icon set.',
+    },
+  },
+}

--- a/packages/ui/src/components/GlobalAlert/__stories__/Variants.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/Variants.stories.tsx
@@ -22,7 +22,7 @@ Variants.parameters = {
   docs: {
     description: {
       story:
-        'Using `sentiment` prop you can change the sentiment of the component. Each sentiment has a default icon set.',
+        'Using `variant` prop you can change the variant of the component. Each variant has a default icon set.',
     },
   },
 }

--- a/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
@@ -1,0 +1,9 @@
+import type { Meta } from '@storybook/react'
+import { GlobalAlert } from '..'
+
+export default {
+  component: GlobalAlert,
+  title: 'Components/Feedback/GlobalAlert',
+} as Meta
+
+export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
@@ -4,6 +4,11 @@ import { GlobalAlert } from '..'
 export default {
   component: GlobalAlert,
   title: 'Components/Feedback/GlobalAlert',
+  subcomponents: { 'GlobalAlert.Link': GlobalAlert.Link },
 } as Meta
 
 export { Playground } from './Playground.stories'
+export { Variants } from './Variants.stories'
+export { Closable } from './Closable.stories'
+export { Button } from './Button.stories'
+export { Link } from './Link.stories'

--- a/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
@@ -1538,7 +1538,7 @@ exports[`GlobalAlert renders correctly with link 1`] = `
       <p
         class="cache-fzpogg-StyledText e13y3mga0"
       >
-        This is a 
+        This is a 
         <a
           class="cache-11vhm6c-StyledLink e1afnb7a0"
           data-variant="inline"
@@ -1547,7 +1547,7 @@ exports[`GlobalAlert renders correctly with link 1`] = `
         >
           Global Alert
         </a>
-         link
+          link
       </p>
     </div>
     <button

--- a/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,1568 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlobalAlert renders correctly with all variants renders correctly variant danger 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="danger"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      >
+        Sample GlobalAlert
+      </p>
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalAlert renders correctly with all variants renders correctly variant info 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="info"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      >
+        Sample GlobalAlert
+      </p>
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalAlert renders correctly with all variants renders correctly variant promotional 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="promotional"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      >
+        Sample GlobalAlert
+      </p>
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalAlert renders correctly with buttonText and onClickButton 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-ulqn51-StyledFilledButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 32px;
+  padding: 0 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #e9eaeb;
+  border: none;
+  color: #222638;
+}
+
+.cache-ulqn51-StyledFilledButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-ulqn51-StyledFilledButton:active {
+  box-shadow: 0px 0px 0px 3px #151a2d5c;
+}
+
+.cache-ulqn51-StyledFilledButton:hover,
+.cache-ulqn51-StyledFilledButton:active {
+  background: #d9dadd;
+  color: #151a2d;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="info"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      >
+        Sample GlobalAlert
+      </p>
+      <button
+        class="cache-ulqn51-StyledFilledButton e112qvla2"
+        type="button"
+      >
+        Button
+      </button>
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalAlert renders correctly with children as component 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="info"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      />
+      <p>
+        Sample GlobalAlert
+      </p>
+      <p />
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalAlert renders correctly with closable and onClose 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="info"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      >
+        Sample GlobalAlert
+      </p>
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalAlert renders correctly with default values 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="info"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      >
+        Simple GlobalAlert
+      </p>
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalAlert renders correctly with link 1`] = `
+<DocumentFragment>
+  .cache-kjn9ce-Stack-Container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+  height: 56px;
+  padding: 0 16px;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='info'] {
+  background-color: #0078d2;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='danger'] {
+  background-color: #e51963;
+}
+
+.cache-kjn9ce-Stack-Container[data-variant='promotional'] {
+  background: linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);
+}
+
+.cache-1osn1u7-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-fzpogg-StyledText {
+  color: #ffffff;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-1gcyg5q-StyledLink {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  color: #ffffff;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  text-decoration-color: transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: text-decoration-color 250ms ease-out;
+  transition: text-decoration-color 250ms ease-out;
+  gap: 8px;
+  position: relative;
+  cursor: pointer;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+}
+
+.cache-1gcyg5q-StyledLink .e1afnb7a2 {
+  -webkit-transition: -webkit-transform 250ms ease-out;
+  transition: transform 250ms ease-out;
+}
+
+.cache-1gcyg5q-StyledLink>* {
+  pointer-events: none;
+}
+
+.cache-1gcyg5q-StyledLink:hover,
+.cache-1gcyg5q-StyledLink:focus {
+  outline: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  color: #ffffff;
+  text-decoration-color: #ffffff;
+}
+
+.cache-1gcyg5q-StyledLink:hover .e1afnb7a2,
+.cache-1gcyg5q-StyledLink:focus .e1afnb7a2 {
+  -webkit-transform: translate(-4px, 0);
+  -moz-transform: translate(-4px, 0);
+  -ms-transform: translate(-4px, 0);
+  transform: translate(-4px, 0);
+}
+
+.cache-1gcyg5q-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1gcyg5q-StyledLink:hover::after,
+.cache-1gcyg5q-StyledLink:focus::after {
+  background-color: #3f4250;
+}
+
+.cache-1gcyg5q-StyledLink:active {
+  text-decoration-thickness: 2px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 24px;
+  padding: 0 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 24px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: none;
+  position: absolute;
+  right: 24px;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
+.cache-yx7dgl-StyledFilledButton-CloseButton:hover,
+.cache-yx7dgl-StyledFilledButton-CloseButton:focus,
+.cache-yx7dgl-StyledFilledButton-CloseButton:active {
+  background: none;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+<div
+    class="cache-kjn9ce-Stack-Container ewvyccp0"
+    data-variant="info"
+  >
+    <div
+      class="cache-1osn1u7-Stack ehpbis70"
+    >
+      <p
+        class="cache-fzpogg-StyledText e13y3mga0"
+      >
+        This is a 
+        <a
+          class="cache-1gcyg5q-StyledLink e1afnb7a0"
+          data-variant="inline"
+          href="scaleway.com"
+          prominence="stronger"
+        >
+          Global Alert
+        </a>
+         link
+      </p>
+    </div>
+    <button
+      class="ewvyccp1 cache-yx7dgl-StyledFilledButton-CloseButton e112qvla2"
+      type="button"
+    >
+      <svg
+        class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+        />
+      </svg>
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
@@ -1376,7 +1376,7 @@ exports[`GlobalAlert renders correctly with link 1`] = `
   text-decoration: none;
 }
 
-.cache-1gcyg5q-StyledLink {
+.cache-11vhm6c-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1414,45 +1414,45 @@ exports[`GlobalAlert renders correctly with link 1`] = `
   text-case: none;
 }
 
-.cache-1gcyg5q-StyledLink .e1afnb7a2 {
+.cache-11vhm6c-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1gcyg5q-StyledLink>* {
+.cache-11vhm6c-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1gcyg5q-StyledLink:hover,
-.cache-1gcyg5q-StyledLink:focus {
+.cache-11vhm6c-StyledLink:hover,
+.cache-11vhm6c-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #ffffff;
-  text-decoration-color: #ffffff;
+  color: #f9f9fa;
+  text-decoration-color: #f9f9fa;
 }
 
-.cache-1gcyg5q-StyledLink:hover .e1afnb7a2,
-.cache-1gcyg5q-StyledLink:focus .e1afnb7a2 {
+.cache-11vhm6c-StyledLink:hover .e1afnb7a2,
+.cache-11vhm6c-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1gcyg5q-StyledLink[data-variant='inline'] {
+.cache-11vhm6c-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1gcyg5q-StyledLink:hover::after,
-.cache-1gcyg5q-StyledLink:focus::after {
+.cache-11vhm6c-StyledLink:hover::after,
+.cache-11vhm6c-StyledLink:focus::after {
   background-color: #3f4250;
 }
 
-.cache-1gcyg5q-StyledLink:active {
+.cache-11vhm6c-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -1540,7 +1540,7 @@ exports[`GlobalAlert renders correctly with link 1`] = `
       >
         This is a 
         <a
-          class="cache-1gcyg5q-StyledLink e1afnb7a0"
+          class="cache-11vhm6c-StyledLink e1afnb7a0"
           data-variant="inline"
           href="scaleway.com"
           prominence="stronger"

--- a/packages/ui/src/components/GlobalAlert/__tests__/index.test.tsx
+++ b/packages/ui/src/components/GlobalAlert/__tests__/index.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test } from '@jest/globals'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { GlobalAlert } from '..'
+import {
+  renderWithTheme,
+  shouldMatchEmotionSnapshot,
+} from '../../../../.jest/helpers'
+
+describe('GlobalAlert', () => {
+  test('renders correctly with default values', () =>
+    shouldMatchEmotionSnapshot(<GlobalAlert>Simple GlobalAlert</GlobalAlert>))
+
+  test('renders correctly with children as component', () =>
+    shouldMatchEmotionSnapshot(
+      <GlobalAlert>
+        <p>Sample GlobalAlert</p>
+      </GlobalAlert>,
+    ))
+
+  test('renders correctly with buttonText and onClickButton', () =>
+    shouldMatchEmotionSnapshot(
+      <GlobalAlert buttonText="Button" onClickButton={() => 'ok'}>
+        Sample GlobalAlert
+      </GlobalAlert>,
+    ))
+
+  test('renders correctly with closable and onClose', () =>
+    shouldMatchEmotionSnapshot(
+      <GlobalAlert closable onClose={() => 'ok'}>
+        Sample GlobalAlert
+      </GlobalAlert>,
+    ))
+
+  describe(`renders correctly with all variants`, () => {
+    ;(['info', 'danger', 'promotional'] as const).forEach(variant => {
+      test(`renders correctly variant ${variant}`, () =>
+        shouldMatchEmotionSnapshot(
+          <GlobalAlert variant={variant}>Sample GlobalAlert</GlobalAlert>,
+        ))
+    })
+  })
+
+  test(`should render GlobalAlert and then close it`, async () => {
+    renderWithTheme(
+      <GlobalAlert onClose={() => 'ok'} data-testid="GlobalAlert">
+        Sample GlobalAlert
+      </GlobalAlert>,
+    )
+
+    const Alert = screen.getByTestId('GlobalAlert')
+    expect(Alert).toBeVisible()
+
+    const closeButton = screen.getByRole('button')
+    await userEvent.click(closeButton)
+
+    await waitFor(() => {
+      expect(Alert).not.toBeVisible()
+    })
+  })
+
+  test('renders correctly with link', () =>
+    shouldMatchEmotionSnapshot(
+      <GlobalAlert buttonText="button">
+        This is a{' '}
+        <GlobalAlert.Link href="scaleway.com">Global Alert</GlobalAlert.Link>{' '}
+        link
+      </GlobalAlert>,
+    ))
+})

--- a/packages/ui/src/components/GlobalAlert/__tests__/index.test.tsx
+++ b/packages/ui/src/components/GlobalAlert/__tests__/index.test.tsx
@@ -62,9 +62,9 @@ describe('GlobalAlert', () => {
   test('renders correctly with link', () =>
     shouldMatchEmotionSnapshot(
       <GlobalAlert buttonText="button">
-        This is a{' '}
-        <GlobalAlert.Link href="scaleway.com">Global Alert</GlobalAlert.Link>{' '}
-        link
+        This is a&nbsp;
+        <GlobalAlert.Link href="scaleway.com">Global Alert</GlobalAlert.Link>
+        &nbsp; link
       </GlobalAlert>,
     ))
 })

--- a/packages/ui/src/components/GlobalAlert/index.tsx
+++ b/packages/ui/src/components/GlobalAlert/index.tsx
@@ -63,7 +63,7 @@ export const GlobalAlert = ({
   'data-testid': dataTestId,
 }: GlobalAlertProps) => {
   const { theme } = useTheme()
-  const [opened, setOpened] = useReducer(value => !value, true)
+  const [opened, toggleOpened] = useReducer(value => !value, true)
 
   if (!opened) return null
 
@@ -108,7 +108,7 @@ export const GlobalAlert = ({
           icon="close"
           sentiment="primary"
           onClick={() => {
-            setOpened()
+            toggleOpened()
             onClose?.()
           }}
         />

--- a/packages/ui/src/components/GlobalAlert/index.tsx
+++ b/packages/ui/src/components/GlobalAlert/index.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled'
+import type { ReactNode } from 'react'
+import { Stack } from '../Stack'
+
+type GlobalAlertProps = {
+  children: ReactNode
+  sentiment?: 'info' | 'danger' | 'promotional'
+}
+
+const Container = styled(Stack)`
+  width: 100%;
+  height: 56px;
+  padding: 0 ${({ theme }) => theme.space['2']};
+
+  &[data-sentiment='info'] {
+    background-color: ${({ theme }) => theme.colors.info.background};
+  }
+
+  &[data-sentiment='danger'] {
+    background-color: ${({ theme }) => theme.colors.danger.background};
+  }
+
+  &[data-sentiment='promotional'] {
+    background-color: ${({ theme }) =>
+      theme.colors.other.gradients.background.aqua};
+  }
+`
+
+export const GlobalAlert = ({
+  children,
+  sentiment = 'info',
+}: GlobalAlertProps) => (
+  <Container
+    justifyContent="center"
+    alignItems="center"
+    flex={1}
+    data-sentiment={sentiment}
+  >
+    {children}
+  </Container>
+)

--- a/packages/ui/src/components/GlobalAlert/index.tsx
+++ b/packages/ui/src/components/GlobalAlert/index.tsx
@@ -1,41 +1,120 @@
+import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { ReactNode } from 'react'
+import { useReducer } from 'react'
+import { Button, SIZE_HEIGHT } from '../Button'
 import { Stack } from '../Stack'
+import { Text } from '../Text'
+import { GlobalAlertLink } from './GlobalAlertLink'
 
-type GlobalAlertProps = {
-  children: ReactNode
-  sentiment?: 'info' | 'danger' | 'promotional'
-}
+const CloseButton = styled(Button)`
+  background: none;
+  position: absolute;
+  right: ${SIZE_HEIGHT.xsmall}px;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background: none;
+  }
+`
 
 const Container = styled(Stack)`
   width: 100%;
   height: 56px;
   padding: 0 ${({ theme }) => theme.space['2']};
 
-  &[data-sentiment='info'] {
-    background-color: ${({ theme }) => theme.colors.info.background};
+  &[data-variant='info'] {
+    background-color: ${({ theme }) => theme.colors.info.backgroundStrong};
   }
 
-  &[data-sentiment='danger'] {
-    background-color: ${({ theme }) => theme.colors.danger.background};
+  &[data-variant='danger'] {
+    background-color: ${({ theme }) => theme.colors.danger.backgroundStrong};
   }
 
-  &[data-sentiment='promotional'] {
-    background-color: ${({ theme }) =>
-      theme.colors.other.gradients.background.aqua};
+  &[data-variant='promotional'] {
+    background: ${({ theme }) => theme.colors.other.gradients.background.aqua};
   }
 `
 
+type GlobalAlertProps = {
+  children: ReactNode
+  variant?: 'info' | 'danger' | 'promotional'
+  onClose?: () => void
+  closable?: boolean
+  className?: string
+  'data-testid'?: string
+  buttonText?: string
+  onClickButton?: () => void
+}
+
+/**
+ * GlobalAlert is a component that is used to display a global alert message.
+ * It has its own internal state and can be closed by clicking on the close button.
+ */
 export const GlobalAlert = ({
   children,
-  sentiment = 'info',
-}: GlobalAlertProps) => (
-  <Container
-    justifyContent="center"
-    alignItems="center"
-    flex={1}
-    data-sentiment={sentiment}
-  >
-    {children}
-  </Container>
-)
+  variant = 'info',
+  onClose,
+  closable = true,
+  buttonText,
+  onClickButton,
+  className,
+  'data-testid': dataTestId,
+}: GlobalAlertProps) => {
+  const { theme } = useTheme()
+  const [opened, setOpened] = useReducer(value => !value, true)
+
+  if (!opened) return null
+
+  return (
+    <Container
+      justifyContent="center"
+      alignItems="center"
+      direction="row"
+      data-variant={variant}
+      data-testid={dataTestId}
+      className={className}
+    >
+      <Stack
+        gap={2}
+        direction="row"
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Text
+          variant="bodySmall"
+          as="p"
+          sentiment="neutral"
+          prominence={theme === 'light' ? 'stronger' : 'strong'}
+        >
+          {children}
+        </Text>
+        {onClickButton && buttonText ? (
+          <Button
+            onClick={onClickButton}
+            variant="filled"
+            sentiment="neutral"
+            size="small"
+          >
+            {buttonText}
+          </Button>
+        ) : null}
+      </Stack>
+      {closable ? (
+        <CloseButton
+          variant="filled"
+          size="xsmall"
+          icon="close"
+          sentiment="primary"
+          onClick={() => {
+            setOpened()
+            onClose?.()
+          }}
+        />
+      ) : null}
+    </Container>
+  )
+}
+
+GlobalAlert.Link = GlobalAlertLink

--- a/packages/ui/src/components/Link/__stories__/Variants.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/Variants.stories.tsx
@@ -1,0 +1,19 @@
+import type { Decorator } from '@storybook/react'
+import type { ComponentProps } from 'react'
+import { Link } from '..'
+import { Stack } from '../../Stack'
+
+export const Variants = (props: ComponentProps<typeof Link>) =>
+  (['inline', 'standalone'] as const).map(variant => (
+    <Link {...props} key={variant} variant={variant}>
+      {variant}
+    </Link>
+  ))
+
+Variants.decorators = [
+  StoryComponent => (
+    <Stack>
+      <StoryComponent />
+    </Stack>
+  ),
+] as Decorator[]

--- a/packages/ui/src/components/Link/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/index.stories.tsx
@@ -8,6 +8,7 @@ export default {
 
 export { Playground } from './Playground.stories'
 export { Sentiments } from './Sentiments.stories'
+export { Variants } from './Variants.stories'
 export { Target } from './Target.stories'
 export { Size } from './Size.stories'
 export { OneLine } from './OneLine.stories'

--- a/packages/ui/src/components/Link/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Link/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Link prominence render prominence default 1`] = `
 <DocumentFragment>
-  .cache-ihv4h0-StyledLink {
+  .cache-1ptg5vw-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -40,17 +40,17 @@ exports[`Link prominence render prominence default 1`] = `
   text-case: none;
 }
 
-.cache-ihv4h0-StyledLink .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-ihv4h0-StyledLink>* {
+.cache-1ptg5vw-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-ihv4h0-StyledLink:hover,
-.cache-ihv4h0-StyledLink:focus {
+.cache-1ptg5vw-StyledLink:hover,
+.cache-1ptg5vw-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -59,25 +59,32 @@ exports[`Link prominence render prominence default 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:hover .e1afnb7a2,
-.cache-ihv4h0-StyledLink:focus .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
+.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-ihv4h0-StyledLink:hover::after,
-.cache-ihv4h0-StyledLink:focus::after {
+.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ptg5vw-StyledLink:hover::after,
+.cache-1ptg5vw-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:active {
+.cache-1ptg5vw-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-ihv4h0-StyledLink e1afnb7a0"
+    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
     prominence="default"
   >
@@ -88,7 +95,7 @@ exports[`Link prominence render prominence default 1`] = `
 
 exports[`Link prominence render prominence strong 1`] = `
 <DocumentFragment>
-  .cache-14syxuu-StyledLink {
+  .cache-1lpfl92-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -126,17 +133,17 @@ exports[`Link prominence render prominence strong 1`] = `
   text-case: none;
 }
 
-.cache-14syxuu-StyledLink .e1afnb7a2 {
+.cache-1lpfl92-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-14syxuu-StyledLink>* {
+.cache-1lpfl92-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-14syxuu-StyledLink:hover,
-.cache-14syxuu-StyledLink:focus {
+.cache-1lpfl92-StyledLink:hover,
+.cache-1lpfl92-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -145,25 +152,32 @@ exports[`Link prominence render prominence strong 1`] = `
   text-decoration-color: #ffffff;
 }
 
-.cache-14syxuu-StyledLink:hover .e1afnb7a2,
-.cache-14syxuu-StyledLink:focus .e1afnb7a2 {
+.cache-1lpfl92-StyledLink:hover .e1afnb7a2,
+.cache-1lpfl92-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-14syxuu-StyledLink:hover::after,
-.cache-14syxuu-StyledLink:focus::after {
+.cache-1lpfl92-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1lpfl92-StyledLink:hover::after,
+.cache-1lpfl92-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-14syxuu-StyledLink:active {
+.cache-1lpfl92-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-14syxuu-StyledLink e1afnb7a0"
+    class="cache-1lpfl92-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
     prominence="strong"
   >
@@ -172,9 +186,102 @@ exports[`Link prominence render prominence strong 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Link prominence render prominence stronger 1`] = `
+<DocumentFragment>
+  .cache-1awn4d9-StyledLink {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  color: #3f4250;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  text-decoration-color: transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: text-decoration-color 250ms ease-out;
+  transition: text-decoration-color 250ms ease-out;
+  gap: 8px;
+  position: relative;
+  cursor: pointer;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  font-size: 16px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  paragraph-spacing: 0;
+  text-case: none;
+}
+
+.cache-1awn4d9-StyledLink .e1afnb7a2 {
+  -webkit-transition: -webkit-transform 250ms ease-out;
+  transition: transform 250ms ease-out;
+}
+
+.cache-1awn4d9-StyledLink>* {
+  pointer-events: none;
+}
+
+.cache-1awn4d9-StyledLink:hover,
+.cache-1awn4d9-StyledLink:focus {
+  outline: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  color: #3f4250;
+  text-decoration-color: #3f4250;
+}
+
+.cache-1awn4d9-StyledLink:hover .e1afnb7a2,
+.cache-1awn4d9-StyledLink:focus .e1afnb7a2 {
+  -webkit-transform: translate(-4px, 0);
+  -moz-transform: translate(-4px, 0);
+  -ms-transform: translate(-4px, 0);
+  transform: translate(-4px, 0);
+}
+
+.cache-1awn4d9-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1awn4d9-StyledLink:hover::after,
+.cache-1awn4d9-StyledLink:focus::after {
+  background-color: #005da3;
+}
+
+.cache-1awn4d9-StyledLink:active {
+  text-decoration-thickness: 2px;
+}
+
+<a
+    class="cache-1awn4d9-StyledLink e1afnb7a0"
+    data-variant="standalone"
+    href="/"
+    prominence="stronger"
+  >
+    Hello
+  </a>
+</DocumentFragment>
+`;
+
 exports[`Link prominence render prominence weak 1`] = `
 <DocumentFragment>
-  .cache-ihv4h0-StyledLink {
+  .cache-1ptg5vw-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -212,17 +319,17 @@ exports[`Link prominence render prominence weak 1`] = `
   text-case: none;
 }
 
-.cache-ihv4h0-StyledLink .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-ihv4h0-StyledLink>* {
+.cache-1ptg5vw-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-ihv4h0-StyledLink:hover,
-.cache-ihv4h0-StyledLink:focus {
+.cache-1ptg5vw-StyledLink:hover,
+.cache-1ptg5vw-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -231,25 +338,32 @@ exports[`Link prominence render prominence weak 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:hover .e1afnb7a2,
-.cache-ihv4h0-StyledLink:focus .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
+.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-ihv4h0-StyledLink:hover::after,
-.cache-ihv4h0-StyledLink:focus::after {
+.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ptg5vw-StyledLink:hover::after,
+.cache-1ptg5vw-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:active {
+.cache-1ptg5vw-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-ihv4h0-StyledLink e1afnb7a0"
+    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
     prominence="weak"
   >
@@ -260,7 +374,7 @@ exports[`Link prominence render prominence weak 1`] = `
 
 exports[`Link render correctly with bad sentiment 1`] = `
 <DocumentFragment>
-  .cache-2sbsfl-StyledLink {
+  .cache-lk8t2n-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -298,17 +412,17 @@ exports[`Link render correctly with bad sentiment 1`] = `
   text-case: none;
 }
 
-.cache-2sbsfl-StyledLink .e1afnb7a2 {
+.cache-lk8t2n-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-2sbsfl-StyledLink>* {
+.cache-lk8t2n-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-2sbsfl-StyledLink:hover,
-.cache-2sbsfl-StyledLink:focus {
+.cache-lk8t2n-StyledLink:hover,
+.cache-lk8t2n-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -317,25 +431,32 @@ exports[`Link render correctly with bad sentiment 1`] = `
   text-decoration-color: #3f4250;
 }
 
-.cache-2sbsfl-StyledLink:hover .e1afnb7a2,
-.cache-2sbsfl-StyledLink:focus .e1afnb7a2 {
+.cache-lk8t2n-StyledLink:hover .e1afnb7a2,
+.cache-lk8t2n-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-2sbsfl-StyledLink:hover::after,
-.cache-2sbsfl-StyledLink:focus::after {
+.cache-lk8t2n-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-lk8t2n-StyledLink:hover::after,
+.cache-lk8t2n-StyledLink:focus::after {
   background-color: #3f4250;
 }
 
-.cache-2sbsfl-StyledLink:active {
+.cache-lk8t2n-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-2sbsfl-StyledLink e1afnb7a0"
+    class="cache-lk8t2n-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -345,7 +466,7 @@ exports[`Link render correctly with bad sentiment 1`] = `
 
 exports[`Link render correctly with href props 1`] = `
 <DocumentFragment>
-  .cache-1tigebz-StyledLink {
+  .cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -383,17 +504,17 @@ exports[`Link render correctly with href props 1`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -402,25 +523,32 @@ exports[`Link render correctly with href props 1`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1tigebz-StyledLink e1afnb7a0"
+    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -430,7 +558,7 @@ exports[`Link render correctly with href props 1`] = `
 
 exports[`Link render correctly with href props 2`] = `
 <DocumentFragment>
-  .cache-100n8vz-StyledLink {
+  .cache-o4vvox-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -468,17 +596,17 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-100n8vz-StyledLink .e1afnb7a2 {
+.cache-o4vvox-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-100n8vz-StyledLink>* {
+.cache-o4vvox-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-100n8vz-StyledLink:hover,
-.cache-100n8vz-StyledLink:focus {
+.cache-o4vvox-StyledLink:hover,
+.cache-o4vvox-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -487,20 +615,26 @@ exports[`Link render correctly with href props 2`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-100n8vz-StyledLink:hover .e1afnb7a2,
-.cache-100n8vz-StyledLink:focus .e1afnb7a2 {
+.cache-o4vvox-StyledLink:hover .e1afnb7a2,
+.cache-o4vvox-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(4px, 0);
   -moz-transform: translate(4px, 0);
   -ms-transform: translate(4px, 0);
   transform: translate(4px, 0);
 }
 
-.cache-100n8vz-StyledLink:hover::after,
-.cache-100n8vz-StyledLink:focus::after {
+.cache-o4vvox-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-o4vvox-StyledLink:hover::after,
+.cache-o4vvox-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-100n8vz-StyledLink:active {
+.cache-o4vvox-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -514,7 +648,8 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-100n8vz-StyledLink e1afnb7a0"
+    class="cache-o4vvox-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     <svg
@@ -527,7 +662,7 @@ exports[`Link render correctly with href props 2`] = `
     </svg>
     Hello
   </a>
-  .cache-1tigebz-StyledLink {
+  .cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -565,17 +700,17 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -584,20 +719,26 @@ exports[`Link render correctly with href props 2`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -611,7 +752,8 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-1tigebz-StyledLink e1afnb7a0"
+    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -624,7 +766,7 @@ exports[`Link render correctly with href props 2`] = `
       />
     </svg>
   </a>
-  .cache-1tigebz-StyledLink {
+  .cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -662,17 +804,17 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -681,20 +823,26 @@ exports[`Link render correctly with href props 2`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -716,7 +864,8 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-1tigebz-StyledLink e1afnb7a0"
+    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
     rel="noopener noreferrer"
     target="_blank"
@@ -735,7 +884,7 @@ exports[`Link render correctly with href props 2`] = `
       </svg>
     </span>
   </a>
-  .cache-100n8vz-StyledLink {
+  .cache-o4vvox-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -773,17 +922,17 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-100n8vz-StyledLink .e1afnb7a2 {
+.cache-o4vvox-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-100n8vz-StyledLink>* {
+.cache-o4vvox-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-100n8vz-StyledLink:hover,
-.cache-100n8vz-StyledLink:focus {
+.cache-o4vvox-StyledLink:hover,
+.cache-o4vvox-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -792,20 +941,26 @@ exports[`Link render correctly with href props 2`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-100n8vz-StyledLink:hover .e1afnb7a2,
-.cache-100n8vz-StyledLink:focus .e1afnb7a2 {
+.cache-o4vvox-StyledLink:hover .e1afnb7a2,
+.cache-o4vvox-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(4px, 0);
   -moz-transform: translate(4px, 0);
   -ms-transform: translate(4px, 0);
   transform: translate(4px, 0);
 }
 
-.cache-100n8vz-StyledLink:hover::after,
-.cache-100n8vz-StyledLink:focus::after {
+.cache-o4vvox-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-o4vvox-StyledLink:hover::after,
+.cache-o4vvox-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-100n8vz-StyledLink:active {
+.cache-o4vvox-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -827,7 +982,8 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-100n8vz-StyledLink e1afnb7a0"
+    class="cache-o4vvox-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
     rel="noopener noreferrer"
     target="_blank"
@@ -851,7 +1007,7 @@ exports[`Link render correctly with href props 2`] = `
 
 exports[`Link render correctly with no sentiment 1`] = `
 <DocumentFragment>
-  .cache-ihv4h0-StyledLink {
+  .cache-1ptg5vw-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -889,17 +1045,17 @@ exports[`Link render correctly with no sentiment 1`] = `
   text-case: none;
 }
 
-.cache-ihv4h0-StyledLink .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-ihv4h0-StyledLink>* {
+.cache-1ptg5vw-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-ihv4h0-StyledLink:hover,
-.cache-ihv4h0-StyledLink:focus {
+.cache-1ptg5vw-StyledLink:hover,
+.cache-1ptg5vw-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -908,25 +1064,32 @@ exports[`Link render correctly with no sentiment 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:hover .e1afnb7a2,
-.cache-ihv4h0-StyledLink:focus .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
+.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-ihv4h0-StyledLink:hover::after,
-.cache-ihv4h0-StyledLink:focus::after {
+.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ptg5vw-StyledLink:hover::after,
+.cache-1ptg5vw-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:active {
+.cache-1ptg5vw-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-ihv4h0-StyledLink e1afnb7a0"
+    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -936,7 +1099,7 @@ exports[`Link render correctly with no sentiment 1`] = `
 
 exports[`Link render correctly with oneLine 1`] = `
 <DocumentFragment>
-  .cache-1qrexgi-StyledLink {
+  .cache-13rkwgk-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -975,17 +1138,17 @@ exports[`Link render correctly with oneLine 1`] = `
   text-case: none;
 }
 
-.cache-1qrexgi-StyledLink .e1afnb7a2 {
+.cache-13rkwgk-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1qrexgi-StyledLink>* {
+.cache-13rkwgk-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1qrexgi-StyledLink:hover,
-.cache-1qrexgi-StyledLink:focus {
+.cache-13rkwgk-StyledLink:hover,
+.cache-13rkwgk-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -994,20 +1157,26 @@ exports[`Link render correctly with oneLine 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-1qrexgi-StyledLink:hover .e1afnb7a2,
-.cache-1qrexgi-StyledLink:focus .e1afnb7a2 {
+.cache-13rkwgk-StyledLink:hover .e1afnb7a2,
+.cache-13rkwgk-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1qrexgi-StyledLink:hover::after,
-.cache-1qrexgi-StyledLink:focus::after {
+.cache-13rkwgk-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-13rkwgk-StyledLink:hover::after,
+.cache-13rkwgk-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1qrexgi-StyledLink:active {
+.cache-13rkwgk-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -1015,7 +1184,8 @@ exports[`Link render correctly with oneLine 1`] = `
     style="margin-bottom: 16px; margin-top: 8px; width: 200px;"
   >
     <a
-      class="cache-1qrexgi-StyledLink e1afnb7a0"
+      class="cache-13rkwgk-StyledLink e1afnb7a0"
+      data-variant="standalone"
       href="/"
     >
       Hello this is a very long text that should be truncated
@@ -1026,7 +1196,7 @@ exports[`Link render correctly with oneLine 1`] = `
 
 exports[`Link render correctly with sizes 1`] = `
 <DocumentFragment>
-  .cache-ihv4h0-StyledLink {
+  .cache-1ptg5vw-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1064,17 +1234,17 @@ exports[`Link render correctly with sizes 1`] = `
   text-case: none;
 }
 
-.cache-ihv4h0-StyledLink .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-ihv4h0-StyledLink>* {
+.cache-1ptg5vw-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-ihv4h0-StyledLink:hover,
-.cache-ihv4h0-StyledLink:focus {
+.cache-1ptg5vw-StyledLink:hover,
+.cache-1ptg5vw-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1083,31 +1253,38 @@ exports[`Link render correctly with sizes 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:hover .e1afnb7a2,
-.cache-ihv4h0-StyledLink:focus .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
+.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-ihv4h0-StyledLink:hover::after,
-.cache-ihv4h0-StyledLink:focus::after {
+.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ptg5vw-StyledLink:hover::after,
+.cache-1ptg5vw-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:active {
+.cache-1ptg5vw-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-ihv4h0-StyledLink e1afnb7a0"
+    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
   </a>
   ,
-  .cache-1ys335w-StyledLink {
+  .cache-1f4u5jc-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1145,17 +1322,17 @@ exports[`Link render correctly with sizes 1`] = `
   text-case: none;
 }
 
-.cache-1ys335w-StyledLink .e1afnb7a2 {
+.cache-1f4u5jc-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ys335w-StyledLink>* {
+.cache-1f4u5jc-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ys335w-StyledLink:hover,
-.cache-1ys335w-StyledLink:focus {
+.cache-1f4u5jc-StyledLink:hover,
+.cache-1f4u5jc-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1164,25 +1341,32 @@ exports[`Link render correctly with sizes 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-1ys335w-StyledLink:hover .e1afnb7a2,
-.cache-1ys335w-StyledLink:focus .e1afnb7a2 {
+.cache-1f4u5jc-StyledLink:hover .e1afnb7a2,
+.cache-1f4u5jc-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ys335w-StyledLink:hover::after,
-.cache-1ys335w-StyledLink:focus::after {
+.cache-1f4u5jc-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1f4u5jc-StyledLink:hover::after,
+.cache-1f4u5jc-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1ys335w-StyledLink:active {
+.cache-1f4u5jc-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ys335w-StyledLink e1afnb7a0"
+    class="cache-1f4u5jc-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -1193,7 +1377,7 @@ exports[`Link render correctly with sizes 1`] = `
 
 exports[`Link render correctly with target blank 1`] = `
 <DocumentFragment>
-  .cache-1tigebz-StyledLink {
+  .cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1231,17 +1415,17 @@ exports[`Link render correctly with target blank 1`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1250,20 +1434,26 @@ exports[`Link render correctly with target blank 1`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -1285,7 +1475,8 @@ exports[`Link render correctly with target blank 1`] = `
 }
 
 <a
-    class="cache-1tigebz-StyledLink e1afnb7a0"
+    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
     rel="noopener noreferrer"
     target="_blank"
@@ -1307,9 +1498,188 @@ exports[`Link render correctly with target blank 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Link render correctly with variants props 1`] = `
+<DocumentFragment>
+  .cache-1rk3jb4-StyledLink {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  color: #641cb3;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  text-decoration-color: transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: text-decoration-color 250ms ease-out;
+  transition: text-decoration-color 250ms ease-out;
+  gap: 8px;
+  position: relative;
+  cursor: pointer;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  font-size: 16px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  paragraph-spacing: 0;
+  text-case: none;
+}
+
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+  -webkit-transition: -webkit-transform 250ms ease-out;
+  transition: transform 250ms ease-out;
+}
+
+.cache-1rk3jb4-StyledLink>* {
+  pointer-events: none;
+}
+
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
+  outline: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  color: #641cb3;
+  text-decoration-color: #641cb3;
+}
+
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+  -webkit-transform: translate(-4px, 0);
+  -moz-transform: translate(-4px, 0);
+  -ms-transform: translate(-4px, 0);
+  transform: translate(-4px, 0);
+}
+
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
+  background-color: #641cb3;
+}
+
+.cache-1rk3jb4-StyledLink:active {
+  text-decoration-thickness: 2px;
+}
+
+<a
+    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    data-variant="inline"
+    href="/"
+  >
+    Hello
+  </a>
+  .cache-1rk3jb4-StyledLink {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  color: #641cb3;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  text-decoration-color: transparent;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: text-decoration-color 250ms ease-out;
+  transition: text-decoration-color 250ms ease-out;
+  gap: 8px;
+  position: relative;
+  cursor: pointer;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  font-size: 16px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  paragraph-spacing: 0;
+  text-case: none;
+}
+
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+  -webkit-transition: -webkit-transform 250ms ease-out;
+  transition: transform 250ms ease-out;
+}
+
+.cache-1rk3jb4-StyledLink>* {
+  pointer-events: none;
+}
+
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
+  outline: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  color: #641cb3;
+  text-decoration-color: #641cb3;
+}
+
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+  -webkit-transform: translate(-4px, 0);
+  -moz-transform: translate(-4px, 0);
+  -ms-transform: translate(-4px, 0);
+  transform: translate(-4px, 0);
+}
+
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
+  background-color: #641cb3;
+}
+
+.cache-1rk3jb4-StyledLink:active {
+  text-decoration-thickness: 2px;
+}
+
+<a
+    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    data-variant="standalone"
+    href="/"
+  >
+    Hello
+  </a>
+</DocumentFragment>
+`;
+
 exports[`Link sentiment render danger 1`] = `
 <DocumentFragment>
-  .cache-9ez2b5-StyledLink {
+  .cache-1ny05v1-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1347,17 +1717,17 @@ exports[`Link sentiment render danger 1`] = `
   text-case: none;
 }
 
-.cache-9ez2b5-StyledLink .e1afnb7a2 {
+.cache-1ny05v1-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-9ez2b5-StyledLink>* {
+.cache-1ny05v1-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-9ez2b5-StyledLink:hover,
-.cache-9ez2b5-StyledLink:focus {
+.cache-1ny05v1-StyledLink:hover,
+.cache-1ny05v1-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1366,25 +1736,32 @@ exports[`Link sentiment render danger 1`] = `
   text-decoration-color: #b3144d;
 }
 
-.cache-9ez2b5-StyledLink:hover .e1afnb7a2,
-.cache-9ez2b5-StyledLink:focus .e1afnb7a2 {
+.cache-1ny05v1-StyledLink:hover .e1afnb7a2,
+.cache-1ny05v1-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-9ez2b5-StyledLink:hover::after,
-.cache-9ez2b5-StyledLink:focus::after {
+.cache-1ny05v1-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ny05v1-StyledLink:hover::after,
+.cache-1ny05v1-StyledLink:focus::after {
   background-color: #b3144d;
 }
 
-.cache-9ez2b5-StyledLink:active {
+.cache-1ny05v1-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-9ez2b5-StyledLink e1afnb7a0"
+    class="cache-1ny05v1-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -1394,7 +1771,7 @@ exports[`Link sentiment render danger 1`] = `
 
 exports[`Link sentiment render info 1`] = `
 <DocumentFragment>
-  .cache-ihv4h0-StyledLink {
+  .cache-1ptg5vw-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1432,17 +1809,17 @@ exports[`Link sentiment render info 1`] = `
   text-case: none;
 }
 
-.cache-ihv4h0-StyledLink .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-ihv4h0-StyledLink>* {
+.cache-1ptg5vw-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-ihv4h0-StyledLink:hover,
-.cache-ihv4h0-StyledLink:focus {
+.cache-1ptg5vw-StyledLink:hover,
+.cache-1ptg5vw-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1451,25 +1828,32 @@ exports[`Link sentiment render info 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:hover .e1afnb7a2,
-.cache-ihv4h0-StyledLink:focus .e1afnb7a2 {
+.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
+.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-ihv4h0-StyledLink:hover::after,
-.cache-ihv4h0-StyledLink:focus::after {
+.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1ptg5vw-StyledLink:hover::after,
+.cache-1ptg5vw-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-ihv4h0-StyledLink:active {
+.cache-1ptg5vw-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-ihv4h0-StyledLink e1afnb7a0"
+    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -1479,7 +1863,7 @@ exports[`Link sentiment render info 1`] = `
 
 exports[`Link sentiment render neutral 1`] = `
 <DocumentFragment>
-  .cache-2sbsfl-StyledLink {
+  .cache-lk8t2n-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1517,17 +1901,17 @@ exports[`Link sentiment render neutral 1`] = `
   text-case: none;
 }
 
-.cache-2sbsfl-StyledLink .e1afnb7a2 {
+.cache-lk8t2n-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-2sbsfl-StyledLink>* {
+.cache-lk8t2n-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-2sbsfl-StyledLink:hover,
-.cache-2sbsfl-StyledLink:focus {
+.cache-lk8t2n-StyledLink:hover,
+.cache-lk8t2n-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1536,25 +1920,32 @@ exports[`Link sentiment render neutral 1`] = `
   text-decoration-color: #3f4250;
 }
 
-.cache-2sbsfl-StyledLink:hover .e1afnb7a2,
-.cache-2sbsfl-StyledLink:focus .e1afnb7a2 {
+.cache-lk8t2n-StyledLink:hover .e1afnb7a2,
+.cache-lk8t2n-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-2sbsfl-StyledLink:hover::after,
-.cache-2sbsfl-StyledLink:focus::after {
+.cache-lk8t2n-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-lk8t2n-StyledLink:hover::after,
+.cache-lk8t2n-StyledLink:focus::after {
   background-color: #3f4250;
 }
 
-.cache-2sbsfl-StyledLink:active {
+.cache-lk8t2n-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-2sbsfl-StyledLink e1afnb7a0"
+    class="cache-lk8t2n-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -1564,7 +1955,7 @@ exports[`Link sentiment render neutral 1`] = `
 
 exports[`Link sentiment render primary 1`] = `
 <DocumentFragment>
-  .cache-1tigebz-StyledLink {
+  .cache-1rk3jb4-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1602,17 +1993,17 @@ exports[`Link sentiment render primary 1`] = `
   text-case: none;
 }
 
-.cache-1tigebz-StyledLink .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1tigebz-StyledLink>* {
+.cache-1rk3jb4-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1tigebz-StyledLink:hover,
-.cache-1tigebz-StyledLink:focus {
+.cache-1rk3jb4-StyledLink:hover,
+.cache-1rk3jb4-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1621,25 +2012,32 @@ exports[`Link sentiment render primary 1`] = `
   text-decoration-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:hover .e1afnb7a2,
-.cache-1tigebz-StyledLink:focus .e1afnb7a2 {
+.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
+.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1tigebz-StyledLink:hover::after,
-.cache-1tigebz-StyledLink:focus::after {
+.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1rk3jb4-StyledLink:hover::after,
+.cache-1rk3jb4-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1tigebz-StyledLink:active {
+.cache-1rk3jb4-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1tigebz-StyledLink e1afnb7a0"
+    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -1649,7 +2047,7 @@ exports[`Link sentiment render primary 1`] = `
 
 exports[`Link sentiment render secondary 1`] = `
 <DocumentFragment>
-  .cache-1ip9cnb-StyledLink {
+  .cache-11lp9by-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1687,17 +2085,17 @@ exports[`Link sentiment render secondary 1`] = `
   text-case: none;
 }
 
-.cache-1ip9cnb-StyledLink .e1afnb7a2 {
+.cache-11lp9by-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ip9cnb-StyledLink>* {
+.cache-11lp9by-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ip9cnb-StyledLink:hover,
-.cache-1ip9cnb-StyledLink:focus {
+.cache-11lp9by-StyledLink:hover,
+.cache-11lp9by-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1706,25 +2104,32 @@ exports[`Link sentiment render secondary 1`] = `
   text-decoration-color: #ac22e7;
 }
 
-.cache-1ip9cnb-StyledLink:hover .e1afnb7a2,
-.cache-1ip9cnb-StyledLink:focus .e1afnb7a2 {
+.cache-11lp9by-StyledLink:hover .e1afnb7a2,
+.cache-11lp9by-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ip9cnb-StyledLink:hover::after,
-.cache-1ip9cnb-StyledLink:focus::after {
+.cache-11lp9by-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-11lp9by-StyledLink:hover::after,
+.cache-11lp9by-StyledLink:focus::after {
   background-color: #ac22e7;
 }
 
-.cache-1ip9cnb-StyledLink:active {
+.cache-11lp9by-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ip9cnb-StyledLink e1afnb7a0"
+    class="cache-11lp9by-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -1734,7 +2139,7 @@ exports[`Link sentiment render secondary 1`] = `
 
 exports[`Link sentiment render success 1`] = `
 <DocumentFragment>
-  .cache-1fi3om-StyledLink {
+  .cache-j4v288-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1772,17 +2177,17 @@ exports[`Link sentiment render success 1`] = `
   text-case: none;
 }
 
-.cache-1fi3om-StyledLink .e1afnb7a2 {
+.cache-j4v288-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1fi3om-StyledLink>* {
+.cache-j4v288-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1fi3om-StyledLink:hover,
-.cache-1fi3om-StyledLink:focus {
+.cache-j4v288-StyledLink:hover,
+.cache-j4v288-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1791,25 +2196,32 @@ exports[`Link sentiment render success 1`] = `
   text-decoration-color: #22674e;
 }
 
-.cache-1fi3om-StyledLink:hover .e1afnb7a2,
-.cache-1fi3om-StyledLink:focus .e1afnb7a2 {
+.cache-j4v288-StyledLink:hover .e1afnb7a2,
+.cache-j4v288-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1fi3om-StyledLink:hover::after,
-.cache-1fi3om-StyledLink:focus::after {
+.cache-j4v288-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-j4v288-StyledLink:hover::after,
+.cache-j4v288-StyledLink:focus::after {
   background-color: #22674e;
 }
 
-.cache-1fi3om-StyledLink:active {
+.cache-j4v288-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1fi3om-StyledLink e1afnb7a0"
+    class="cache-j4v288-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello
@@ -1819,7 +2231,7 @@ exports[`Link sentiment render success 1`] = `
 
 exports[`Link sentiment render warning 1`] = `
 <DocumentFragment>
-  .cache-338xm8-StyledLink {
+  .cache-d6r5dr-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1857,17 +2269,17 @@ exports[`Link sentiment render warning 1`] = `
   text-case: none;
 }
 
-.cache-338xm8-StyledLink .e1afnb7a2 {
+.cache-d6r5dr-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-338xm8-StyledLink>* {
+.cache-d6r5dr-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-338xm8-StyledLink:hover,
-.cache-338xm8-StyledLink:focus {
+.cache-d6r5dr-StyledLink:hover,
+.cache-d6r5dr-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -1876,25 +2288,32 @@ exports[`Link sentiment render warning 1`] = `
   text-decoration-color: #7c5400;
 }
 
-.cache-338xm8-StyledLink:hover .e1afnb7a2,
-.cache-338xm8-StyledLink:focus .e1afnb7a2 {
+.cache-d6r5dr-StyledLink:hover .e1afnb7a2,
+.cache-d6r5dr-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-338xm8-StyledLink:hover::after,
-.cache-338xm8-StyledLink:focus::after {
+.cache-d6r5dr-StyledLink[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-d6r5dr-StyledLink:hover::after,
+.cache-d6r5dr-StyledLink:focus::after {
   background-color: #7c5400;
 }
 
-.cache-338xm8-StyledLink:active {
+.cache-d6r5dr-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-338xm8-StyledLink e1afnb7a0"
+    class="cache-d6r5dr-StyledLink e1afnb7a0"
+    data-variant="standalone"
     href="/"
   >
     Hello

--- a/packages/ui/src/components/Link/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Link/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Link prominence render prominence default 1`] = `
 <DocumentFragment>
-  .cache-1ptg5vw-StyledLink {
+  .cache-jzq3t2-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -40,50 +40,50 @@ exports[`Link prominence render prominence default 1`] = `
   text-case: none;
 }
 
-.cache-1ptg5vw-StyledLink .e1afnb7a2 {
+.cache-jzq3t2-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ptg5vw-StyledLink>* {
+.cache-jzq3t2-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ptg5vw-StyledLink:hover,
-.cache-1ptg5vw-StyledLink:focus {
+.cache-jzq3t2-StyledLink:hover,
+.cache-jzq3t2-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
-.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
+.cache-jzq3t2-StyledLink:hover .e1afnb7a2,
+.cache-jzq3t2-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+.cache-jzq3t2-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ptg5vw-StyledLink:hover::after,
-.cache-1ptg5vw-StyledLink:focus::after {
+.cache-jzq3t2-StyledLink:hover::after,
+.cache-jzq3t2-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1ptg5vw-StyledLink:active {
+.cache-jzq3t2-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    class="cache-jzq3t2-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
     prominence="default"
@@ -95,7 +95,7 @@ exports[`Link prominence render prominence default 1`] = `
 
 exports[`Link prominence render prominence strong 1`] = `
 <DocumentFragment>
-  .cache-1lpfl92-StyledLink {
+  .cache-1bhysvz-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -133,50 +133,50 @@ exports[`Link prominence render prominence strong 1`] = `
   text-case: none;
 }
 
-.cache-1lpfl92-StyledLink .e1afnb7a2 {
+.cache-1bhysvz-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1lpfl92-StyledLink>* {
+.cache-1bhysvz-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1lpfl92-StyledLink:hover,
-.cache-1lpfl92-StyledLink:focus {
+.cache-1bhysvz-StyledLink:hover,
+.cache-1bhysvz-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #ffffff;
-  text-decoration-color: #ffffff;
+  color: #f9f9fa;
+  text-decoration-color: #f9f9fa;
 }
 
-.cache-1lpfl92-StyledLink:hover .e1afnb7a2,
-.cache-1lpfl92-StyledLink:focus .e1afnb7a2 {
+.cache-1bhysvz-StyledLink:hover .e1afnb7a2,
+.cache-1bhysvz-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1lpfl92-StyledLink[data-variant='inline'] {
+.cache-1bhysvz-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1lpfl92-StyledLink:hover::after,
-.cache-1lpfl92-StyledLink:focus::after {
+.cache-1bhysvz-StyledLink:hover::after,
+.cache-1bhysvz-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1lpfl92-StyledLink:active {
+.cache-1bhysvz-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1lpfl92-StyledLink e1afnb7a0"
+    class="cache-1bhysvz-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
     prominence="strong"
@@ -188,7 +188,7 @@ exports[`Link prominence render prominence strong 1`] = `
 
 exports[`Link prominence render prominence stronger 1`] = `
 <DocumentFragment>
-  .cache-1awn4d9-StyledLink {
+  .cache-1n90v43-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -226,50 +226,50 @@ exports[`Link prominence render prominence stronger 1`] = `
   text-case: none;
 }
 
-.cache-1awn4d9-StyledLink .e1afnb7a2 {
+.cache-1n90v43-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1awn4d9-StyledLink>* {
+.cache-1n90v43-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1awn4d9-StyledLink:hover,
-.cache-1awn4d9-StyledLink:focus {
+.cache-1n90v43-StyledLink:hover,
+.cache-1n90v43-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #3f4250;
-  text-decoration-color: #3f4250;
+  color: #222638;
+  text-decoration-color: #222638;
 }
 
-.cache-1awn4d9-StyledLink:hover .e1afnb7a2,
-.cache-1awn4d9-StyledLink:focus .e1afnb7a2 {
+.cache-1n90v43-StyledLink:hover .e1afnb7a2,
+.cache-1n90v43-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1awn4d9-StyledLink[data-variant='inline'] {
+.cache-1n90v43-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1awn4d9-StyledLink:hover::after,
-.cache-1awn4d9-StyledLink:focus::after {
+.cache-1n90v43-StyledLink:hover::after,
+.cache-1n90v43-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1awn4d9-StyledLink:active {
+.cache-1n90v43-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1awn4d9-StyledLink e1afnb7a0"
+    class="cache-1n90v43-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
     prominence="stronger"
@@ -281,7 +281,7 @@ exports[`Link prominence render prominence stronger 1`] = `
 
 exports[`Link prominence render prominence weak 1`] = `
 <DocumentFragment>
-  .cache-1ptg5vw-StyledLink {
+  .cache-jzq3t2-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -319,50 +319,50 @@ exports[`Link prominence render prominence weak 1`] = `
   text-case: none;
 }
 
-.cache-1ptg5vw-StyledLink .e1afnb7a2 {
+.cache-jzq3t2-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ptg5vw-StyledLink>* {
+.cache-jzq3t2-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ptg5vw-StyledLink:hover,
-.cache-1ptg5vw-StyledLink:focus {
+.cache-jzq3t2-StyledLink:hover,
+.cache-jzq3t2-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
-.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
+.cache-jzq3t2-StyledLink:hover .e1afnb7a2,
+.cache-jzq3t2-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+.cache-jzq3t2-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ptg5vw-StyledLink:hover::after,
-.cache-1ptg5vw-StyledLink:focus::after {
+.cache-jzq3t2-StyledLink:hover::after,
+.cache-jzq3t2-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1ptg5vw-StyledLink:active {
+.cache-jzq3t2-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    class="cache-jzq3t2-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
     prominence="weak"
@@ -374,7 +374,7 @@ exports[`Link prominence render prominence weak 1`] = `
 
 exports[`Link render correctly with bad sentiment 1`] = `
 <DocumentFragment>
-  .cache-lk8t2n-StyledLink {
+  .cache-k0a54d-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -412,50 +412,50 @@ exports[`Link render correctly with bad sentiment 1`] = `
   text-case: none;
 }
 
-.cache-lk8t2n-StyledLink .e1afnb7a2 {
+.cache-k0a54d-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-lk8t2n-StyledLink>* {
+.cache-k0a54d-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-lk8t2n-StyledLink:hover,
-.cache-lk8t2n-StyledLink:focus {
+.cache-k0a54d-StyledLink:hover,
+.cache-k0a54d-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #3f4250;
-  text-decoration-color: #3f4250;
+  color: #222638;
+  text-decoration-color: #222638;
 }
 
-.cache-lk8t2n-StyledLink:hover .e1afnb7a2,
-.cache-lk8t2n-StyledLink:focus .e1afnb7a2 {
+.cache-k0a54d-StyledLink:hover .e1afnb7a2,
+.cache-k0a54d-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-lk8t2n-StyledLink[data-variant='inline'] {
+.cache-k0a54d-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-lk8t2n-StyledLink:hover::after,
-.cache-lk8t2n-StyledLink:focus::after {
+.cache-k0a54d-StyledLink:hover::after,
+.cache-k0a54d-StyledLink:focus::after {
   background-color: #3f4250;
 }
 
-.cache-lk8t2n-StyledLink:active {
+.cache-k0a54d-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-lk8t2n-StyledLink e1afnb7a0"
+    class="cache-k0a54d-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -466,7 +466,7 @@ exports[`Link render correctly with bad sentiment 1`] = `
 
 exports[`Link render correctly with href props 1`] = `
 <DocumentFragment>
-  .cache-1rk3jb4-StyledLink {
+  .cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -504,50 +504,50 @@ exports[`Link render correctly with href props 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    class="cache-1erdb2u-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -558,7 +558,7 @@ exports[`Link render correctly with href props 1`] = `
 
 exports[`Link render correctly with href props 2`] = `
 <DocumentFragment>
-  .cache-o4vvox-StyledLink {
+  .cache-1y94hd0-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -596,45 +596,45 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-o4vvox-StyledLink .e1afnb7a2 {
+.cache-1y94hd0-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-o4vvox-StyledLink>* {
+.cache-1y94hd0-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-o4vvox-StyledLink:hover,
-.cache-o4vvox-StyledLink:focus {
+.cache-1y94hd0-StyledLink:hover,
+.cache-1y94hd0-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-o4vvox-StyledLink:hover .e1afnb7a2,
-.cache-o4vvox-StyledLink:focus .e1afnb7a2 {
+.cache-1y94hd0-StyledLink:hover .e1afnb7a2,
+.cache-1y94hd0-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(4px, 0);
   -moz-transform: translate(4px, 0);
   -ms-transform: translate(4px, 0);
   transform: translate(4px, 0);
 }
 
-.cache-o4vvox-StyledLink[data-variant='inline'] {
+.cache-1y94hd0-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-o4vvox-StyledLink:hover::after,
-.cache-o4vvox-StyledLink:focus::after {
+.cache-1y94hd0-StyledLink:hover::after,
+.cache-1y94hd0-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-o4vvox-StyledLink:active {
+.cache-1y94hd0-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -648,7 +648,7 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-o4vvox-StyledLink e1afnb7a0"
+    class="cache-1y94hd0-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -662,7 +662,7 @@ exports[`Link render correctly with href props 2`] = `
     </svg>
     Hello
   </a>
-  .cache-1rk3jb4-StyledLink {
+  .cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -700,45 +700,45 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -752,7 +752,7 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    class="cache-1erdb2u-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -766,7 +766,7 @@ exports[`Link render correctly with href props 2`] = `
       />
     </svg>
   </a>
-  .cache-1rk3jb4-StyledLink {
+  .cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -804,45 +804,45 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -864,7 +864,7 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    class="cache-1erdb2u-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
     rel="noopener noreferrer"
@@ -884,7 +884,7 @@ exports[`Link render correctly with href props 2`] = `
       </svg>
     </span>
   </a>
-  .cache-o4vvox-StyledLink {
+  .cache-1y94hd0-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -922,45 +922,45 @@ exports[`Link render correctly with href props 2`] = `
   text-case: none;
 }
 
-.cache-o4vvox-StyledLink .e1afnb7a2 {
+.cache-1y94hd0-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-o4vvox-StyledLink>* {
+.cache-1y94hd0-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-o4vvox-StyledLink:hover,
-.cache-o4vvox-StyledLink:focus {
+.cache-1y94hd0-StyledLink:hover,
+.cache-1y94hd0-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-o4vvox-StyledLink:hover .e1afnb7a2,
-.cache-o4vvox-StyledLink:focus .e1afnb7a2 {
+.cache-1y94hd0-StyledLink:hover .e1afnb7a2,
+.cache-1y94hd0-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(4px, 0);
   -moz-transform: translate(4px, 0);
   -ms-transform: translate(4px, 0);
   transform: translate(4px, 0);
 }
 
-.cache-o4vvox-StyledLink[data-variant='inline'] {
+.cache-1y94hd0-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-o4vvox-StyledLink:hover::after,
-.cache-o4vvox-StyledLink:focus::after {
+.cache-1y94hd0-StyledLink:hover::after,
+.cache-1y94hd0-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-o4vvox-StyledLink:active {
+.cache-1y94hd0-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -982,7 +982,7 @@ exports[`Link render correctly with href props 2`] = `
 }
 
 <a
-    class="cache-o4vvox-StyledLink e1afnb7a0"
+    class="cache-1y94hd0-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
     rel="noopener noreferrer"
@@ -1007,7 +1007,7 @@ exports[`Link render correctly with href props 2`] = `
 
 exports[`Link render correctly with no sentiment 1`] = `
 <DocumentFragment>
-  .cache-1ptg5vw-StyledLink {
+  .cache-jzq3t2-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1045,50 +1045,50 @@ exports[`Link render correctly with no sentiment 1`] = `
   text-case: none;
 }
 
-.cache-1ptg5vw-StyledLink .e1afnb7a2 {
+.cache-jzq3t2-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ptg5vw-StyledLink>* {
+.cache-jzq3t2-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ptg5vw-StyledLink:hover,
-.cache-1ptg5vw-StyledLink:focus {
+.cache-jzq3t2-StyledLink:hover,
+.cache-jzq3t2-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
-.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
+.cache-jzq3t2-StyledLink:hover .e1afnb7a2,
+.cache-jzq3t2-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+.cache-jzq3t2-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ptg5vw-StyledLink:hover::after,
-.cache-1ptg5vw-StyledLink:focus::after {
+.cache-jzq3t2-StyledLink:hover::after,
+.cache-jzq3t2-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1ptg5vw-StyledLink:active {
+.cache-jzq3t2-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    class="cache-jzq3t2-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -1099,7 +1099,7 @@ exports[`Link render correctly with no sentiment 1`] = `
 
 exports[`Link render correctly with oneLine 1`] = `
 <DocumentFragment>
-  .cache-13rkwgk-StyledLink {
+  .cache-u5ms8t-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1138,45 +1138,45 @@ exports[`Link render correctly with oneLine 1`] = `
   text-case: none;
 }
 
-.cache-13rkwgk-StyledLink .e1afnb7a2 {
+.cache-u5ms8t-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-13rkwgk-StyledLink>* {
+.cache-u5ms8t-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-13rkwgk-StyledLink:hover,
-.cache-13rkwgk-StyledLink:focus {
+.cache-u5ms8t-StyledLink:hover,
+.cache-u5ms8t-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-13rkwgk-StyledLink:hover .e1afnb7a2,
-.cache-13rkwgk-StyledLink:focus .e1afnb7a2 {
+.cache-u5ms8t-StyledLink:hover .e1afnb7a2,
+.cache-u5ms8t-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-13rkwgk-StyledLink[data-variant='inline'] {
+.cache-u5ms8t-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-13rkwgk-StyledLink:hover::after,
-.cache-13rkwgk-StyledLink:focus::after {
+.cache-u5ms8t-StyledLink:hover::after,
+.cache-u5ms8t-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-13rkwgk-StyledLink:active {
+.cache-u5ms8t-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -1184,7 +1184,7 @@ exports[`Link render correctly with oneLine 1`] = `
     style="margin-bottom: 16px; margin-top: 8px; width: 200px;"
   >
     <a
-      class="cache-13rkwgk-StyledLink e1afnb7a0"
+      class="cache-u5ms8t-StyledLink e1afnb7a0"
       data-variant="standalone"
       href="/"
     >
@@ -1196,7 +1196,7 @@ exports[`Link render correctly with oneLine 1`] = `
 
 exports[`Link render correctly with sizes 1`] = `
 <DocumentFragment>
-  .cache-1ptg5vw-StyledLink {
+  .cache-jzq3t2-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1234,57 +1234,57 @@ exports[`Link render correctly with sizes 1`] = `
   text-case: none;
 }
 
-.cache-1ptg5vw-StyledLink .e1afnb7a2 {
+.cache-jzq3t2-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ptg5vw-StyledLink>* {
+.cache-jzq3t2-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ptg5vw-StyledLink:hover,
-.cache-1ptg5vw-StyledLink:focus {
+.cache-jzq3t2-StyledLink:hover,
+.cache-jzq3t2-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
-.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
+.cache-jzq3t2-StyledLink:hover .e1afnb7a2,
+.cache-jzq3t2-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+.cache-jzq3t2-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ptg5vw-StyledLink:hover::after,
-.cache-1ptg5vw-StyledLink:focus::after {
+.cache-jzq3t2-StyledLink:hover::after,
+.cache-jzq3t2-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1ptg5vw-StyledLink:active {
+.cache-jzq3t2-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    class="cache-jzq3t2-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
     Hello
   </a>
   ,
-  .cache-1f4u5jc-StyledLink {
+  .cache-j2fist-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1322,50 +1322,50 @@ exports[`Link render correctly with sizes 1`] = `
   text-case: none;
 }
 
-.cache-1f4u5jc-StyledLink .e1afnb7a2 {
+.cache-j2fist-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1f4u5jc-StyledLink>* {
+.cache-j2fist-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1f4u5jc-StyledLink:hover,
-.cache-1f4u5jc-StyledLink:focus {
+.cache-j2fist-StyledLink:hover,
+.cache-j2fist-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1f4u5jc-StyledLink:hover .e1afnb7a2,
-.cache-1f4u5jc-StyledLink:focus .e1afnb7a2 {
+.cache-j2fist-StyledLink:hover .e1afnb7a2,
+.cache-j2fist-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1f4u5jc-StyledLink[data-variant='inline'] {
+.cache-j2fist-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1f4u5jc-StyledLink:hover::after,
-.cache-1f4u5jc-StyledLink:focus::after {
+.cache-j2fist-StyledLink:hover::after,
+.cache-j2fist-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1f4u5jc-StyledLink:active {
+.cache-j2fist-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1f4u5jc-StyledLink e1afnb7a0"
+    class="cache-j2fist-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -1377,7 +1377,7 @@ exports[`Link render correctly with sizes 1`] = `
 
 exports[`Link render correctly with target blank 1`] = `
 <DocumentFragment>
-  .cache-1rk3jb4-StyledLink {
+  .cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1415,45 +1415,45 @@ exports[`Link render correctly with target blank 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -1475,7 +1475,7 @@ exports[`Link render correctly with target blank 1`] = `
 }
 
 <a
-    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    class="cache-1erdb2u-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
     rel="noopener noreferrer"
@@ -1500,7 +1500,7 @@ exports[`Link render correctly with target blank 1`] = `
 
 exports[`Link render correctly with variants props 1`] = `
 <DocumentFragment>
-  .cache-1rk3jb4-StyledLink {
+  .cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1538,56 +1538,56 @@ exports[`Link render correctly with variants props 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    class="cache-1erdb2u-StyledLink e1afnb7a0"
     data-variant="inline"
     href="/"
   >
     Hello
   </a>
-  .cache-1rk3jb4-StyledLink {
+  .cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1625,50 +1625,50 @@ exports[`Link render correctly with variants props 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    class="cache-1erdb2u-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -1679,7 +1679,7 @@ exports[`Link render correctly with variants props 1`] = `
 
 exports[`Link sentiment render danger 1`] = `
 <DocumentFragment>
-  .cache-1ny05v1-StyledLink {
+  .cache-6kni59-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1717,50 +1717,50 @@ exports[`Link sentiment render danger 1`] = `
   text-case: none;
 }
 
-.cache-1ny05v1-StyledLink .e1afnb7a2 {
+.cache-6kni59-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ny05v1-StyledLink>* {
+.cache-6kni59-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ny05v1-StyledLink:hover,
-.cache-1ny05v1-StyledLink:focus {
+.cache-6kni59-StyledLink:hover,
+.cache-6kni59-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #b3144d;
-  text-decoration-color: #b3144d;
+  color: #92103f;
+  text-decoration-color: #92103f;
 }
 
-.cache-1ny05v1-StyledLink:hover .e1afnb7a2,
-.cache-1ny05v1-StyledLink:focus .e1afnb7a2 {
+.cache-6kni59-StyledLink:hover .e1afnb7a2,
+.cache-6kni59-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ny05v1-StyledLink[data-variant='inline'] {
+.cache-6kni59-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ny05v1-StyledLink:hover::after,
-.cache-1ny05v1-StyledLink:focus::after {
+.cache-6kni59-StyledLink:hover::after,
+.cache-6kni59-StyledLink:focus::after {
   background-color: #b3144d;
 }
 
-.cache-1ny05v1-StyledLink:active {
+.cache-6kni59-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ny05v1-StyledLink e1afnb7a0"
+    class="cache-6kni59-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -1771,7 +1771,7 @@ exports[`Link sentiment render danger 1`] = `
 
 exports[`Link sentiment render info 1`] = `
 <DocumentFragment>
-  .cache-1ptg5vw-StyledLink {
+  .cache-jzq3t2-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1809,50 +1809,50 @@ exports[`Link sentiment render info 1`] = `
   text-case: none;
 }
 
-.cache-1ptg5vw-StyledLink .e1afnb7a2 {
+.cache-jzq3t2-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1ptg5vw-StyledLink>* {
+.cache-jzq3t2-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1ptg5vw-StyledLink:hover,
-.cache-1ptg5vw-StyledLink:focus {
+.cache-jzq3t2-StyledLink:hover,
+.cache-jzq3t2-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1ptg5vw-StyledLink:hover .e1afnb7a2,
-.cache-1ptg5vw-StyledLink:focus .e1afnb7a2 {
+.cache-jzq3t2-StyledLink:hover .e1afnb7a2,
+.cache-jzq3t2-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1ptg5vw-StyledLink[data-variant='inline'] {
+.cache-jzq3t2-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1ptg5vw-StyledLink:hover::after,
-.cache-1ptg5vw-StyledLink:focus::after {
+.cache-jzq3t2-StyledLink:hover::after,
+.cache-jzq3t2-StyledLink:focus::after {
   background-color: #005da3;
 }
 
-.cache-1ptg5vw-StyledLink:active {
+.cache-jzq3t2-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1ptg5vw-StyledLink e1afnb7a0"
+    class="cache-jzq3t2-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -1863,7 +1863,7 @@ exports[`Link sentiment render info 1`] = `
 
 exports[`Link sentiment render neutral 1`] = `
 <DocumentFragment>
-  .cache-lk8t2n-StyledLink {
+  .cache-k0a54d-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1901,50 +1901,50 @@ exports[`Link sentiment render neutral 1`] = `
   text-case: none;
 }
 
-.cache-lk8t2n-StyledLink .e1afnb7a2 {
+.cache-k0a54d-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-lk8t2n-StyledLink>* {
+.cache-k0a54d-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-lk8t2n-StyledLink:hover,
-.cache-lk8t2n-StyledLink:focus {
+.cache-k0a54d-StyledLink:hover,
+.cache-k0a54d-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #3f4250;
-  text-decoration-color: #3f4250;
+  color: #222638;
+  text-decoration-color: #222638;
 }
 
-.cache-lk8t2n-StyledLink:hover .e1afnb7a2,
-.cache-lk8t2n-StyledLink:focus .e1afnb7a2 {
+.cache-k0a54d-StyledLink:hover .e1afnb7a2,
+.cache-k0a54d-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-lk8t2n-StyledLink[data-variant='inline'] {
+.cache-k0a54d-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-lk8t2n-StyledLink:hover::after,
-.cache-lk8t2n-StyledLink:focus::after {
+.cache-k0a54d-StyledLink:hover::after,
+.cache-k0a54d-StyledLink:focus::after {
   background-color: #3f4250;
 }
 
-.cache-lk8t2n-StyledLink:active {
+.cache-k0a54d-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-lk8t2n-StyledLink e1afnb7a0"
+    class="cache-k0a54d-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -1955,7 +1955,7 @@ exports[`Link sentiment render neutral 1`] = `
 
 exports[`Link sentiment render primary 1`] = `
 <DocumentFragment>
-  .cache-1rk3jb4-StyledLink {
+  .cache-1erdb2u-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -1993,50 +1993,50 @@ exports[`Link sentiment render primary 1`] = `
   text-case: none;
 }
 
-.cache-1rk3jb4-StyledLink .e1afnb7a2 {
+.cache-1erdb2u-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1rk3jb4-StyledLink>* {
+.cache-1erdb2u-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-1rk3jb4-StyledLink:hover,
-.cache-1rk3jb4-StyledLink:focus {
+.cache-1erdb2u-StyledLink:hover,
+.cache-1erdb2u-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #641cb3;
-  text-decoration-color: #641cb3;
+  color: #521094;
+  text-decoration-color: #521094;
 }
 
-.cache-1rk3jb4-StyledLink:hover .e1afnb7a2,
-.cache-1rk3jb4-StyledLink:focus .e1afnb7a2 {
+.cache-1erdb2u-StyledLink:hover .e1afnb7a2,
+.cache-1erdb2u-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1rk3jb4-StyledLink[data-variant='inline'] {
+.cache-1erdb2u-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1rk3jb4-StyledLink:hover::after,
-.cache-1rk3jb4-StyledLink:focus::after {
+.cache-1erdb2u-StyledLink:hover::after,
+.cache-1erdb2u-StyledLink:focus::after {
   background-color: #641cb3;
 }
 
-.cache-1rk3jb4-StyledLink:active {
+.cache-1erdb2u-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-1rk3jb4-StyledLink e1afnb7a0"
+    class="cache-1erdb2u-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -2047,7 +2047,7 @@ exports[`Link sentiment render primary 1`] = `
 
 exports[`Link sentiment render secondary 1`] = `
 <DocumentFragment>
-  .cache-11lp9by-StyledLink {
+  .cache-6dylcc-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -2085,50 +2085,50 @@ exports[`Link sentiment render secondary 1`] = `
   text-case: none;
 }
 
-.cache-11lp9by-StyledLink .e1afnb7a2 {
+.cache-6dylcc-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-11lp9by-StyledLink>* {
+.cache-6dylcc-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-11lp9by-StyledLink:hover,
-.cache-11lp9by-StyledLink:focus {
+.cache-6dylcc-StyledLink:hover,
+.cache-6dylcc-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #ac22e7;
-  text-decoration-color: #ac22e7;
+  color: #8f1cc2;
+  text-decoration-color: #8f1cc2;
 }
 
-.cache-11lp9by-StyledLink:hover .e1afnb7a2,
-.cache-11lp9by-StyledLink:focus .e1afnb7a2 {
+.cache-6dylcc-StyledLink:hover .e1afnb7a2,
+.cache-6dylcc-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-11lp9by-StyledLink[data-variant='inline'] {
+.cache-6dylcc-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-11lp9by-StyledLink:hover::after,
-.cache-11lp9by-StyledLink:focus::after {
+.cache-6dylcc-StyledLink:hover::after,
+.cache-6dylcc-StyledLink:focus::after {
   background-color: #ac22e7;
 }
 
-.cache-11lp9by-StyledLink:active {
+.cache-6dylcc-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-11lp9by-StyledLink e1afnb7a0"
+    class="cache-6dylcc-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -2139,7 +2139,7 @@ exports[`Link sentiment render secondary 1`] = `
 
 exports[`Link sentiment render success 1`] = `
 <DocumentFragment>
-  .cache-j4v288-StyledLink {
+  .cache-19h48de-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -2177,50 +2177,50 @@ exports[`Link sentiment render success 1`] = `
   text-case: none;
 }
 
-.cache-j4v288-StyledLink .e1afnb7a2 {
+.cache-19h48de-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-j4v288-StyledLink>* {
+.cache-19h48de-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-j4v288-StyledLink:hover,
-.cache-j4v288-StyledLink:focus {
+.cache-19h48de-StyledLink:hover,
+.cache-19h48de-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #22674e;
-  text-decoration-color: #22674e;
+  color: #1b533f;
+  text-decoration-color: #1b533f;
 }
 
-.cache-j4v288-StyledLink:hover .e1afnb7a2,
-.cache-j4v288-StyledLink:focus .e1afnb7a2 {
+.cache-19h48de-StyledLink:hover .e1afnb7a2,
+.cache-19h48de-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-j4v288-StyledLink[data-variant='inline'] {
+.cache-19h48de-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-j4v288-StyledLink:hover::after,
-.cache-j4v288-StyledLink:focus::after {
+.cache-19h48de-StyledLink:hover::after,
+.cache-19h48de-StyledLink:focus::after {
   background-color: #22674e;
 }
 
-.cache-j4v288-StyledLink:active {
+.cache-19h48de-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-j4v288-StyledLink e1afnb7a0"
+    class="cache-19h48de-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >
@@ -2231,7 +2231,7 @@ exports[`Link sentiment render success 1`] = `
 
 exports[`Link sentiment render warning 1`] = `
 <DocumentFragment>
-  .cache-d6r5dr-StyledLink {
+  .cache-1hft7lf-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -2269,50 +2269,50 @@ exports[`Link sentiment render warning 1`] = `
   text-case: none;
 }
 
-.cache-d6r5dr-StyledLink .e1afnb7a2 {
+.cache-1hft7lf-StyledLink .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-d6r5dr-StyledLink>* {
+.cache-1hft7lf-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-d6r5dr-StyledLink:hover,
-.cache-d6r5dr-StyledLink:focus {
+.cache-1hft7lf-StyledLink:hover,
+.cache-1hft7lf-StyledLink:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #7c5400;
-  text-decoration-color: #7c5400;
+  color: #664300;
+  text-decoration-color: #664300;
 }
 
-.cache-d6r5dr-StyledLink:hover .e1afnb7a2,
-.cache-d6r5dr-StyledLink:focus .e1afnb7a2 {
+.cache-1hft7lf-StyledLink:hover .e1afnb7a2,
+.cache-1hft7lf-StyledLink:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-d6r5dr-StyledLink[data-variant='inline'] {
+.cache-1hft7lf-StyledLink[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-d6r5dr-StyledLink:hover::after,
-.cache-d6r5dr-StyledLink:focus::after {
+.cache-1hft7lf-StyledLink:hover::after,
+.cache-1hft7lf-StyledLink:focus::after {
   background-color: #7c5400;
 }
 
-.cache-d6r5dr-StyledLink:active {
+.cache-1hft7lf-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
 <a
-    class="cache-d6r5dr-StyledLink e1afnb7a0"
+    class="cache-1hft7lf-StyledLink e1afnb7a0"
     data-variant="standalone"
     href="/"
   >

--- a/packages/ui/src/components/Link/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Link/__tests__/index.test.tsx
@@ -68,6 +68,18 @@ describe('Link', () => {
       </>,
     ))
 
+  test(`render correctly with variants props`, () =>
+    shouldMatchEmotionSnapshot(
+      <>
+        <Link sentiment="primary" href="/" variant="inline">
+          Hello
+        </Link>
+        <Link sentiment="primary" href="/" variant="standalone">
+          Hello
+        </Link>
+      </>,
+    ))
+
   test(`render correctly with bad sentiment`, () =>
     shouldMatchEmotionSnapshot(
       // @ts-expect-error Use a wrong sentiment

--- a/packages/ui/src/components/Link/index.tsx
+++ b/packages/ui/src/components/Link/index.tsx
@@ -20,6 +20,7 @@ export const PROMINENCES = {
   default: '',
   weak: 'weak',
   strong: 'strong',
+  stronger: 'stronger',
 }
 
 export type ProminenceProps = keyof typeof PROMINENCES
@@ -42,6 +43,7 @@ type LinkProps = {
   'aria-label'?: string
   oneLine?: boolean
   'data-testid'?: string
+  variant?: 'inline' | 'standalone'
 }
 
 const ICON_SIZE = 16
@@ -141,6 +143,11 @@ const StyledLink = styled('a', {
     }}
   }
 
+  &[data-variant='inline'] {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+  }
+
   &:hover::after,
   &:focus::after {
     background-color: ${({ theme, sentiment }) =>
@@ -172,6 +179,7 @@ export const Link = forwardRef(
       'aria-label': ariaLabel,
       oneLine = false,
       'data-testid': dataTestId,
+      variant = 'standalone',
     }: LinkProps,
     ref: ForwardedRef<HTMLAnchorElement>,
   ) => {
@@ -208,6 +216,7 @@ export const Link = forwardRef(
           aria-label={ariaLabel}
           oneLine={oneLine}
           data-testid={dataTestId}
+          data-variant={variant}
         >
           {!isBlank && iconPosition === 'left' ? (
             <StyledIcon name="arrow-left" size={ICON_SIZE} />

--- a/packages/ui/src/components/Link/index.tsx
+++ b/packages/ui/src/components/Link/index.tsx
@@ -133,12 +133,14 @@ const StyledLink = styled('a', {
     ${({ theme, sentiment, prominence }) => {
       const definedProminence = capitalize(PROMINENCES[prominence ?? 'default'])
       const themeColor = theme.colors[sentiment]
-      const text = `text${definedProminence}` as keyof typeof themeColor
+      const text = `text${definedProminence}Hover` as keyof typeof themeColor
 
       return `
-        color: ${theme.colors[sentiment]?.[text] ?? theme.colors.neutral.text};
+        color: ${
+          theme.colors[sentiment]?.[text] ?? theme.colors.neutral.textHover
+        };
         text-decoration-color: ${
-          theme.colors[sentiment]?.[text] ?? theme.colors.neutral.text
+          theme.colors[sentiment]?.[text] ?? theme.colors.neutral.textHover
         };`
     }}
   }

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -3029,7 +3029,7 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton {
+.cache-1olgjpb-StyledLink-StyledTabButton {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -3106,93 +3106,93 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   line-height: 24px;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton .e1afnb7a2 {
+.cache-1olgjpb-StyledLink-StyledTabButton .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton>* {
+.cache-1olgjpb-StyledLink-StyledTabButton>* {
   pointer-events: none;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton:hover,
-.cache-1sfkqzi-StyledLink-StyledTabButton:focus {
+.cache-1olgjpb-StyledLink-StyledTabButton:hover,
+.cache-1olgjpb-StyledLink-StyledTabButton:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  color: #005da3;
-  text-decoration-color: #005da3;
+  color: #004c85;
+  text-decoration-color: #004c85;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton:hover .e1afnb7a2,
-.cache-1sfkqzi-StyledLink-StyledTabButton:focus .e1afnb7a2 {
+.cache-1olgjpb-StyledLink-StyledTabButton:hover .e1afnb7a2,
+.cache-1olgjpb-StyledLink-StyledTabButton:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton[data-variant='inline'] {
+.cache-1olgjpb-StyledLink-StyledTabButton[data-variant='inline'] {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton:hover::after,
-.cache-1sfkqzi-StyledLink-StyledTabButton:focus::after {
+.cache-1olgjpb-StyledLink-StyledTabButton:hover::after,
+.cache-1olgjpb-StyledLink-StyledTabButton:focus::after {
   background-color: #005da3;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton:active {
+.cache-1olgjpb-StyledLink-StyledTabButton:active {
   text-decoration-thickness: 2px;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton:hover,
-.cache-1sfkqzi-StyledLink-StyledTabButton:active,
-.cache-1sfkqzi-StyledLink-StyledTabButton:focus {
+.cache-1olgjpb-StyledLink-StyledTabButton:hover,
+.cache-1olgjpb-StyledLink-StyledTabButton:active,
+.cache-1olgjpb-StyledLink-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton:focus-visible {
+.cache-1olgjpb-StyledLink-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-selected='true'] {
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-selected='true'] {
   color: #641cb3;
   border-bottom-color: #8c40ef;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-selected='true'] .e1hzf7cr3 {
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-selected='true'] .e1hzf7cr3 {
   color: #641cb3;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #641cb3;
   border-bottom-color: #8c40ef;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr4,
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr4,
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr4 {
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr4,
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr4,
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr4 {
   background-color: #f1eefc;
   border-color: #f1eefc;
   color: #641cb3;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr3,
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr3,
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr3 {
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr3,
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr3,
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr3 {
   color: #641cb3;
 }
 
-.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='true'],
-.cache-1sfkqzi-StyledLink-StyledTabButton:disabled {
+.cache-1olgjpb-StyledLink-StyledTabButton[aria-disabled='true'],
+.cache-1olgjpb-StyledLink-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
@@ -3237,7 +3237,7 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
       </div>
     </a>
     <a
-      class="e1hzf7cr0 cache-1sfkqzi-StyledLink-StyledTabButton e1afnb7a0"
+      class="e1hzf7cr0 cache-1olgjpb-StyledLink-StyledTabButton e1afnb7a0"
       data-variant="standalone"
       href="#"
     >

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -3029,7 +3029,7 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton {
+.cache-1sfkqzi-StyledLink-StyledTabButton {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -3106,17 +3106,17 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   line-height: 24px;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton .e1afnb7a2 {
+.cache-1sfkqzi-StyledLink-StyledTabButton .e1afnb7a2 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton>* {
+.cache-1sfkqzi-StyledLink-StyledTabButton>* {
   pointer-events: none;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton:hover,
-.cache-1um138k-StyledLink-StyledTabButton:focus {
+.cache-1sfkqzi-StyledLink-StyledTabButton:hover,
+.cache-1sfkqzi-StyledLink-StyledTabButton:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -3125,68 +3125,74 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   text-decoration-color: #005da3;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton:hover .e1afnb7a2,
-.cache-1um138k-StyledLink-StyledTabButton:focus .e1afnb7a2 {
+.cache-1sfkqzi-StyledLink-StyledTabButton:hover .e1afnb7a2,
+.cache-1sfkqzi-StyledLink-StyledTabButton:focus .e1afnb7a2 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-1um138k-StyledLink-StyledTabButton:hover::after,
-.cache-1um138k-StyledLink-StyledTabButton:focus::after {
+.cache-1sfkqzi-StyledLink-StyledTabButton[data-variant='inline'] {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+}
+
+.cache-1sfkqzi-StyledLink-StyledTabButton:hover::after,
+.cache-1sfkqzi-StyledLink-StyledTabButton:focus::after {
   background-color: #005da3;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton:active {
+.cache-1sfkqzi-StyledLink-StyledTabButton:active {
   text-decoration-thickness: 2px;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton:hover,
-.cache-1um138k-StyledLink-StyledTabButton:active,
-.cache-1um138k-StyledLink-StyledTabButton:focus {
+.cache-1sfkqzi-StyledLink-StyledTabButton:hover,
+.cache-1sfkqzi-StyledLink-StyledTabButton:active,
+.cache-1sfkqzi-StyledLink-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton:focus-visible {
+.cache-1sfkqzi-StyledLink-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton[aria-selected='true'] {
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-selected='true'] {
   color: #641cb3;
   border-bottom-color: #8c40ef;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton[aria-selected='true'] .e1hzf7cr3 {
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-selected='true'] .e1hzf7cr3 {
   color: #641cb3;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #641cb3;
   border-bottom-color: #8c40ef;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr4,
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr4,
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr4 {
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr4,
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr4,
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr4 {
   background-color: #f1eefc;
   border-color: #f1eefc;
   color: #641cb3;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr3,
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr3,
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr3 {
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover[data-is-selected='false'] .e1hzf7cr3,
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus[data-is-selected='false'] .e1hzf7cr3,
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active[data-is-selected='false'] .e1hzf7cr3 {
   color: #641cb3;
 }
 
-.cache-1um138k-StyledLink-StyledTabButton[aria-disabled='true'],
-.cache-1um138k-StyledLink-StyledTabButton:disabled {
+.cache-1sfkqzi-StyledLink-StyledTabButton[aria-disabled='true'],
+.cache-1sfkqzi-StyledLink-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
@@ -3231,7 +3237,8 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
       </div>
     </a>
     <a
-      class="e1hzf7cr0 cache-1um138k-StyledLink-StyledTabButton e1afnb7a0"
+      class="e1hzf7cr0 cache-1sfkqzi-StyledLink-StyledTabButton e1afnb7a0"
+      data-variant="standalone"
       href="#"
     >
       <div

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -66,3 +66,4 @@ export {
   Icon,
 } from '@ultraviolet/icons'
 export { MenuV2 } from './MenuV2'
+export { GlobalAlert } from './GlobalAlert'


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

- New `<GlobalAlert />` component
- New prop `variant` for `<Link />` component:
  - `variant="standalone"` (default): renders a standalone link without underline
  - `variant="inline"`: renders an inline link with underline

## Relevant logs and/or screenshots

<img width="980" alt="Screenshot 2023-11-21 at 18 41 27" src="https://github.com/scaleway/ultraviolet/assets/15812968/023d8ae5-07b9-48cb-b9a3-83854b235333">
<img width="979" alt="Screenshot 2023-11-21 at 18 41 33" src="https://github.com/scaleway/ultraviolet/assets/15812968/28a0ae2a-defb-4050-b668-2799890d620e">
<img width="176" alt="Screenshot 2023-11-21 at 18 41 41" src="https://github.com/scaleway/ultraviolet/assets/15812968/c6aedaed-dbe1-45cf-8e69-e6abd76ff036">

