### PR TITLE
docs(storybook): add more clarity into storybook about sub components

### DIFF
--- a/packages/plus/src/components/ContentCardGroup/__stories__/index.stories.tsx
+++ b/packages/plus/src/components/ContentCardGroup/__stories__/index.stories.tsx
@@ -4,7 +4,7 @@ import { ContentCardGroup } from '..'
 export default {
   component: ContentCardGroup,
   title: 'Plus/Compositions/ContentCardGroup',
-  subcomponents: { Card: ContentCardGroup.Card },
+  subcomponents: { 'ContentCardGroup.Card': ContentCardGroup.Card },
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/Breadcrumbs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/index.stories.tsx
@@ -3,7 +3,7 @@ import { Breadcrumbs, Item } from '..'
 
 export default {
   component: Breadcrumbs,
-  subcomponents: { Item },
+  subcomponents: { 'Breadcrumbs.Item': Item },
   title: 'Components/Navigation/Breadcrumbs',
 } as Meta
 

--- a/packages/ui/src/components/Carousel/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Carousel/__stories__/index.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta } from '@storybook/react'
-import { Carousel, CarouselItem } from '..'
+import { Carousel } from '..'
 
 export default {
   component: Carousel,
   title: 'Components/Data Display/Carousel',
-  subcomponents: { CarouselItem },
+  subcomponents: { 'Carousel.Item': Carousel.Item },
 } as Meta<typeof Carousel>
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/Table/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/index.stories.tsx
@@ -4,7 +4,7 @@ import { Table } from '..'
 export default {
   component: Table,
   title: 'Components/Data Display/Table',
-  subcomponents: { Row: Table.Row, Cell: Table.Cell },
+  subcomponents: { 'Table.Row': Table.Row, 'Table.Cell': Table.Cell },
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/Tabs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Tabs/__stories__/index.stories.tsx
@@ -1,10 +1,9 @@
 import type { Meta } from '@storybook/react'
 import { Tabs } from '..'
-import { Tab } from '../Tab'
 
 export default {
   component: Tabs,
-  subcomponents: { Tab },
+  subcomponents: { 'Tabs.Tab': Tabs.Tab },
   title: 'Components/Navigation/Tabs',
 } as Meta<typeof Tabs>
 


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Improvement of the clarity of storybook by adding correct sub component name. I can't fix the issue with snippet as Storybook doesn't seems to support it. There is an open issue about it here: https://github.com/storybookjs/storybook/issues/11919

Before:
![Screenshot 2023-11-22 at 10 51 19](https://github.com/scaleway/ultraviolet/assets/15812968/15c987fc-ab6c-40e2-be92-7856edb619ef)


After:
![Screenshot 2023-11-22 at 10 51 22](https://github.com/scaleway/ultraviolet/assets/15812968/c0b98847-55cf-4249-aaf3-b28421a85f45)
