### PR TITLE
fix(Checkbox): trigger a on change on space bar pressed

### DIFF
--- a/.changeset/wet-terms-again.md
+++ b/.changeset/wet-terms-again.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/form': patch
+---
+
+Fix `<CheckboxField />` to trigger on change when state changes

--- a/.changeset/wet-terms-repeat.md
+++ b/.changeset/wet-terms-repeat.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/ui': patch
+---
+
+Fix `<Checkbox />` to trigger on change when state changes

--- a/packages/form/src/components/CheckboxField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/CheckboxField/__stories__/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from '@storybook/react'
+import { Snippet, Stack, Text } from '@ultraviolet/ui'
 import { CheckboxField, Form } from '../..'
 import { mockErrors } from '../../../mocks'
 
@@ -7,7 +8,19 @@ export default {
   decorators: [
     ChildStory => (
       <Form onRawSubmit={() => {}} errors={mockErrors}>
-        {ChildStory()}
+        {values => (
+          <Stack gap={2}>
+            {ChildStory()}
+            <Stack gap={1}>
+              <Text variant="bodyStrong" as="p">
+                Form values:
+              </Text>
+              <Snippet prefix="lines">
+                {JSON.stringify(values.values, null, 1)}
+              </Snippet>
+            </Stack>
+          </Stack>
+        )}
       </Form>
     ),
   ],

--- a/packages/ui/src/components/Checkbox/__tests__/index.tsx
+++ b/packages/ui/src/components/Checkbox/__tests__/index.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Checkbox } from '..'
 import {
@@ -158,38 +158,5 @@ describe('Checkbox', () => {
     })
     await userEvent.click(input)
     expect(input.checked).toBe(true)
-  })
-
-  test('check checkbox with space key for a11y', async () => {
-    renderWithTheme(
-      <Checkbox onChange={() => {}} value="test">
-        Checkbox Label
-      </Checkbox>,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>('checkbox', {
-      hidden: true,
-    })
-
-    input.focus()
-    expect(input).toHaveFocus()
-    fireEvent.keyDown(input, { charCode: 32, code: 'Space', key: ' ' })
-    await waitFor(() => expect(input.checked).toBe(true))
-  })
-
-  test('should not check checkbox with key A', async () => {
-    renderWithTheme(
-      <Checkbox onChange={() => {}} value="test">
-        Checkbox Label
-      </Checkbox>,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>('checkbox', {
-      hidden: true,
-    })
-
-    input.focus()
-    fireEvent.keyDown(input, { charCode: 65, code: 'KeyA', key: 'a' })
-    await waitFor(() => expect(input.checked).toBe(false))
   })
 })

--- a/packages/ui/src/components/Checkbox/index.tsx
+++ b/packages/ui/src/components/Checkbox/index.tsx
@@ -5,7 +5,6 @@ import type {
   ChangeEvent,
   ForwardedRef,
   InputHTMLAttributes,
-  KeyboardEvent,
   ReactNode,
 } from 'react'
 import { forwardRef, useCallback, useEffect, useId, useState } from 'react'
@@ -341,13 +340,6 @@ export const Checkbox = forwardRef(
       [onChange, progress, setState],
     )
 
-    const onKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
-      if (event.key.charCodeAt(0) === 32) {
-        event.preventDefault()
-        setState(current => !current)
-      }
-    }, [])
-
     return (
       <Tooltip text={tooltip}>
         <CheckboxContainer
@@ -373,7 +365,6 @@ export const Checkbox = forwardRef(
             checked={state === 'indeterminate' ? false : state}
             size={size}
             onChange={onLocalChange}
-            onKeyDown={onKeyDown}
             onFocus={onFocus}
             onBlur={onBlur}
             disabled={disabled}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Checkbox was not working properly when using space bar as only the internal state was updated. To do so I used the ref of the input and simulate a click on the input when space bar is pressed. This way we ensure the same events occur when space bar is clicked.

#### How to test?

(Describe what you did)

1. Go to storybook > CheckboxField

2. Focus the checkbox input and press space bar

3. You should see the form values updating correctly and the icon the change 

## Relevant logs and/or screenshots

Before:

https://github.com/scaleway/ultraviolet/assets/15812968/dda953ca-cf4c-4544-abdc-1431a26c8765

After:

https://github.com/scaleway/ultraviolet/assets/15812968/c3db9412-4a79-4dcf-bde1-f61738124910
