### PR TITLE
fix(Tag): to display tooltip when tag content is too long

### DIFF
--- a/.changeset/pink-dolphins-approve.md
+++ b/.changeset/pink-dolphins-approve.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/form': patch
+'@ultraviolet/ui': patch
+---
+
+Add a tooltip on `<Tag />` component when text is too long

--- a/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -179,14 +179,19 @@ exports[`ToggleField should render correctly with default tags 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-td7tdt {
+.cache-13ui0sz {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1i4ofie {
@@ -300,8 +305,7 @@ exports[`ToggleField should render correctly with default tags 1`] = `
         class="cache-1j7jvp7 el6733p2"
       >
         <span
-          aria-disabled="false"
-          class="cache-td7tdt el6733p1"
+          class="el6733p1 cache-13ui0sz e13y3mga0"
         >
           tags-1
         </span>
@@ -325,8 +329,7 @@ exports[`ToggleField should render correctly with default tags 1`] = `
         class="cache-1j7jvp7 el6733p2"
       >
         <span
-          aria-disabled="false"
-          class="cache-td7tdt el6733p1"
+          class="el6733p1 cache-13ui0sz e13y3mga0"
         >
           tags-2
         </span>
@@ -416,14 +419,19 @@ exports[`ToggleField should render correctly with default tags on initialValues 
   border: solid 1px #d9dadd;
 }
 
