### PR TITLE
fix(EstimateCost): when discount is set to 0 display correct values

### DIFF
--- a/.changeset/shiny-flowers-invent.md
+++ b/.changeset/shiny-flowers-invent.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/plus': patch
+---
+
+Fix EstimateCost when the discount is set to 0

--- a/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
+++ b/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
@@ -358,7 +358,7 @@ export const EstimateCostContent = ({
                         }
                         sentiment="warning"
                       >
-                        {`${discount * 100}
+                        {`${discount > 0 ? discount * 100 : ''}
                           ${
                             locales[
                               `estimate.cost.beta.${

--- a/packages/plus/src/components/EstimateCost/__stories__/GlobalDiscount.stories.tsx
+++ b/packages/plus/src/components/EstimateCost/__stories__/GlobalDiscount.stories.tsx
@@ -13,7 +13,7 @@ GlobalDiscount.args = {
     </EstimateCost.Item>,
   ],
   isBeta: true,
-  discount: 0.5,
+  discount: 0,
 }
 
 GlobalDiscount.parameters = {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.spec.tsx.snap
@@ -8318,7 +8318,7 @@ exports[`EstimateCost - Regular Item render basic props with overlay beta 1`] = 
               <span
                 class="e1xb5k8j4 ej33bna0 cache-7s9nya-BadgeBeta e13y3mga0"
               >
-                0
+                
                           Free During Beta
               </span>
               <h3

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.spec.tsx.snap
@@ -5014,7 +5014,7 @@ exports[`EstimateCost - index render isBeta without discount 1`] = `
               <span
                 class="e1xb5k8j4 ej33bna0 cache-7s9nya-BadgeBeta e13y3mga0"
               >
-                0
+                
                           Free During Beta
               </span>
               <h3
@@ -18541,7 +18541,7 @@ exports[`EstimateCost - index render with isBeta but undefined discount 1`] = `
               <span
                 class="e1xb5k8j4 ej33bna0 cache-7s9nya-BadgeBeta e13y3mga0"
               >
-                0
+                
                           Free During Beta
               </span>
               <h3
@@ -19813,7 +19813,7 @@ exports[`EstimateCost - index render with isBeta, discount 0 and defaultTimeUnit
               <span
                 class="e1xb5k8j4 ej33bna0 cache-7s9nya-BadgeBeta e13y3mga0"
               >
-                0
+                
                           Free During Beta
               </span>
               <h3


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Estimate cost is showing wrong values when setting discount to 0.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2023-12-08 at 17 28 35](https://github.com/scaleway/ultraviolet/assets/15812968/daa633e3-0572-4cd2-8711-ba4c2ff04f63) | ![Screenshot 2023-12-08 at 17 27 51](https://github.com/scaleway/ultraviolet/assets/15812968/944a0ca0-7c1f-4c7c-b19c-954d39e28b4a) |
