### PR TITLE
feat(tokens): new text tokens for gradients

### DIFF
--- a/.changeset/tender-bugs-pump.md
+++ b/.changeset/tender-bugs-pump.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/themes": minor
+---
+
+New tokens `colors.other.gradients.text.dark` and `colors.other.gradients.text.light` available. 
+Those tokens can be used for text above gradient background.

--- a/packages/themes/src/themes/console/dark.ts
+++ b/packages/themes/src/themes/console/dark.ts
@@ -144,6 +144,7 @@ export const darkTheme = {
           primary:
             'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
         },
+        text: { dark: '#0c0f1a', light: '#ffffff' },
       },
       icon: {
         category: { primary: { fill: '#a061f4', fillStrong: '#d8c5fc' } },

--- a/packages/themes/src/themes/console/darker.ts
+++ b/packages/themes/src/themes/console/darker.ts
@@ -144,6 +144,7 @@ export const darkerTheme = {
           primary:
             'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
         },
+        text: { dark: '#000000', light: '#e2e4e4' },
       },
       icon: {
         category: { primary: { fill: '#8d40ee', fillStrong: '#ceb1fb' } },

--- a/packages/themes/src/themes/console/light.ts
+++ b/packages/themes/src/themes/console/light.ts
@@ -144,6 +144,7 @@ export const lightTheme = {
           primary:
             'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
         },
+        text: { dark: '#222638', light: '#ffffff' },
       },
       icon: {
         category: { primary: { fill: '#521094', fillStrong: '#a060f6' } },


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Gradient can be tricky and does not always work with our current text token. In order to display a text on a gradient we need the text color to follow the gradient to be visible through themes change. To do so we added a new prop `text` in the theme for gradient that will be used for text above gradient background.

They are accessible with: `theme.colors.other.gradients.text.dark` or `theme.colors.other.gradients.text.light`
