### PR TITLE
fix(EstimateCost): unit input to be clearable in time amount

### DIFF
--- a/.changeset/silent-ladybugs-provide.md
+++ b/.changeset/silent-ladybugs-provide.md
@@ -1,0 +1,5 @@
+---
+'@ultraviolet/plus': patch
+---
+
+Fix `<EstimateCost />` unit input to be clearable completly

--- a/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { SelectInput, Stack, TextInput } from '@ultraviolet/ui'
-import type { ComponentProps } from 'react'
+import type { ComponentProps, FocusEvent } from 'react'
 
 type SelectOption = Exclude<
   NonNullable<ComponentProps<typeof SelectInput>['value']>,
@@ -48,7 +48,6 @@ const CustomSelectInput = styled(SelectInput)<{
 }>`
   ${({ width }) => width && `width: ${width}px;`}
   ${({ height }) => height && `height: ${height}px;`}
-
   &:hover,
   &:focus {
     text-decoration: none;
@@ -131,8 +130,21 @@ export const UnitInput = ({
       value={value}
       placeholder={placeholder}
       onChange={input => {
-        const numericValue = input ? parseInt(input, 10) : minValue
+        const numericValue = parseInt(input, 10)
         onChange(numericValue)
+      }}
+      onBlur={(event: FocusEvent<HTMLInputElement>) => {
+        const numericValue = parseInt(event.target.value, 10)
+        if (Number.isNaN(numericValue)) {
+          onChange(minValue)
+        }
+
+        if (numericValue < minValue) {
+          onChange(minValue)
+        }
+        if (numericValue > maxValue) {
+          onChange(maxValue)
+        }
       }}
       className={className}
       disabled={disabled}

--- a/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
@@ -135,13 +135,10 @@ export const UnitInput = ({
       }}
       onBlur={(event: FocusEvent<HTMLInputElement>) => {
         const numericValue = parseInt(event.target.value, 10)
-        if (Number.isNaN(numericValue)) {
+        if (Number.isNaN(numericValue) || numericValue < minValue) {
           onChange(minValue)
         }
 
-        if (numericValue < minValue) {
-          onChange(minValue)
-        }
         if (numericValue > maxValue) {
           onChange(maxValue)
         }

--- a/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
@@ -80,6 +80,7 @@ type UnitInputProps = {
   value?: UnitInputValue['inputValue']
   unitValue?: UnitInputValue['unit']
   onChange: (value: UnitInputValue['inputValue']) => void
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void
   onChangeUnitValue: (value: UnitInputValue['unit']) => void
   options: SelectOption[]
   placeholder?: string
@@ -102,6 +103,7 @@ export const UnitInput = ({
   size = 'medium',
   placeholder = '0',
   onChange,
+  onBlur,
   onChangeUnitValue,
   value,
   unitValue,
@@ -142,6 +144,8 @@ export const UnitInput = ({
         if (numericValue > maxValue) {
           onChange(maxValue)
         }
+
+        onBlur?.(event)
       }}
       className={className}
       disabled={disabled}

--- a/packages/plus/src/components/EstimateCost/__tests__/CustomUnitInput.spec.tsx
+++ b/packages/plus/src/components/EstimateCost/__tests__/CustomUnitInput.spec.tsx
@@ -1,5 +1,17 @@
-import { afterAll, beforeAll, describe, jest, test } from '@jest/globals'
-import { shouldMatchEmotionSnapshot } from '../../../../.jest/helpers'
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  renderWithTheme,
+  shouldMatchEmotionSnapshot,
+} from '../../../../.jest/helpers'
 import { CustomUnitInput } from '../Components/CustomUnitInput'
 
 describe('EstimateCost - CustomUnitInput', () => {
@@ -19,4 +31,22 @@ describe('EstimateCost - CustomUnitInput', () => {
         timeUnits={['seconds', 'minutes', 'hours', 'days', 'months']}
       />,
     ))
+
+  test('render and trigger on blur when leaving input empty', async () => {
+    renderWithTheme(
+      <CustomUnitInput
+        setIteration={() => {}}
+        iteration={{ value: 1, unit: 'hours' }}
+        timeUnits={['seconds', 'minutes', 'hours', 'days', 'months']}
+      />,
+    )
+
+    const input = screen.getByRole<HTMLInputElement>('spinbutton')
+    await waitFor(() => expect(input.value).toBe('1'))
+    await userEvent.click(input)
+    await userEvent.type(input, '{ArrowLeft}{Backspace}0')
+    await userEvent.tab()
+
+    await waitFor(() => expect(input.value).toBe('1'))
+  })
 })

--- a/packages/plus/src/components/EstimateCost/__tests__/helper.spec.ts
+++ b/packages/plus/src/components/EstimateCost/__tests__/helper.spec.ts
@@ -35,4 +35,16 @@ describe('EstimateCost - helper', () => {
       }),
     ).toEqual(9.198)
   })
+
+  it('should calculate work with NaN timeAmount number', () => {
+    expect(
+      calculatePrice({
+        price: 0.0014,
+        amount: 5,
+        amountFree: 2,
+        timeUnit: 'months',
+        timeAmount: NaN,
+      }),
+    ).toEqual(0)
+  })
 })

--- a/packages/plus/src/components/EstimateCost/helper.ts
+++ b/packages/plus/src/components/EstimateCost/helper.ts
@@ -18,9 +18,10 @@ export const calculatePrice = ({
   timeAmount: number
   discount?: number
 }) => {
+  const nonNanTimeAmount = Number.isNaN(timeAmount) ? 0 : timeAmount
   const value =
     (price - price * discount) *
-    (timeAmount * multiplier[`${timeUnit}`]) *
+    (nonNanTimeAmount * multiplier[`${timeUnit}`]) *
     Math.max(amount - amountFree, 0)
 
   // Avoid having negative price in any cases


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

UnitInput in EstimateCost is kinda buggy. We cannot remove completly the value set inside, this is because we always set the change if the value exists. When you remove all the value is empty and so the onChange is not triggered. I fixed it by using onBlur and set min / max value when use gets out of the input.

## Relevant logs and/or screenshots

Before

https://github.com/scaleway/ultraviolet/assets/15812968/0c18e414-9160-486b-b9a8-9b953dea7782


After


https://github.com/scaleway/ultraviolet/assets/15812968/842d1021-c6ea-4400-b269-2f1ba588a6dc


