### PR TITLE
fix(Text): one line prop to be working on modals

### DIFF
--- a/.changeset/green-guests-yell.md
+++ b/.changeset/green-guests-yell.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fix `<Text />` component with prop `oneLine` when on modals

--- a/packages/ui/.jest/helpers.tsx
+++ b/packages/ui/.jest/helpers.tsx
@@ -8,7 +8,7 @@ type WrapperProps = {
   children: ReactNode
 }
 
-const Wrapper = ({ theme = defaultTheme, children }: WrapperProps) => (
+export const Wrapper = ({ theme = defaultTheme, children }: WrapperProps) => (
   <ThemeProvider theme={theme}>{children}</ThemeProvider>
 )
 

--- a/packages/ui/src/components/Modal/__stories__/WithTooltip.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/WithTooltip.stories.tsx
@@ -1,12 +1,28 @@
 import type { StoryFn } from '@storybook/react'
 import { Button } from '../../Button'
-import { Tooltip } from '../../Tooltip'
+import { Row } from '../../Row'
+import { Stack } from '../../Stack'
+import { Text } from '../../Text'
 import { Modal } from '../index'
 
 export const WithTooltip: StoryFn = props => (
   <Modal {...props} disclosure={<Button>With a Tooltip</Button>}>
-    <Tooltip text="The Tooltip should be on top of the Modal.">
-      Content with a tooltip
-    </Tooltip>
+    <Row templateColumns="4fr 2fr 2fr 1fr" alignItems="center">
+      <Text as="span" variant="body" oneLine>
+        This-is-a-really-long-file-name-that-will-be-truncated.svg
+      </Text>
+
+      <Stack alignItems="end" justifyContent="center">
+        <Text variant="body" as="span">
+          130.5 MB
+        </Text>
+      </Stack>
+
+      <Stack alignItems="end" justifyContent="center">
+        <Text variant="body" as="span">
+          Uploaded
+        </Text>
+      </Stack>
+    </Row>
   </Modal>
 )

--- a/packages/ui/src/components/Text/index.tsx
+++ b/packages/ui/src/components/Text/index.tsx
@@ -2,8 +2,9 @@ import type { Theme } from '@emotion/react'
 import styled from '@emotion/styled'
 import type React from 'react'
 import type { ElementType, ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 import recursivelyGetChildrenString from '../../helpers/recursivelyGetChildrenString'
+import { useIsOverflowing } from '../../hooks/useIsOverflowing'
 import type { Color } from '../../theme'
 import { typography } from '../../theme'
 import capitalize from '../../utils/capitalize'
@@ -150,21 +151,13 @@ export const Text = ({
   'data-testid': dataTestId,
 }: TextProps) => {
   const computedSentiment = sentiment ?? color
-
-  const [isTruncated, setIsTruncated] = useState(false)
   const elementRef = useRef(null)
+  const isOverflowing = useIsOverflowing(elementRef)
 
   const finalStringChildren = recursivelyGetChildrenString(children)
 
-  useEffect(() => {
-    if (oneLine && elementRef?.current) {
-      const { offsetWidth, scrollWidth } = elementRef.current
-      setIsTruncated(offsetWidth < scrollWidth)
-    }
-  }, [oneLine])
-
   return (
-    <Tooltip text={oneLine && isTruncated ? finalStringChildren : ''}>
+    <Tooltip text={oneLine && isOverflowing ? finalStringChildren : ''}>
       <StyledText
         ref={elementRef}
         as={as}

--- a/packages/ui/src/hooks/__tests__/useIsOverflowing.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useIsOverflowing.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useIsOverflowing } from '../useIsOverflowing'
+
+describe('useIsOverflowing', () => {
+  it('should be false with no overflow', async () => {
+    const { result } = renderHook(() =>
+      useIsOverflowing({ current: document.createElement('div') }),
+    )
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+  })
+
+  it('should be false with no overflow and callback at false too', async () => {
+    const callback = jest.fn()
+    const { result } = renderHook(() =>
+      useIsOverflowing({ current: document.createElement('div') }, callback),
+    )
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should be true with overflow', async () => {
+    const element = document.createElement('div')
+
+    const { result } = renderHook(() =>
+      useIsOverflowing({
+        current: {
+          ...element,
+          clientWidth: 100,
+          scrollWidth: 200,
+        },
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current).toBe(true)
+    })
+  })
+
+  it('should be true with overflow and callback at true too', async () => {
+    const callback = jest.fn()
+    const element = document.createElement('div')
+
+    const { result } = renderHook(() =>
+      useIsOverflowing(
+        {
+          current: {
+            ...element,
+            clientWidth: 100,
+            scrollWidth: 200,
+          },
+        },
+        callback,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(result.current).toBe(true)
+    })
+
+    expect(callback).toHaveBeenCalledWith(true)
+    expect(callback).toHaveBeenCalledTimes(2) // 1 for initial render, 1 for overflow
+  })
+
+  it('should cleanup event listener', () => {
+    const { unmount } = renderHook(() =>
+      useIsOverflowing({ current: document.createElement('div') }),
+    )
+
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener')
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function),
+    )
+    removeEventListenerSpy.mockRestore()
+  })
+
+  it('should handle undefined ref', async () => {
+    const { result } = renderHook(() =>
+      useIsOverflowing({ current: undefined }),
+    )
+
+    await waitFor(() => {
+      expect(result.current).toBe(false)
+    })
+  })
+})

--- a/packages/ui/src/hooks/useIsOverflowing.ts
+++ b/packages/ui/src/hooks/useIsOverflowing.ts
@@ -1,0 +1,40 @@
+import type { MutableRefObject } from 'react'
+import { useEffect, useState } from 'react'
+
+/**
+ * This hook checks if the element has overflow based on the offsetWidth and scrollWidth of the element.
+ */
+export const useIsOverflowing = (
+  ref: MutableRefObject<HTMLElement | HTMLDivElement | undefined | null>,
+  callback?: (hasOverflow: boolean) => void,
+) => {
+  const [isOverflowing, setIsOverflowing] = useState(false)
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (!ref.current) {
+        return
+      }
+
+      const element = ref.current
+
+      const hasOverflow = element.clientWidth < element.scrollWidth
+      setIsOverflowing(hasOverflow)
+      if (callback) callback(hasOverflow)
+    }
+
+    // This will add the function into the browser event queue after the DOM is painted
+    // which is needed to get the correct offsetWidth and scrollWidth
+    setTimeout(() => handleResize(), 0)
+
+    // Listen for resize events
+    window.addEventListener('resize', handleResize)
+
+    // Cleanup the event listener
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [ref, callback])
+
+  return isOverflowing
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14444,8 +14444,8 @@ packages:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
     dev: true
 
-  /punycode@2.3.0:
-    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+  /punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
     dev: true
 
@@ -16276,7 +16276,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0
-      punycode: 2.3.0
+      punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
     dev: true
@@ -16289,7 +16289,7 @@ packages:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
     dependencies:
-      punycode: 2.3.0
+      punycode: 2.3.1
     dev: true
 
   /trim-newlines@3.0.1:
@@ -16630,7 +16630,7 @@ packages:
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
-      punycode: 2.3.0
+      punycode: 2.3.1
     dev: true
 
   /url-parse@1.5.10:


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Text with prop `oneLine` were not working on modals due to the fact that it wasn't detecting properly the overflow. This is because modals appears later in the render and the `clientWidth` and `scrollWidth` are at 0 until the component is mounted. 

To fix this I created a `useIsOverflowing` hook that will detect overflow and wait the DOM to be painted and so the ref to be correctly set before calculating if overflow is happening.

I added test on the hook with 100% coverage.

## Relevant logs and/or screenshots

<img width="672" alt="Screenshot 2023-11-29 at 11 28 29" src="https://github.com/scaleway/ultraviolet/assets/15812968/394beb31-42c8-4eda-bf35-f84a20204d89">

