### PR TITLE
ci: fix size limit to ignore ultraviolet plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     {
       "path": [
         "packages/*/dist/**/*.js",
-        "!packages/illustrations"
+        "!packages/illustrations",
+        "!packages/plus"
       ],
       "limit": "230 kB",
       "webpack": false,


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

Size limit is throwing an error since we exported EstimateCost as it increased the bundle size. We do not want to limit the size of `@ultraviolet/plus` as it is supposed to contains heavy components but we do want to keep this limit on `@ultraviolet/ui` made out of simple components.