-.cache-td7tdt {
+.cache-13ui0sz {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1i4ofie {
@@ -537,8 +545,7 @@ exports[`ToggleField should render correctly with default tags on initialValues 
         class="cache-1j7jvp7 el6733p2"
       >
         <span
-          aria-disabled="false"
-          class="cache-td7tdt el6733p1"
+          class="el6733p1 cache-13ui0sz e13y3mga0"
         >
           tags-1
         </span>
@@ -562,8 +569,7 @@ exports[`ToggleField should render correctly with default tags on initialValues 
         class="cache-1j7jvp7 el6733p2"
       >
         <span
-          aria-disabled="false"
-          class="cache-td7tdt el6733p1"
+          class="el6733p1 cache-13ui0sz e13y3mga0"
         >
           tags-2
         </span>
@@ -653,14 +659,19 @@ exports[`ToggleField should render correctly with default tags on initialValues 
   border: solid 1px #d9dadd;
 }
 
-.cache-td7tdt {
+.cache-13ui0sz {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1i4ofie {
@@ -774,8 +785,7 @@ exports[`ToggleField should render correctly with default tags on initialValues 
         class="cache-1j7jvp7 el6733p2"
       >
         <span
-          aria-disabled="false"
-          class="cache-td7tdt el6733p1"
+          class="el6733p1 cache-13ui0sz e13y3mga0"
         >
           tags-1
         </span>
@@ -799,8 +809,7 @@ exports[`ToggleField should render correctly with default tags on initialValues 
         class="cache-1j7jvp7 el6733p2"
       >
         <span
-          aria-disabled="false"
-          class="cache-td7tdt el6733p1"
+          class="el6733p1 cache-13ui0sz e13y3mga0"
         >
           tags-2
         </span>
@@ -824,8 +833,7 @@ exports[`ToggleField should render correctly with default tags on initialValues 
         class="cache-1j7jvp7 el6733p2"
       >
         <span
-          aria-disabled="false"
-          class="cache-td7tdt el6733p1"
+          class="el6733p1 cache-13ui0sz e13y3mga0"
         >
           test
         </span>

--- a/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -28,22 +28,26 @@ exports[`Tag renders correctly 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <span
     class="cache-1anauza-StyledContainer el6733p2"
   >
     <span
-      aria-disabled="false"
-      class="cache-t6vuyb-StyledTag el6733p1"
+      class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
     >
       test
     </span>
@@ -79,22 +83,26 @@ exports[`Tag renders correctly colored 1`] = `
   border: solid 1px #f1eefc;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <span
     class="cache-144rp8c-StyledContainer el6733p2"
   >
     <span
-      aria-disabled="false"
-      class="cache-t6vuyb-StyledTag el6733p1"
+      class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
     >
       test
     </span>
@@ -131,22 +139,26 @@ exports[`Tag renders correctly disabled 1`] = `
   cursor: not-allowed;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <span
     class="cache-4ijz8s-StyledContainer el6733p2"
   >
     <span
-      aria-disabled="true"
-      class="cache-t6vuyb-StyledTag el6733p1"
+      class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
     >
       test
     </span>
@@ -182,22 +194,26 @@ exports[`Tag renders correctly neutral 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <span
     class="cache-1anauza-StyledContainer el6733p2"
   >
     <span
-      aria-disabled="false"
-      class="cache-t6vuyb-StyledTag el6733p1"
+      class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
     >
       test
     </span>
@@ -252,19 +268,24 @@ exports[`Tag renders correctly with copiable 1`] = `
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <div
-    aria-controls=":r1:"
-    aria-describedby=":r1:"
+    aria-controls=":r8:"
+    aria-describedby=":r8:"
     class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
     tabindex="0"
   >
@@ -272,8 +293,7 @@ exports[`Tag renders correctly with copiable 1`] = `
       class="cache-gkklu9-Container-StyledContainer el6733p3"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         test
       </span>
@@ -319,14 +339,19 @@ exports[`Tag renders correctly with icon 1`] = `
   min-height: 16px;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <span
@@ -341,8 +366,7 @@ exports[`Tag renders correctly with icon 1`] = `
       />
     </svg>
     <span
-      aria-disabled="false"
-      class="cache-t6vuyb-StyledTag el6733p1"
+      class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
     >
       test
     </span>
@@ -378,14 +402,19 @@ exports[`Tag renders correctly with isLoading 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-cmn72i-StyledSvg {
@@ -402,8 +431,7 @@ exports[`Tag renders correctly with isLoading 1`] = `
     class="cache-1anauza-StyledContainer el6733p2"
   >
     <span
-      aria-disabled="false"
-      class="cache-t6vuyb-StyledTag el6733p1"
+      class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
     >
       test
     </span>
@@ -471,14 +499,19 @@ exports[`Tag renders correctly with onClose 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -555,8 +588,7 @@ exports[`Tag renders correctly with onClose 1`] = `
     class="cache-1anauza-StyledContainer el6733p2"
   >
     <span
-      aria-disabled="false"
-      class="cache-t6vuyb-StyledTag el6733p1"
+      class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
     >
       test
     </span>

--- a/packages/ui/src/components/Tag/index.tsx
+++ b/packages/ui/src/components/Tag/index.tsx
@@ -5,6 +5,7 @@ import useClipboard from 'react-use-clipboard'
 import type { Color } from '../../theme'
 import { Button } from '../Button'
 import { Loader } from '../Loader'
+import { Text } from '../Text'
 import { Tooltip } from '../Tooltip'
 
 type IconName = ComponentProps<typeof Icon>['name']
@@ -63,14 +64,8 @@ const StyledContainer = styled('span', {
   }}
 `
 
-const StyledTag = styled.span`
-  font-size: 12px;
-  font-weight: 500;
-  color: inherit;
+const StyledText = styled(Text)`
   max-width: 232px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 `
 
 type TagProps = {
@@ -110,7 +105,9 @@ const TagInner = ({
 }: TagInnerProps) => (
   <>
     {icon ? <Icon name={icon} size={16} /> : null}
-    <StyledTag aria-disabled={disabled}>{children}</StyledTag>
+    <StyledText as="span" variant="caption" oneLine aria-disabled={disabled}>
+      {children}
+    </StyledText>
 
     {/* @check: Size issue here, Clickable icon ? */}
     {onClose && !isLoading ? (

--- a/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -57,14 +57,19 @@ exports[`TagInput add tag from input 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -175,8 +180,7 @@ exports[`TagInput add tag from input 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -200,8 +204,7 @@ exports[`TagInput add tag from input 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -225,8 +228,7 @@ exports[`TagInput add tag from input 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         test
       </span>
@@ -316,14 +318,19 @@ exports[`TagInput add tag from input with error 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -434,8 +441,7 @@ exports[`TagInput add tag from input with error 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -459,8 +465,7 @@ exports[`TagInput add tag from input with error 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -550,14 +555,19 @@ exports[`TagInput add tag on paste 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -668,8 +678,7 @@ exports[`TagInput add tag on paste 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -693,8 +702,7 @@ exports[`TagInput add tag on paste 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -718,8 +726,7 @@ exports[`TagInput add tag on paste 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         test
       </span>
@@ -809,14 +816,19 @@ exports[`TagInput add tag on paste with error 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -927,8 +939,7 @@ exports[`TagInput add tag on paste with error 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -952,8 +963,7 @@ exports[`TagInput add tag on paste with error 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -1043,14 +1053,19 @@ exports[`TagInput delete tag 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -1161,8 +1176,7 @@ exports[`TagInput delete tag 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -1252,14 +1266,19 @@ exports[`TagInput delete tag with backspace 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -1370,8 +1389,7 @@ exports[`TagInput delete tag with backspace 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -1461,14 +1479,19 @@ exports[`TagInput delete tag with error 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-cmn72i-StyledSvg {
@@ -1589,8 +1612,7 @@ exports[`TagInput delete tag with error 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         throw
       </span>
@@ -1631,8 +1653,7 @@ exports[`TagInput delete tag with error 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         error
       </span>
@@ -1723,14 +1744,19 @@ exports[`TagInput renders correctly when disabled 1`] = `
   cursor: not-allowed;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1itpb4h-StyledGhostButton-StyledCloseButton {
@@ -1801,8 +1827,7 @@ exports[`TagInput renders correctly when disabled 1`] = `
       class="cache-4ijz8s-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="true"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -1827,8 +1852,7 @@ exports[`TagInput renders correctly when disabled 1`] = `
       class="cache-4ijz8s-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="true"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -1910,14 +1934,19 @@ exports[`TagInput renders correctly when manualInput is disabled 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -1997,8 +2026,7 @@ exports[`TagInput renders correctly when manualInput is disabled 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -2022,8 +2050,7 @@ exports[`TagInput renders correctly when manualInput is disabled 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -2104,14 +2131,19 @@ exports[`TagInput renders correctly when variant = base 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -2222,8 +2254,7 @@ exports[`TagInput renders correctly when variant = base 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -2247,8 +2278,7 @@ exports[`TagInput renders correctly when variant = base 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -2334,14 +2364,19 @@ exports[`TagInput renders correctly when variant = bordered 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -2452,8 +2487,7 @@ exports[`TagInput renders correctly when variant = bordered 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -2477,8 +2511,7 @@ exports[`TagInput renders correctly when variant = bordered 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -2559,14 +2592,19 @@ exports[`TagInput renders correctly when variant = no-border 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -2677,8 +2715,7 @@ exports[`TagInput renders correctly when variant = no-border 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -2702,8 +2739,7 @@ exports[`TagInput renders correctly when variant = no-border 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -2869,14 +2905,19 @@ exports[`TagInput renders correctly with some tags 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -2987,8 +3028,7 @@ exports[`TagInput renders correctly with some tags 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -3012,8 +3052,7 @@ exports[`TagInput renders correctly with some tags 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -3102,14 +3141,19 @@ exports[`TagInput renders correctly with some tags 2`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -3220,8 +3264,7 @@ exports[`TagInput renders correctly with some tags 2`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -3245,8 +3288,7 @@ exports[`TagInput renders correctly with some tags 2`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -3335,14 +3377,19 @@ exports[`TagInput renders correctly with some tags as objects 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -3453,8 +3500,7 @@ exports[`TagInput renders correctly with some tags as objects 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -3478,8 +3524,7 @@ exports[`TagInput renders correctly with some tags as objects 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>
@@ -3568,14 +3613,19 @@ exports[`TagInput renders correctly with some tags objects 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-sitm2s-StyledGhostButton-StyledCloseButton {
@@ -3686,8 +3736,7 @@ exports[`TagInput renders correctly with some tags objects 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         hello
       </span>
@@ -3711,8 +3760,7 @@ exports[`TagInput renders correctly with some tags objects 1`] = `
       class="cache-1anauza-StyledContainer el6733p2"
     >
       <span
-        aria-disabled="false"
-        class="cache-t6vuyb-StyledTag el6733p1"
+        class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
       >
         world
       </span>

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -48,14 +48,19 @@ exports[`TagList renders correctly 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1hzk1lh-StyledChildrenContainer {
@@ -94,16 +99,15 @@ exports[`TagList renders correctly 1`] = `
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             scaleway
           </span>
         </span>
       </div>
       <div
-        aria-controls=":r0:"
-        aria-describedby=":r0:"
+        aria-controls=":r1:"
+        aria-describedby=":r1:"
         class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
         tabindex="-1"
       >
@@ -186,14 +190,19 @@ exports[`TagList renders correctly with copiable 1`] = `
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <div>
@@ -204,8 +213,8 @@ exports[`TagList renders correctly with copiable 1`] = `
         class="cache-1alpvce-StyledTagContainer eb6op480"
       >
         <div
-          aria-controls=":r4:"
-          aria-describedby=":r4:"
+          aria-controls=":rc:"
+          aria-describedby=":rc:"
           class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
           tabindex="0"
         >
@@ -213,16 +222,15 @@ exports[`TagList renders correctly with copiable 1`] = `
             class="cache-gkklu9-Container-StyledContainer el6733p3"
           >
             <span
-              aria-disabled="false"
-              class="cache-t6vuyb-StyledTag el6733p1"
+              class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
             >
               scaleway
             </span>
           </button>
         </div>
         <div
-          aria-controls=":r5:"
-          aria-describedby=":r5:"
+          aria-controls=":re:"
+          aria-describedby=":re:"
           class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
           tabindex="0"
         >
@@ -230,8 +238,7 @@ exports[`TagList renders correctly with copiable 1`] = `
             class="cache-gkklu9-Container-StyledContainer el6733p3"
           >
             <span
-              aria-disabled="false"
-              class="cache-t6vuyb-StyledTag el6733p1"
+              class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
             >
               cloud
             </span>
@@ -291,14 +298,19 @@ exports[`TagList renders correctly with custom threshold 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <div>
@@ -312,8 +324,7 @@ exports[`TagList renders correctly with custom threshold 1`] = `
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             scaleway
           </span>
@@ -322,8 +333,7 @@ exports[`TagList renders correctly with custom threshold 1`] = `
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             cloud
           </span>
@@ -382,14 +392,19 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1hzk1lh-StyledChildrenContainer {
@@ -428,8 +443,7 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             scaleway
           </span>
@@ -438,16 +452,15 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             cloud
           </span>
         </span>
       </div>
       <div
-        aria-controls=":r1:"
-        aria-describedby=":r1:"
+        aria-controls=":r6:"
+        aria-describedby=":r6:"
         class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
         tabindex="-1"
       >
@@ -511,14 +524,19 @@ exports[`TagList renders correctly with custom threshold and extra tags and maxL
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1hzk1lh-StyledChildrenContainer {
@@ -557,16 +575,15 @@ exports[`TagList renders correctly with custom threshold and extra tags and maxL
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             scaleway
           </span>
         </span>
       </div>
       <div
-        aria-controls=":r2:"
-        aria-describedby=":r2:"
+        aria-controls=":r8:"
+        aria-describedby=":r8:"
         class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
         tabindex="-1"
       >
@@ -649,14 +666,19 @@ exports[`TagList renders correctly with icons 1`] = `
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 <div>
@@ -667,8 +689,8 @@ exports[`TagList renders correctly with icons 1`] = `
         class="cache-1alpvce-StyledTagContainer eb6op480"
       >
         <div
-          aria-controls=":r6:"
-          aria-describedby=":r6:"
+          aria-controls=":rg:"
+          aria-describedby=":rg:"
           class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
           tabindex="0"
         >
@@ -676,16 +698,15 @@ exports[`TagList renders correctly with icons 1`] = `
             class="cache-gkklu9-Container-StyledContainer el6733p3"
           >
             <span
-              aria-disabled="false"
-              class="cache-t6vuyb-StyledTag el6733p1"
+              class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
             >
               scaleway
             </span>
           </button>
         </div>
         <div
-          aria-controls=":r7:"
-          aria-describedby=":r7:"
+          aria-controls=":ri:"
+          aria-describedby=":ri:"
           class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
           tabindex="0"
         >
@@ -693,8 +714,7 @@ exports[`TagList renders correctly with icons 1`] = `
             class="cache-gkklu9-Container-StyledContainer el6733p3"
           >
             <span
-              aria-disabled="false"
-              class="cache-t6vuyb-StyledTag el6733p1"
+              class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
             >
               cloud
             </span>
@@ -758,14 +778,19 @@ exports[`TagList renders correctly with multiline 1`] = `
   border: solid 1px #d9dadd;
 }
 
-.cache-t6vuyb-StyledTag {
+.cache-1l2yxbb-StyledText-StyledText {
   font-size: 12px;
+  font-family: Inter,Asap;
   font-weight: 500;
-  color: inherit;
-  max-width: 232px;
-  overflow: hidden;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
 }
 
 .cache-1hzk1lh-StyledChildrenContainer {
@@ -804,8 +829,7 @@ exports[`TagList renders correctly with multiline 1`] = `
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             scaleway
           </span>
@@ -814,16 +838,15 @@ exports[`TagList renders correctly with multiline 1`] = `
           class="cache-1anauza-StyledContainer el6733p2"
         >
           <span
-            aria-disabled="false"
-            class="cache-t6vuyb-StyledTag el6733p1"
+            class="el6733p1 cache-1l2yxbb-StyledText-StyledText e13y3mga0"
           >
             cloud
           </span>
         </span>
       </div>
       <div
-        aria-controls=":r3:"
-        aria-describedby=":r3:"
+        aria-controls=":rb:"
+        aria-describedby=":rb:"
         class="cache-1hzk1lh-StyledChildrenContainer e4h1g860"
         tabindex="-1"
       >


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

When the tag is too long we are hiding the text but we never show it with a tooltip.

## Relevant logs and/or screenshots

Before:
![Screenshot 2023-11-22 at 16 01 31](https://github.com/scaleway/ultraviolet/assets/15812968/b6848079-8342-4d91-964e-558c0699ea00)


After:
![Screenshot 2023-11-22 at 16 01 35](https://github.com/scaleway/ultraviolet/assets/15812968/344590c6-29fa-4b01-a531-67ca98fd31b0)

