### PR TITLE
fix(SelectableCard): type checkbox to work properly when clicking on both card and checkbox

### DIFF
--- a/.changeset/moody-goats-remain.md
+++ b/.changeset/moody-goats-remain.md
@@ -1,0 +1,6 @@
+---
+'@ultraviolet/form': patch
+'@ultraviolet/ui': patch
+---
+
+Fix `<SelectableCard />` with type `checkbox` to workproperly when clicking on both the checkbox and the container

--- a/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -75,7 +75,7 @@ exports[`SelectableCardField should render correctly 1`] = `
   width: 100%;
 }
 
-.cache-1rouikf-StyledRadio {
+.cache-1dii88a-OverloadedRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -97,68 +97,69 @@ exports[`SelectableCardField should render correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='false'],
-.cache-1rouikf-StyledRadio[aria-disabled='false']>label {
+.cache-1dii88a-OverloadedRadio[aria-disabled='false'],
+.cache-1dii88a-OverloadedRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'][data-checked='false'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true']>label,
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld3 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true']>label,
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1rouikf-StyledRadio[data-checked='true'] {
+.cache-1dii88a-OverloadedRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1rouikf-StyledRadio[data-error='true'] {
+.cache-1dii88a-OverloadedRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio input+svg {
+.cache-1dii88a-OverloadedRadio input+svg {
   display: none;
 }
 
-.cache-1rouikf-StyledRadio label {
+.cache-1dii88a-OverloadedRadio label {
   display: none;
 }
 
@@ -236,7 +237,7 @@ exports[`SelectableCardField should render correctly 1`] = `
     novalidate=""
   >
     <div
-      class="cache-gy87p5 e1s5n3hj2"
+      class="cache-gy87p5 e1s5n3hj3"
       data-checked="false"
       data-disabled="false"
       data-error="false"
@@ -246,7 +247,7 @@ exports[`SelectableCardField should render correctly 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj1 cache-1dii88a-OverloadedRadio ehkrmld2"
           data-checked="false"
           data-error="false"
         >
@@ -367,7 +368,7 @@ exports[`SelectableCardField should render correctly checked 1`] = `
   width: 100%;
 }
 
-.cache-1rouikf-StyledRadio {
+.cache-1dii88a-OverloadedRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -389,68 +390,69 @@ exports[`SelectableCardField should render correctly checked 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='false'],
-.cache-1rouikf-StyledRadio[aria-disabled='false']>label {
+.cache-1dii88a-OverloadedRadio[aria-disabled='false'],
+.cache-1dii88a-OverloadedRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'][data-checked='false'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true']>label,
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld3 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true']>label,
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1rouikf-StyledRadio[data-checked='true'] {
+.cache-1dii88a-OverloadedRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1rouikf-StyledRadio[data-error='true'] {
+.cache-1dii88a-OverloadedRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio input+svg {
+.cache-1dii88a-OverloadedRadio input+svg {
   display: none;
 }
 
-.cache-1rouikf-StyledRadio label {
+.cache-1dii88a-OverloadedRadio label {
   display: none;
 }
 
@@ -528,7 +530,7 @@ exports[`SelectableCardField should render correctly checked 1`] = `
     novalidate=""
   >
     <div
-      class="cache-gy87p5 e1s5n3hj2"
+      class="cache-gy87p5 e1s5n3hj3"
       data-checked="true"
       data-disabled="false"
       data-error="false"
@@ -538,7 +540,7 @@ exports[`SelectableCardField should render correctly checked 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj1 cache-1dii88a-OverloadedRadio ehkrmld2"
           data-checked="true"
           data-error="false"
         >
@@ -660,7 +662,7 @@ exports[`SelectableCardField should render correctly disabled 1`] = `
   width: 100%;
 }
 
-.cache-1rouikf-StyledRadio {
+.cache-1dii88a-OverloadedRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -682,68 +684,69 @@ exports[`SelectableCardField should render correctly disabled 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='false'],
-.cache-1rouikf-StyledRadio[aria-disabled='false']>label {
+.cache-1dii88a-OverloadedRadio[aria-disabled='false'],
+.cache-1dii88a-OverloadedRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'][data-checked='false'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true']>label,
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld3 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true']>label,
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1rouikf-StyledRadio[data-checked='true'] {
+.cache-1dii88a-OverloadedRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1rouikf-StyledRadio[data-error='true'] {
+.cache-1dii88a-OverloadedRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio input+svg {
+.cache-1dii88a-OverloadedRadio input+svg {
   display: none;
 }
 
-.cache-1rouikf-StyledRadio label {
+.cache-1dii88a-OverloadedRadio label {
   display: none;
 }
 
@@ -821,7 +824,7 @@ exports[`SelectableCardField should render correctly disabled 1`] = `
     novalidate=""
   >
     <div
-      class="cache-gy87p5 e1s5n3hj2"
+      class="cache-gy87p5 e1s5n3hj3"
       data-checked="false"
       data-disabled="true"
       data-error="false"
@@ -831,7 +834,7 @@ exports[`SelectableCardField should render correctly disabled 1`] = `
       >
         <div
           aria-disabled="true"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj1 cache-1dii88a-OverloadedRadio ehkrmld2"
           data-checked="false"
           data-error="false"
         >
@@ -953,7 +956,7 @@ exports[`SelectableCardField should render correctly with errors 1`] = `
   width: 100%;
 }
 
-.cache-1rouikf-StyledRadio {
+.cache-1dii88a-OverloadedRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -975,68 +978,69 @@ exports[`SelectableCardField should render correctly with errors 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='false'],
-.cache-1rouikf-StyledRadio[aria-disabled='false']>label {
+.cache-1dii88a-OverloadedRadio[aria-disabled='false'],
+.cache-1dii88a-OverloadedRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'][data-checked='false'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true']>label,
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld3 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true']>label,
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1rouikf-StyledRadio[data-checked='true'] {
+.cache-1dii88a-OverloadedRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1rouikf-StyledRadio[data-error='true'] {
+.cache-1dii88a-OverloadedRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio input+svg {
+.cache-1dii88a-OverloadedRadio input+svg {
   display: none;
 }
 
-.cache-1rouikf-StyledRadio label {
+.cache-1dii88a-OverloadedRadio label {
   display: none;
 }
 
@@ -1114,7 +1118,7 @@ exports[`SelectableCardField should render correctly with errors 1`] = `
     novalidate=""
   >
     <div
-      class="cache-gy87p5 e1s5n3hj2"
+      class="cache-gy87p5 e1s5n3hj3"
       data-checked="false"
       data-disabled="false"
       data-error="true"
@@ -1124,7 +1128,7 @@ exports[`SelectableCardField should render correctly with errors 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj1 cache-1dii88a-OverloadedRadio ehkrmld2"
           data-checked="false"
           data-error="true"
         >
@@ -1250,7 +1254,7 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
   width: 100%;
 }
 
-.cache-1rouikf-StyledRadio {
+.cache-1dii88a-OverloadedRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1272,68 +1276,69 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='false'],
-.cache-1rouikf-StyledRadio[aria-disabled='false']>label {
+.cache-1dii88a-OverloadedRadio[aria-disabled='false'],
+.cache-1dii88a-OverloadedRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'][data-checked='false'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true']>label,
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld3 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true']>label,
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1rouikf-StyledRadio[data-checked='true'] {
+.cache-1dii88a-OverloadedRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1rouikf-StyledRadio[data-error='true'] {
+.cache-1dii88a-OverloadedRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1rouikf-StyledRadio[aria-disabled='true'] {
+.cache-1dii88a-OverloadedRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1rouikf-StyledRadio input+svg {
+.cache-1dii88a-OverloadedRadio input+svg {
   display: none;
 }
 
-.cache-1rouikf-StyledRadio label {
+.cache-1dii88a-OverloadedRadio label {
   display: none;
 }
 
@@ -1411,7 +1416,7 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
     novalidate=""
   >
     <div
-      class="cache-gy87p5 e1s5n3hj2"
+      class="cache-gy87p5 e1s5n3hj3"
       data-checked="true"
       data-disabled="false"
       data-error="false"
@@ -1421,7 +1426,7 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj1 cache-1dii88a-OverloadedRadio ehkrmld2"
           data-checked="true"
           data-error="false"
         >

--- a/packages/ui/src/components/SelectableCard/__stories__/Examples.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/Examples.stories.tsx
@@ -43,7 +43,7 @@ export const Examples: StoryFn = args => {
         </SelectableCard>
         <SelectableCard
           {...args}
-          name="label-15"
+          name="label-14"
           checked={value === 'label-15'}
           value="label-15"
           type="radio"
@@ -72,7 +72,7 @@ export const Examples: StoryFn = args => {
           value="label-20"
           type="checkbox"
           onChange={event =>
-            onChange2({ ...value2, 'label-20': !event.currentTarget.checked })
+            onChange2({ ...value2, 'label-20': event.currentTarget.checked })
           }
           showTick
           label={
@@ -96,7 +96,7 @@ export const Examples: StoryFn = args => {
           value="label-21"
           type="checkbox"
           onChange={event =>
-            onChange2({ ...value2, 'label-21': !event.currentTarget.checked })
+            onChange2({ ...value2, 'label-21': event.currentTarget.checked })
           }
           showTick
           label={
@@ -123,7 +123,7 @@ export const Examples: StoryFn = args => {
           value="label-22"
           type="checkbox"
           onChange={event =>
-            onChange3({ ...value3, 'label-22': !event.currentTarget.checked })
+            onChange3({ ...value3, 'label-22': event.currentTarget.checked })
           }
           showTick
           label={
@@ -147,7 +147,7 @@ export const Examples: StoryFn = args => {
           value="label-23"
           type="checkbox"
           onChange={event =>
-            onChange3({ ...value3, 'label-23': !event.currentTarget.checked })
+            onChange3({ ...value3, 'label-23': event.currentTarget.checked })
           }
           showTick
           label={
@@ -172,7 +172,7 @@ export const Examples: StoryFn = args => {
           value="label-24"
           type="checkbox"
           onChange={event =>
-            onChange3({ ...value3, 'label-24': !event.currentTarget.checked })
+            onChange3({ ...value3, 'label-24': event.currentTarget.checked })
           }
           showTick
           label={
@@ -197,7 +197,7 @@ export const Examples: StoryFn = args => {
           value="label-25"
           type="checkbox"
           onChange={event =>
-            onChange3({ ...value3, 'label-25': !event.currentTarget.checked })
+            onChange3({ ...value3, 'label-25': event.currentTarget.checked })
           }
           showTick
           label={

--- a/packages/ui/src/components/SelectableCard/__stories__/ShowTick.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/ShowTick.stories.tsx
@@ -40,7 +40,7 @@ export const ShowTick: StoryFn = args => {
           type="checkbox"
           showTick
           onChange={event =>
-            onChange2({ ...value2, 'label-1': !event.currentTarget.checked })
+            onChange2({ ...value2, 'label-1': event.currentTarget.checked })
           }
           label="Checkbox 1"
         />
@@ -52,7 +52,7 @@ export const ShowTick: StoryFn = args => {
           type="checkbox"
           showTick
           onChange={event =>
-            onChange2({ ...value2, 'label-2': !event.currentTarget.checked })
+            onChange2({ ...value2, 'label-2': event.currentTarget.checked })
           }
           label="Checkbox 2"
         />

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -71,67 +71,68 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
   cursor: pointer;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   cursor: not-allowed;
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
   fill: #e9eaeb;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
   stroke: #d9dadd;
   fill: #f3f3f4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffd3e3;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffbbd3;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d8c5fc;
   fill: #d8c5fc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e5dbfd;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
   transform-origin: center;
   -webkit-transition: 200ms -webkit-transform ease-in-out;
   transition: 200ms transform ease-in-out;
@@ -145,80 +146,80 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   transform: translate(2px, 2px);
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #e51963;
   stroke: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
   fill: #ffffff;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d6175c;
   fill: #d6175c;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e51963;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   width: 100%;
 }
 
@@ -359,13 +360,13 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
   >
     <div
       aria-disabled="false"
-      class="e1s5n3hj0 cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
+      class="e1s5n3hj0 cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
       data-checked="false"
       data-error="false"
     >
@@ -472,7 +473,7 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -492,67 +493,68 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
   cursor: pointer;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   cursor: not-allowed;
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
   fill: #e9eaeb;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
   stroke: #d9dadd;
   fill: #f3f3f4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffd3e3;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffbbd3;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d8c5fc;
   fill: #d8c5fc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e5dbfd;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
   transform-origin: center;
   -webkit-transition: 200ms -webkit-transform ease-in-out;
   transition: 200ms transform ease-in-out;
@@ -566,80 +568,80 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   transform: translate(2px, 2px);
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #e51963;
   stroke: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
   fill: #ffffff;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d6175c;
   fill: #d6175c;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e51963;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   width: 100%;
 }
 
@@ -780,13 +782,13 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="true"
     data-disabled="false"
   >
     <div
       aria-disabled="false"
-      class="e1s5n3hj0 cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
+      class="e1s5n3hj0 cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
       data-checked="true"
       data-error="false"
     >
@@ -894,7 +896,7 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -914,67 +916,68 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
   cursor: pointer;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   cursor: not-allowed;
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
   fill: #e9eaeb;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
   stroke: #d9dadd;
   fill: #f3f3f4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffd3e3;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffbbd3;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d8c5fc;
   fill: #d8c5fc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e5dbfd;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
   transform-origin: center;
   -webkit-transition: 200ms -webkit-transform ease-in-out;
   transition: 200ms transform ease-in-out;
@@ -988,80 +991,80 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   transform: translate(2px, 2px);
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #e51963;
   stroke: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
   fill: #ffffff;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d6175c;
   fill: #d6175c;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e51963;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   width: 100%;
 }
 
@@ -1202,13 +1205,13 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="true"
   >
     <div
       aria-disabled="true"
-      class="e1s5n3hj0 cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
+      class="e1s5n3hj0 cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
       data-checked="false"
       data-error="false"
     >
@@ -1316,7 +1319,7 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1336,67 +1339,68 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
   cursor: pointer;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   cursor: not-allowed;
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
   fill: #e9eaeb;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
   stroke: #d9dadd;
   fill: #f3f3f4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffd3e3;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffbbd3;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d8c5fc;
   fill: #d8c5fc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e5dbfd;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
   transform-origin: center;
   -webkit-transition: 200ms -webkit-transform ease-in-out;
   transition: 200ms transform ease-in-out;
@@ -1410,80 +1414,80 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   transform: translate(2px, 2px);
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #e51963;
   stroke: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
   fill: #ffffff;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d6175c;
   fill: #d6175c;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e51963;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   width: 100%;
 }
 
@@ -1637,14 +1641,14 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-error="true"
   >
     <div
       aria-disabled="false"
-      class="e1s5n3hj0 cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
+      class="e1s5n3hj0 cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
       data-checked="false"
       data-error="true"
     >
@@ -1763,7 +1767,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1783,67 +1787,68 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
   cursor: pointer;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   cursor: not-allowed;
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
   fill: #e9eaeb;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
   stroke: #d9dadd;
   fill: #f3f3f4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffd3e3;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffbbd3;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d8c5fc;
   fill: #d8c5fc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e5dbfd;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
   transform-origin: center;
   -webkit-transition: 200ms -webkit-transform ease-in-out;
   transition: 200ms transform ease-in-out;
@@ -1857,80 +1862,80 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   transform: translate(2px, 2px);
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #e51963;
   stroke: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
   fill: #ffffff;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d6175c;
   fill: #d6175c;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e51963;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   width: 100%;
 }
 
@@ -2077,13 +2082,13 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
     tabindex="0"
   >
     <div
-      class="cache-63kw8l-Container e1s5n3hj2"
+      class="cache-63kw8l-Container e1s5n3hj3"
       data-checked="false"
       data-disabled="false"
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj0 cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
+        class="e1s5n3hj0 cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
         data-checked="false"
         data-error="false"
       >
@@ -2191,7 +2196,7 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -2211,67 +2216,68 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
   cursor: pointer;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   cursor: not-allowed;
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
   fill: #e9eaeb;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
   stroke: #d9dadd;
   fill: #f3f3f4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffd3e3;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffbbd3;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d8c5fc;
   fill: #d8c5fc;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e5dbfd;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
   transform-origin: center;
   -webkit-transition: 200ms -webkit-transform ease-in-out;
   transition: 200ms transform ease-in-out;
@@ -2285,80 +2291,80 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   transform: translate(2px, 2px);
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #e51963;
   stroke: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
   fill: #ffffff;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #e5dbfd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d6175c;
   fill: #d6175c;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #e51963;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e51963;
   fill: #ffebf2;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox input+svg {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   display: none;
 }
 
-.cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   width: 100%;
 }
 
@@ -2499,13 +2505,13 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="true"
   >
     <div
       aria-disabled="true"
-      class="e1s5n3hj0 cache-lu4y5o-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
+      class="e1s5n3hj0 cache-44kmvr-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
       data-checked="false"
       data-error="false"
     >
@@ -2641,7 +2647,7 @@ exports[`SelectableCard renders correctly with default props 1`] = `
   width: 100%;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2663,68 +2669,69 @@ exports[`SelectableCard renders correctly with default props 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio label {
   display: none;
 }
 
@@ -2799,7 +2806,7 @@ exports[`SelectableCard renders correctly with default props 1`] = `
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
   >
@@ -2808,7 +2815,7 @@ exports[`SelectableCard renders correctly with default props 1`] = `
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj1 cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
         data-checked="false"
       >
         <input
@@ -2927,7 +2934,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
   width: 100%;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2949,68 +2956,69 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio label {
   display: none;
 }
 
@@ -3085,7 +3093,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="true"
     data-disabled="false"
   >
@@ -3094,7 +3102,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj1 cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
         data-checked="true"
       >
         <input
@@ -3214,7 +3222,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
   width: 100%;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3236,68 +3244,69 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio label {
   display: none;
 }
 
@@ -3372,7 +3381,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="true"
   >
@@ -3381,7 +3390,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
     >
       <div
         aria-disabled="true"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj1 cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
         data-checked="false"
       >
         <input
@@ -3501,7 +3510,7 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
   width: 100%;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3523,68 +3532,69 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio label {
   display: none;
 }
 
@@ -3659,7 +3669,7 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-error="true"
@@ -3669,7 +3679,7 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj1 cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
         data-checked="false"
         data-error="true"
       >
@@ -3797,7 +3807,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
   width: 100%;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3819,68 +3829,69 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
-.cache-1nauh8c-RadioContainer-StyledRadio-StyledElement label {
+.cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio label {
   display: none;
 }
 
@@ -3961,7 +3972,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
     tabindex="0"
   >
     <div
-      class="cache-63kw8l-Container e1s5n3hj2"
+      class="cache-63kw8l-Container e1s5n3hj3"
       data-checked="false"
       data-disabled="false"
     >
@@ -3970,7 +3981,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+          class="e1s5n3hj1 cache-1et21s1-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
           data-checked="false"
         >
           <input
@@ -4066,7 +4077,7 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -4086,67 +4097,68 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq3 {
   cursor: pointer;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   cursor: not-allowed;
   color: #b5b7bd;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 {
   fill: #e9eaeb;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq4 .eqr7bqq6 {
   stroke: #d9dadd;
   fill: #f3f3f4;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 {
   fill: #ffd3e3;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffd3e3;
   fill: #ffd3e3;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #ffebf2;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #ffbbd3;
   fill: #ffebf2;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d8c5fc;
   fill: #d8c5fc;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 {
   fill: #e5dbfd;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e5dbfd;
   fill: #e5dbfd;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 path {
   transform-origin: center;
   -webkit-transition: 200ms -webkit-transform ease-in-out;
   transition: 200ms transform ease-in-out;
@@ -4160,72 +4172,72 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   transform: translate(2px, 2px);
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]:checked+.eqr7bqq4 .eqr7bqq6 {
   fill: #e51963;
   stroke: #e51963;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq5 {
   fill: #ffffff;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-checked="mixed"]+.eqr7bqq4 .eqr7bqq6 {
   fill: #8c40ef;
   stroke: #8c40ef;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #e5dbfd;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #792dd4;
   fill: #792dd4;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='false']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #92103f;
   fill: #ffd3e3;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox:hover[aria-disabled='false'] .eqr7bqq2[aria-invalid='true'][aria-checked='true']+.eqr7bqq4 .eqr7bqq6 {
   stroke: #d6175c;
   fill: #d6175c;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 {
   fill: #e51963;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox .eqr7bqq2[aria-invalid="true"]+.eqr7bqq4 .eqr7bqq6 {
   stroke: #e51963;
   fill: #ffebf2;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
+.cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox label {
   width: 100%;
 }
 
@@ -4366,13 +4378,13 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
   >
     <div
       aria-disabled="false"
-      class="e1s5n3hj0 cache-rogj7e-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
+      class="e1s5n3hj0 cache-1lh6i2f-CheckboxContainer-OverloadedCheckbox-StyledElement-StyledCheckbox eqr7bqq1"
       data-checked="false"
       data-error="false"
     >
@@ -4503,7 +4515,7 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
   width: 100%;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4525,60 +4537,61 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-15ags5z-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
@@ -4653,7 +4666,7 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
 }
 
 <div
-    class="cache-63kw8l-Container e1s5n3hj2"
+    class="cache-63kw8l-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
   >
@@ -4662,7 +4675,7 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-15ags5z-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj1 cache-1nu4lpe-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
         data-checked="false"
       >
         <input

--- a/packages/ui/src/components/SelectableCard/index.tsx
+++ b/packages/ui/src/components/SelectableCard/index.tsx
@@ -80,12 +80,17 @@ const StyledElement = styled('div', {
   }
 `
 
-const StyledRadio = StyledElement.withComponent(Radio)
+const OverloadedRadio = StyledElement.withComponent(Radio)
+const StyledRadio = styled(OverloadedRadio)`
+  pointer-events: none; // Prevents the label from being clickable as we want the container to be clickable
+`
 const OverloadedCheckbox = StyledElement.withComponent(Checkbox)
 const StyledCheckbox = styled(OverloadedCheckbox)`
   label {
     width: 100%;
   }
+
+  pointer-events: none; // Prevents the label from being clickable as we want the container to be clickable
 `
 
 type SelectableCardProps = {

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`SwitchButton renders correctly 1`] = `
   width: 100%;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -244,64 +244,65 @@ exports[`SwitchButton renders correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
@@ -388,7 +389,7 @@ exports[`SwitchButton renders correctly 1`] = `
       class="cache-tib6m2-StyledBorderedBox e4ryteh1"
     >
       <div
-        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="false"
         data-disabled="false"
       >
@@ -397,7 +398,7 @@ exports[`SwitchButton renders correctly 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj1 cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
             data-checked="false"
           >
             <input
@@ -444,7 +445,7 @@ exports[`SwitchButton renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="true"
         data-disabled="false"
       >
@@ -453,7 +454,7 @@ exports[`SwitchButton renders correctly 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj1 cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
             data-checked="true"
           >
             <input
@@ -631,7 +632,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
   width: 100%;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -653,64 +654,65 @@ exports[`SwitchButton renders correctly with right value 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
@@ -797,7 +799,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
       class="cache-tib6m2-StyledBorderedBox e4ryteh1"
     >
       <div
-        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="false"
         data-disabled="false"
       >
@@ -806,7 +808,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj1 cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
             data-checked="false"
           >
             <input
@@ -853,7 +855,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
         </div>
       </div>
       <div
-        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="true"
         data-disabled="false"
       >
@@ -862,7 +864,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj1 cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
             data-checked="true"
           >
             <input
@@ -1048,7 +1050,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
   width: 100%;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1070,64 +1072,65 @@ exports[`SwitchButton renders with tooltip 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  pointer-events: none;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='false'],
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='false']>label {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false'],
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='false']>label {
   cursor: pointer;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'][data-checked='false'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'][data-checked='false'] {
   color: #b5b7bd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 {
   fill: #8c40ef;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3+.ehkrmld4 .ehkrmld6 {
   fill: #e5dbfd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 {
   fill: #b3144d;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio:hover[aria-disabled='false'] .ehkrmld3[aria-invalid='true']+.ehkrmld4 .ehkrmld6 {
   fill: #ffd3e3;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true']>label,
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld3 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true']>label,
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld3 {
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 {
   fill: #e9eaeb;
   cursor: not-allowed;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] .ehkrmld4 .ehkrmld6 {
   fill: #f3f3f4;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[data-checked='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-checked='true'] {
   color: #641cb3;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[data-error='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[data-error='true'] {
   color: #b3144d;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement[aria-disabled='true'] {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio[aria-disabled='true'] {
   color: #b5b7bd;
 }
 
-.cache-14syb4e-RadioContainer-StyledRadio-StyledElement input+svg {
+.cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio input+svg {
   display: none;
 }
 
@@ -1220,7 +1223,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
         class="cache-tib6m2-StyledBorderedBox e4ryteh1"
       >
         <div
-          class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj2"
+          class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj3"
           data-checked="false"
           data-disabled="false"
         >
@@ -1229,7 +1232,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
           >
             <div
               aria-disabled="false"
-              class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+              class="e1s5n3hj1 cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
               data-checked="false"
             >
               <input
@@ -1276,7 +1279,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
           </div>
         </div>
         <div
-          class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj2"
+          class="e4ryteh0 cache-1kca9ar-Container-StyledSelectableCard e1s5n3hj3"
           data-checked="true"
           data-disabled="false"
         >
@@ -1285,7 +1288,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
           >
             <div
               aria-disabled="false"
-              class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+              class="e1s5n3hj1 cache-5awa2g-RadioContainer-OverloadedRadio-StyledElement-StyledRadio ehkrmld2"
               data-checked="true"
             >
               <input

--- a/packages/ui/src/components/SwitchButton/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SwitchButton/__tests__/index.test.tsx
@@ -74,15 +74,14 @@ describe('SwitchButton', () => {
           label: 'Right',
           value: 'right',
         }}
+        data-testid="switch-button"
         tooltip="This is a tooltip"
       />,
     )
 
-    const input = screen.getAllByRole('radio', {
-      hidden: true,
-    })
+    const rightButton = screen.getByTestId('switch-button-right')
 
-    await userEvent.click(input[1])
+    await userEvent.click(rightButton)
   })
 })
 

--- a/packages/ui/src/components/SwitchButton/index.tsx
+++ b/packages/ui/src/components/SwitchButton/index.tsx
@@ -137,6 +137,7 @@ export const SwitchButton = ({
             onFocus={onFocus}
             data-checked={localValue === leftButton.value}
             label={leftButton.label}
+            data-testid={dataTestId ? `${dataTestId}-left` : undefined}
           />
           <StyledSelectableCard
             ref={rightButtonRef}
@@ -148,6 +149,7 @@ export const SwitchButton = ({
             onFocus={onFocus}
             data-checked={localValue === rightButton.value}
             label={rightButton.label}
+            data-testid={dataTestId ? `${dataTestId}-right` : undefined}
           />
         </StyledBorderedBox>
       </div>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The `SelectableCard` is a complex component that uses both a `Checkbox` and `Radio` behind the hood. Both of those input are wrapped into a `Card` that is clickable and changes the value of the input.

The issue here is that when you click on the label or the checkbox, it bubble up the change event to the parent container triggering 2 changes. To avoid this I added a `pointer-event: none;` on both the checkbox and radio inside `SelectablecCard`. 
This way we ensure that when you click on the `Card` it's the `SelectableCard` that changes the state.


## Relevant logs and/or screenshots

Before:

https://github.com/scaleway/ultraviolet/assets/15812968/78aee77f-dfc5-4851-9e64-9865104ab8a2

After:

https://github.com/scaleway/ultraviolet/assets/15812968/e5c2d5bc-38dc-4c61-8fac-691002f6a5d3
