### PR TITLE
fix(DateInput): to use tokens from theme for font

### DIFF
--- a/.changeset/rotten-wolves-compete.md
+++ b/.changeset/rotten-wolves-compete.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/form': patch
+'@ultraviolet/ui': patch
+---
+
+Component `<DateInput />` to use font tokens from theme

--- a/packages/form/src/components/DateField/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/form/src/components/DateField/__tests__/__snapshots__/index.tsx.snap
@@ -2,37 +2,37 @@
 
 exports[`DateField should render correctly 1`] = `
 <DocumentFragment>
-  .cache-b59ts5 {
+  .cache-8drsly {
   width: 100%;
 }
 
-.cache-b59ts5 div.react-datepicker-wrapper {
+.cache-8drsly div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-b59ts5 div.react-datepicker__input-container {
+.cache-8drsly div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-b59ts5 div.react-datepicker__triangle {
+.cache-8drsly div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-b59ts5 div.react-datepicker__month-container {
+.cache-8drsly div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-b59ts5 .react-datepicker-popper {
+.cache-8drsly .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-b59ts5 .calendar {
-  font-family: 'Asap';
+.cache-8drsly .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__header {
+.cache-8drsly .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -42,30 +42,30 @@ exports[`DateField should render correctly 1`] = `
   position: inherit;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__triangle {
+.cache-8drsly .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__month {
+.cache-8drsly .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day-names {
+.cache-8drsly .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-8drsly .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day {
+.cache-8drsly .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -74,76 +74,76 @@ exports[`DateField should render correctly 1`] = `
   margin-right: 3px;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--selected {
+.cache-8drsly .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--selected:disabled {
+.cache-8drsly .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range {
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-range {
+.cache-8drsly .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--in-range:disabled {
+.cache-8drsly .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-start {
+.cache-8drsly .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--range-start:disabled {
+.cache-8drsly .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-end {
+.cache-8drsly .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--range-end:disabled {
+.cache-8drsly .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--keyboard-selected {
+.cache-8drsly .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day:hover {
+.cache-8drsly .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--disabled {
+.cache-8drsly .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--disabled:hover {
+.cache-8drsly .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -283,7 +283,7 @@ exports[`DateField should render correctly 1`] = `
     novalidate=""
   >
     <div
-      class="cache-b59ts5 e1bm75lk2"
+      class="cache-8drsly e1bm75lk2"
     >
       <div
         class="react-datepicker-wrapper"
@@ -343,37 +343,37 @@ exports[`DateField should render correctly 1`] = `
 
 exports[`DateField should render correctly disabled 1`] = `
 <DocumentFragment>
-  .cache-b59ts5 {
+  .cache-8drsly {
   width: 100%;
 }
 
-.cache-b59ts5 div.react-datepicker-wrapper {
+.cache-8drsly div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-b59ts5 div.react-datepicker__input-container {
+.cache-8drsly div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-b59ts5 div.react-datepicker__triangle {
+.cache-8drsly div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-b59ts5 div.react-datepicker__month-container {
+.cache-8drsly div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-b59ts5 .react-datepicker-popper {
+.cache-8drsly .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-b59ts5 .calendar {
-  font-family: 'Asap';
+.cache-8drsly .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__header {
+.cache-8drsly .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -383,30 +383,30 @@ exports[`DateField should render correctly disabled 1`] = `
   position: inherit;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__triangle {
+.cache-8drsly .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__month {
+.cache-8drsly .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day-names {
+.cache-8drsly .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-8drsly .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day {
+.cache-8drsly .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -415,76 +415,76 @@ exports[`DateField should render correctly disabled 1`] = `
   margin-right: 3px;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--selected {
+.cache-8drsly .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--selected:disabled {
+.cache-8drsly .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range {
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-range {
+.cache-8drsly .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--in-range:disabled {
+.cache-8drsly .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-start {
+.cache-8drsly .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--range-start:disabled {
+.cache-8drsly .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-end {
+.cache-8drsly .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--range-end:disabled {
+.cache-8drsly .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--keyboard-selected {
+.cache-8drsly .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day:hover {
+.cache-8drsly .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--disabled {
+.cache-8drsly .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--disabled:hover {
+.cache-8drsly .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -629,7 +629,7 @@ exports[`DateField should render correctly disabled 1`] = `
     novalidate=""
   >
     <div
-      class="cache-b59ts5 e1bm75lk2"
+      class="cache-8drsly e1bm75lk2"
     >
       <div
         class="react-datepicker-wrapper"
@@ -691,37 +691,37 @@ exports[`DateField should render correctly disabled 1`] = `
 
 exports[`DateField should trigger events 1`] = `
 <DocumentFragment>
-  .cache-b59ts5 {
+  .cache-8drsly {
   width: 100%;
 }
 
-.cache-b59ts5 div.react-datepicker-wrapper {
+.cache-8drsly div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-b59ts5 div.react-datepicker__input-container {
+.cache-8drsly div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-b59ts5 div.react-datepicker__triangle {
+.cache-8drsly div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-b59ts5 div.react-datepicker__month-container {
+.cache-8drsly div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-b59ts5 .react-datepicker-popper {
+.cache-8drsly .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-b59ts5 .calendar {
-  font-family: 'Asap';
+.cache-8drsly .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__header {
+.cache-8drsly .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -731,30 +731,30 @@ exports[`DateField should trigger events 1`] = `
   position: inherit;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__triangle {
+.cache-8drsly .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__month {
+.cache-8drsly .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day-names {
+.cache-8drsly .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-8drsly .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day {
+.cache-8drsly .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -763,76 +763,76 @@ exports[`DateField should trigger events 1`] = `
   margin-right: 3px;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--selected {
+.cache-8drsly .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--selected:disabled {
+.cache-8drsly .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range {
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-range {
+.cache-8drsly .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--in-range:disabled {
+.cache-8drsly .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-start {
+.cache-8drsly .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--range-start:disabled {
+.cache-8drsly .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-end {
+.cache-8drsly .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-b59ts5 .calendar .react-datepicker__day--range-end:disabled {
+.cache-8drsly .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-8drsly .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--keyboard-selected {
+.cache-8drsly .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day:hover {
+.cache-8drsly .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--disabled {
+.cache-8drsly .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-b59ts5 .calendar .react-datepicker__day--disabled:hover {
+.cache-8drsly .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -972,7 +972,7 @@ exports[`DateField should trigger events 1`] = `
     novalidate=""
   >
     <div
-      class="cache-b59ts5 e1bm75lk2"
+      class="cache-8drsly e1bm75lk2"
     >
       <div
         class="react-datepicker-wrapper"

--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,37 +2,37 @@
 
 exports[`DateInput render correctly with a array of dates to exclude 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -42,30 +42,30 @@ exports[`DateInput render correctly with a array of dates to exclude 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -74,76 +74,76 @@ exports[`DateInput render correctly with a array of dates to exclude 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -306,7 +306,7 @@ exports[`DateInput render correctly with a array of dates to exclude 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -372,37 +372,37 @@ exports[`DateInput render correctly with a array of dates to exclude 1`] = `
 
 exports[`DateInput render correctly with a range of date 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -412,30 +412,30 @@ exports[`DateInput render correctly with a range of date 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -444,76 +444,76 @@ exports[`DateInput render correctly with a range of date 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -676,7 +676,7 @@ exports[`DateInput render correctly with a range of date 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -742,37 +742,37 @@ exports[`DateInput render correctly with a range of date 1`] = `
 
 exports[`DateInput renders correctly disabled 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -782,30 +782,30 @@ exports[`DateInput renders correctly disabled 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -814,76 +814,76 @@ exports[`DateInput renders correctly disabled 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -1032,7 +1032,7 @@ exports[`DateInput renders correctly disabled 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -1101,37 +1101,37 @@ exports[`DateInput renders correctly disabled 1`] = `
 
 exports[`DateInput renders correctly error 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -1141,30 +1141,30 @@ exports[`DateInput renders correctly error 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -1173,76 +1173,76 @@ exports[`DateInput renders correctly error 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -1417,7 +1417,7 @@ exports[`DateInput renders correctly error 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -1485,37 +1485,37 @@ exports[`DateInput renders correctly error 1`] = `
 
 exports[`DateInput renders correctly error disabled 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -1525,30 +1525,30 @@ exports[`DateInput renders correctly error disabled 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -1557,76 +1557,76 @@ exports[`DateInput renders correctly error disabled 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -1807,7 +1807,7 @@ exports[`DateInput renders correctly error disabled 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -1878,37 +1878,37 @@ exports[`DateInput renders correctly error disabled 1`] = `
 
 exports[`DateInput renders correctly error disabled required 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -1918,30 +1918,30 @@ exports[`DateInput renders correctly error disabled required 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -1950,76 +1950,76 @@ exports[`DateInput renders correctly error disabled required 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -2209,7 +2209,7 @@ exports[`DateInput renders correctly error disabled required 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -2288,37 +2288,37 @@ exports[`DateInput renders correctly error disabled required 1`] = `
 
 exports[`DateInput renders correctly min-max 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -2328,30 +2328,30 @@ exports[`DateInput renders correctly min-max 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -2360,76 +2360,76 @@ exports[`DateInput renders correctly min-max 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -2572,7 +2572,7 @@ exports[`DateInput renders correctly min-max 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -2638,37 +2638,37 @@ exports[`DateInput renders correctly min-max 1`] = `
 
 exports[`DateInput renders correctly required 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -2678,30 +2678,30 @@ exports[`DateInput renders correctly required 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -2710,76 +2710,76 @@ exports[`DateInput renders correctly required 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -2931,7 +2931,7 @@ exports[`DateInput renders correctly required 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -3005,37 +3005,37 @@ exports[`DateInput renders correctly required 1`] = `
 
 exports[`DateInput renders correctly with date-fns locale es 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -3045,30 +3045,30 @@ exports[`DateInput renders correctly with date-fns locale es 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -3077,76 +3077,76 @@ exports[`DateInput renders correctly with date-fns locale es 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -3406,7 +3406,7 @@ exports[`DateInput renders correctly with date-fns locale es 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -4080,37 +4080,37 @@ exports[`DateInput renders correctly with date-fns locale es 1`] = `
 
 exports[`DateInput renders correctly with date-fns locale fr 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -4120,30 +4120,30 @@ exports[`DateInput renders correctly with date-fns locale fr 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -4152,76 +4152,76 @@ exports[`DateInput renders correctly with date-fns locale fr 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -4481,7 +4481,7 @@ exports[`DateInput renders correctly with date-fns locale fr 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -5155,37 +5155,37 @@ exports[`DateInput renders correctly with date-fns locale fr 1`] = `
 
 exports[`DateInput renders correctly with date-fns locale ru 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -5195,30 +5195,30 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -5227,76 +5227,76 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -5556,7 +5556,7 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"
@@ -6230,37 +6230,37 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
 
 exports[`DateInput renders correctly with default props 1`] = `
 <DocumentFragment>
-  .cache-1giyhac-StyledWrapper {
+  .cache-ojbm4u-StyledWrapper {
   width: 100%;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker-wrapper {
+.cache-ojbm4u-StyledWrapper div.react-datepicker-wrapper {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__input-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__input-container {
   display: block;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__triangle {
   display: none;
 }
 
-.cache-1giyhac-StyledWrapper div.react-datepicker__month-container {
+.cache-ojbm4u-StyledWrapper div.react-datepicker__month-container {
   padding: 16px;
 }
 
-.cache-1giyhac-StyledWrapper .react-datepicker-popper {
+.cache-ojbm4u-StyledWrapper .react-datepicker-popper {
   z-index: 1000;
 }
 
-.cache-1giyhac-StyledWrapper .calendar {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar {
+  font-family: Inter,Asap;
   border-color: #e9eaeb;
   background-color: #ffffff;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__header {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__header {
   color: #3f4250;
   background-color: #ffffff;
   border-bottom: none;
@@ -6270,30 +6270,30 @@ exports[`DateInput renders correctly with default props 1`] = `
   position: inherit;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__triangle {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__triangle {
   border-bottom-color: #f9f9fa;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__month {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__month {
   margin: 0;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-names {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-names {
   margin-top: 8px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day-name {
-  font-family: 'Asap';
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day-name {
+  font-family: Inter,Asap;
   color: #3f4250;
   font-weight: 500;
   font-size: 14px;
-  line-height: 24px;
+  line-height: 20px;
   text-align: center;
   margin: 3px;
   text-transform: capitalize;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day {
   color: #727683;
   font-size: 16px;
   width: 1.7rem;
@@ -6302,76 +6302,76 @@ exports[`DateInput renders correctly with default props 1`] = `
   margin-right: 3px;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--selected:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end[aria-disabled='true'],
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--keyboard-selected {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day:hover {
   color: #222638;
   background-color: #e9eaeb;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled {
   color: #b5b7bd;
 }
 
-.cache-1giyhac-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
+.cache-ojbm4u-StyledWrapper .calendar .react-datepicker__day--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -6534,7 +6534,7 @@ exports[`DateInput renders correctly with default props 1`] = `
 }
 
 <div
-    class="cache-1giyhac-StyledWrapper e1bm75lk2"
+    class="cache-ojbm4u-StyledWrapper e1bm75lk2"
   >
     <div
       class="react-datepicker-wrapper"

--- a/packages/ui/src/components/DateInput/index.tsx
+++ b/packages/ui/src/components/DateInput/index.tsx
@@ -38,7 +38,7 @@ const StyledWrapper = styled.div`
     z-index: 1000;
   }
   .calendar {
-    font-family: 'Asap';
+    font-family: ${({ theme }) => theme.typography.body.fontFamily};
     border-color: ${({ theme }) => theme.colors.neutral.borderWeak};
     background-color: ${({ theme }) =>
       theme.colors.neutral.backgroundWeakElevated};
@@ -67,11 +67,13 @@ const StyledWrapper = styled.div`
     }
 
     ${PREFIX}__day-name {
-      font-family: 'Asap';
+      font-family: ${({ theme }) =>
+        theme.typography.bodySmallStrong.fontFamily};
       color: ${({ theme }) => theme.colors.neutral.text};
-      font-weight: 500;
-      font-size: 14px;
-      line-height: 24px;
+      font-weight: ${({ theme }) => theme.typography.bodySmallStrong.weight};
+      font-size: ${({ theme }) => theme.typography.bodySmallStrong.fontSize};
+      line-height: ${({ theme }) =>
+        theme.typography.bodySmallStrong.lineHeight};
       text-align: center;
       margin: 3px;
       text-transform: capitalize;
@@ -79,7 +81,7 @@ const StyledWrapper = styled.div`
 
     ${PREFIX}__day {
       color: ${({ theme }) => theme.colors.neutral.textWeak};
-      font-size: 16px;
+      font-size: ${({ theme }) => theme.typography.body.fontSize};
       width: 1.7rem;
       height: 1.7rem;
       margin-left: 3px;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

DateInput was not using the font from tokens which lead to wrong font family.

## Relevant logs and/or screenshots

Before:
<img width="988" alt="Screenshot 2023-11-23 at 14 35 24" src="https://github.com/scaleway/ultraviolet/assets/15812968/2b6a4169-abde-45bb-adb1-6e3216c13c9b">


After:
<img width="986" alt="Screenshot 2023-11-23 at 14 35 31" src="https://github.com/scaleway/ultraviolet/assets/15812968/d13a88ac-296e-48d5-9eec-8d1effb42603">
