### PR TITLE
fix(TextInput): input padding to follow unit length

### DIFF
--- a/.changeset/chilly-cobras-bathe.md
+++ b/.changeset/chilly-cobras-bathe.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Fix `<TextInputField />` to change input padding according to unit size avoiding overflow

--- a/.changeset/curvy-kiwis-turn.md
+++ b/.changeset/curvy-kiwis-turn.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<TextInput />` to change input padding according to unit size avoiding overflow

--- a/.changeset/purple-ads-jam.md
+++ b/.changeset/purple-ads-jam.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<EstimateCost.Unit />` increase the size of the unit and fix overflowing

--- a/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -667,7 +667,7 @@ exports[`TextInputField should render correctly random 1`] = `
   position: relative;
 }
 
-.cache-2i7sd1 {
+.cache-1ehejze {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -694,52 +694,51 @@ exports[`TextInputField should render correctly random 1`] = `
   padding-right: 20px;
   padding-top: 14px;
   padding: 8px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-2i7sd1::-webkit-input-placeholder {
+.cache-1ehejze::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-2i7sd1::-moz-placeholder {
+.cache-1ehejze::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-2i7sd1:-ms-input-placeholder {
+.cache-1ehejze:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-2i7sd1::placeholder {
+.cache-1ehejze::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-2i7sd1:hover,
-.cache-2i7sd1:focus {
+.cache-1ehejze:hover,
+.cache-1ehejze:focus {
   border-color: #792dd4;
 }
 
-.cache-2i7sd1:focus {
+.cache-1ehejze:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-2i7sd1::-webkit-input-placeholder {
+.cache-1ehejze::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-2i7sd1::-moz-placeholder {
+.cache-1ehejze::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-2i7sd1:-ms-input-placeholder {
+.cache-1ehejze:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-2i7sd1::placeholder {
+.cache-1ehejze::placeholder {
   opacity: 1;
 }
 
@@ -884,7 +883,7 @@ exports[`TextInputField should render correctly random 1`] = `
       >
         <input
           autocomplete="on"
-          class="cache-2i7sd1 el3h3g92"
+          class="cache-1ehejze el3h3g92"
           name="test"
           type="text"
           value=""

--- a/packages/plus/src/components/EstimateCost/Components/Unit.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/Unit.tsx
@@ -48,8 +48,7 @@ export const Unit = ({
       <Regular>{capacity}</Regular>
     </ItemResourceName>
   ) : (
-    // 120px is arbitrary, just to avoid full width input (ugly) nor too small input.
-    <div style={{ width: '120px' }}>
+    <div style={{ width: '150px' }}>
       <StyledTextInput
         type="number"
         size="small"

--- a/packages/plus/src/components/EstimateCost/__stories__/Unit.stories.tsx
+++ b/packages/plus/src/components/EstimateCost/__stories__/Unit.stories.tsx
@@ -9,7 +9,7 @@ Unit.args = {
       label="Storage"
       subLabel="50 GB Free"
       price={0.001}
-      unit="GB"
+      unit="samples"
       amountFree={50}
       amount={100}
     >

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.spec.tsx.snap
@@ -738,7 +738,7 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -766,52 +766,52 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -1229,7 +1229,7 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -1239,7 +1239,7 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -2068,7 +2068,7 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -2096,52 +2096,52 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -2559,7 +2559,7 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -2569,7 +2569,7 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -3398,7 +3398,7 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -3426,52 +3426,52 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -3889,7 +3889,7 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -3899,7 +3899,7 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -4742,7 +4742,7 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -4770,52 +4770,52 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -5250,7 +5250,7 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -5260,7 +5260,7 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -6108,7 +6108,7 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -6136,52 +6136,52 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -6616,7 +6616,7 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -6626,7 +6626,7 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -7498,7 +7498,7 @@ exports[`EstimateCost - Unit Item render test 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-q40gpm {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -7526,52 +7526,52 @@ exports[`EstimateCost - Unit Item render test 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(5 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-q40gpm::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-q40gpm::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-q40gpm:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-q40gpm::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-q40gpm:hover,
+.cache-q40gpm:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-q40gpm:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-q40gpm::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-q40gpm::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-q40gpm:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-q40gpm::placeholder {
   opacity: 1;
 }
 
@@ -8082,7 +8082,7 @@ exports[`EstimateCost - Unit Item render test 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -8092,7 +8092,7 @@ exports[`EstimateCost - Unit Item render test 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-q40gpm el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -8174,7 +8174,7 @@ exports[`EstimateCost - Unit Item render test 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -8184,7 +8184,7 @@ exports[`EstimateCost - Unit Item render test 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-q40gpm el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -9027,7 +9027,7 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -9055,52 +9055,52 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -9516,7 +9516,7 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -9526,7 +9526,7 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -10355,7 +10355,7 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -10383,52 +10383,52 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -10858,7 +10858,7 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -10868,7 +10868,7 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"
@@ -11702,7 +11702,7 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
   -moz-appearance: textfield;
 }
 
-.cache-hu08id {
+.cache-1a0hd8o {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -11730,52 +11730,52 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
   padding-top: 14px;
   font-size: 14px;
   padding: 4px 8px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-hu08id:hover,
-.cache-hu08id:focus {
+.cache-1a0hd8o:hover,
+.cache-1a0hd8o:focus {
   border-color: #792dd4;
 }
 
-.cache-hu08id:focus {
+.cache-1a0hd8o:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-hu08id::-webkit-input-placeholder {
+.cache-1a0hd8o::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::-moz-placeholder {
+.cache-1a0hd8o::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id:-ms-input-placeholder {
+.cache-1a0hd8o:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-hu08id::placeholder {
+.cache-1a0hd8o::placeholder {
   opacity: 1;
 }
 
@@ -12193,7 +12193,7 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
                   class="cache-12tubxd-StyledResourceName e1kzy2rr7"
                 >
                   <div
-                    style="width: 120px;"
+                    style="width: 150px;"
                   >
                     <div
                       class="cache-glu28w-StyledTextInput e1pr25uw0"
@@ -12203,7 +12203,7 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
                       >
                         <input
                           autocomplete="on"
-                          class="cache-hu08id el3h3g92"
+                          class="cache-1a0hd8o el3h3g92"
                           name="capacity"
                           placeholder="00"
                           type="number"

--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -226,7 +226,7 @@ exports[`DateInput render correctly with a array of dates to exclude 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -240,7 +240,16 @@ exports[`DateInput render correctly with a array of dates to exclude 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -332,7 +341,7 @@ exports[`DateInput render correctly with a array of dates to exclude 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+                class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -596,7 +605,7 @@ exports[`DateInput render correctly with a range of date 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -610,7 +619,16 @@ exports[`DateInput render correctly with a range of date 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -702,7 +720,7 @@ exports[`DateInput render correctly with a range of date 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+                class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -955,7 +973,7 @@ exports[`DateInput renders correctly disabled 1`] = `
   border-color: #792dd4;
 }
 
-.cache-1m6vn0h-StyledLabel-StyledLabel {
+.cache-1uzanyx-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -969,7 +987,16 @@ exports[`DateInput renders correctly disabled 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -1060,7 +1087,7 @@ exports[`DateInput renders correctly disabled 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-1m6vn0h-StyledLabel-StyledLabel el3h3g96"
+                class="cache-1uzanyx-StyledLabel-StyledLabel el3h3g96"
                 disabled=""
                 for="date-input"
               >
@@ -1336,7 +1363,7 @@ exports[`DateInput renders correctly error 1`] = `
   border-color: #92103f;
 }
 
-.cache-ygsxys-StyledLabel-StyledLabel-StyledLabel {
+.cache-ikb6i3-StyledLabel-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -1350,7 +1377,16 @@ exports[`DateInput renders correctly error 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -1443,7 +1479,7 @@ exports[`DateInput renders correctly error 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-ygsxys-StyledLabel-StyledLabel-StyledLabel el3h3g96"
+                class="cache-ikb6i3-StyledLabel-StyledLabel-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -1725,7 +1761,7 @@ exports[`DateInput renders correctly error disabled 1`] = `
   border-color: #92103f;
 }
 
-.cache-bpr4at-StyledLabel-StyledLabel-StyledLabel-StyledLabel {
+.cache-ldumqz-StyledLabel-StyledLabel-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -1739,7 +1775,16 @@ exports[`DateInput renders correctly error disabled 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -1835,7 +1880,7 @@ exports[`DateInput renders correctly error disabled 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-bpr4at-StyledLabel-StyledLabel-StyledLabel-StyledLabel el3h3g96"
+                class="cache-ldumqz-StyledLabel-StyledLabel-StyledLabel-StyledLabel el3h3g96"
                 disabled=""
                 for="date-input"
               >
@@ -2118,7 +2163,7 @@ exports[`DateInput renders correctly error disabled required 1`] = `
   border-color: #92103f;
 }
 
-.cache-bpr4at-StyledLabel-StyledLabel-StyledLabel-StyledLabel {
+.cache-ldumqz-StyledLabel-StyledLabel-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2132,7 +2177,16 @@ exports[`DateInput renders correctly error disabled required 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2237,7 +2291,7 @@ exports[`DateInput renders correctly error disabled required 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-bpr4at-StyledLabel-StyledLabel-StyledLabel-StyledLabel el3h3g96"
+                class="cache-ldumqz-StyledLabel-StyledLabel-StyledLabel-StyledLabel el3h3g96"
                 disabled=""
                 for="date-input"
               >
@@ -2496,7 +2550,7 @@ exports[`DateInput renders correctly min-max 1`] = `
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2510,7 +2564,16 @@ exports[`DateInput renders correctly min-max 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2598,7 +2661,7 @@ exports[`DateInput renders correctly min-max 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-wtloc3-StyledLabel el3h3g96"
+                class="cache-a0fgh0-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -2846,7 +2909,7 @@ exports[`DateInput renders correctly required 1`] = `
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2860,7 +2923,16 @@ exports[`DateInput renders correctly required 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2957,7 +3029,7 @@ exports[`DateInput renders correctly required 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-wtloc3-StyledLabel el3h3g96"
+                class="cache-a0fgh0-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -3229,7 +3301,7 @@ exports[`DateInput renders correctly with date-fns locale es 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -3243,7 +3315,16 @@ exports[`DateInput renders correctly with date-fns locale es 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -3432,7 +3513,7 @@ exports[`DateInput renders correctly with date-fns locale es 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+                class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -4304,7 +4385,7 @@ exports[`DateInput renders correctly with date-fns locale fr 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -4318,7 +4399,16 @@ exports[`DateInput renders correctly with date-fns locale fr 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -4507,7 +4597,7 @@ exports[`DateInput renders correctly with date-fns locale fr 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+                class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -5379,7 +5469,7 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -5393,7 +5483,16 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -5582,7 +5681,7 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+                class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
                 for="date-input"
               >
                 Date
@@ -6454,7 +6553,7 @@ exports[`DateInput renders correctly with default props 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -6468,7 +6567,16 @@ exports[`DateInput renders correctly with default props 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -6561,7 +6669,7 @@ exports[`DateInput renders correctly with default props 1`] = `
               />
               <label
                 aria-live="assertive"
-                class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+                class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
                 for="date-input-test"
               >
                 Date

--- a/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TextInput should handle events on random button 1`] = `
   position: relative;
 }
 
-.cache-1ciudd4-StyledInput {
+.cache-1ws5f5r-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -33,52 +33,51 @@ exports[`TextInput should handle events on random button 1`] = `
   padding-right: 20px;
   padding-top: 14px;
   padding: 8px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:hover,
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:hover,
+.cache-1ws5f5r-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   opacity: 1;
 }
 
@@ -220,7 +219,7 @@ exports[`TextInput should handle events on random button 1`] = `
     >
       <input
         autocomplete="on"
-        class="cache-1ciudd4-StyledInput el3h3g92"
+        class="cache-1ws5f5r-StyledInput el3h3g92"
         data-testid="test"
         name="test"
         type="text"
@@ -267,7 +266,7 @@ exports[`TextInput should handle events on toggleable password 1`] = `
   position: relative;
 }
 
-.cache-1ciudd4-StyledInput {
+.cache-1ws5f5r-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -294,52 +293,51 @@ exports[`TextInput should handle events on toggleable password 1`] = `
   padding-right: 20px;
   padding-top: 14px;
   padding: 8px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:hover,
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:hover,
+.cache-1ws5f5r-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   opacity: 1;
 }
 
@@ -481,7 +479,7 @@ exports[`TextInput should handle events on toggleable password 1`] = `
     >
       <input
         autocomplete="on"
-        class="cache-1ciudd4-StyledInput el3h3g92"
+        class="cache-1ws5f5r-StyledInput el3h3g92"
         data-testid="test"
         name="password"
         type="password"
@@ -724,7 +722,7 @@ exports[`TextInput should render correctly disabled true 1`] = `
   opacity: 1;
 }
 
-.cache-1xdphpi-StyledLabel-StyledLabel-StyledLabel {
+.cache-16yfce-StyledLabel-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -738,7 +736,16 @@ exports[`TextInput should render correctly disabled true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -780,7 +787,7 @@ exports[`TextInput should render correctly disabled true 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1xdphpi-StyledLabel-StyledLabel-StyledLabel el3h3g96"
+        class="cache-16yfce-StyledLabel-StyledLabel-StyledLabel el3h3g96"
         disabled=""
       >
         Test
@@ -888,7 +895,7 @@ exports[`TextInput should render correctly error string 1`] = `
   border-color: #92103f;
 }
 
-.cache-ygsxys-StyledLabel-StyledLabel-StyledLabel {
+.cache-ikb6i3-StyledLabel-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -902,7 +909,16 @@ exports[`TextInput should render correctly error string 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -943,7 +959,7 @@ exports[`TextInput should render correctly error string 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-ygsxys-StyledLabel-StyledLabel-StyledLabel el3h3g96"
+        class="cache-ikb6i3-StyledLabel-StyledLabel-StyledLabel el3h3g96"
       >
         Test
       </label>
@@ -1276,7 +1292,7 @@ exports[`TextInput should render correctly label and noTopLabel 3`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -1290,7 +1306,16 @@ exports[`TextInput should render correctly label and noTopLabel 3`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -1330,7 +1355,7 @@ exports[`TextInput should render correctly label and noTopLabel 3`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
       >
         Test
       </label>
@@ -1546,7 +1571,7 @@ exports[`TextInput should render correctly required true 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -1560,7 +1585,16 @@ exports[`TextInput should render correctly required true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -1635,7 +1669,7 @@ exports[`TextInput should render correctly required true 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
       >
         Test
       </label>
@@ -1727,7 +1761,7 @@ exports[`TextInput should render correctly with ariaControls 1`] = `
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -1741,7 +1775,16 @@ exports[`TextInput should render correctly with ariaControls 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -1780,7 +1823,7 @@ exports[`TextInput should render correctly with ariaControls 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
         id="test-control"
       >
         test
@@ -1877,7 +1920,7 @@ exports[`TextInput should render correctly with basic props 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -1891,7 +1934,16 @@ exports[`TextInput should render correctly with basic props 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -1933,7 +1985,7 @@ exports[`TextInput should render correctly with basic props 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
         for="test"
       >
         Test
@@ -2014,7 +2066,7 @@ exports[`TextInput should render correctly with defaultValue true 1`] = `
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2028,7 +2080,16 @@ exports[`TextInput should render correctly with defaultValue true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2065,7 +2126,7 @@ exports[`TextInput should render correctly with defaultValue true 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -2161,7 +2222,7 @@ exports[`TextInput should render correctly with edit true 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2175,7 +2236,16 @@ exports[`TextInput should render correctly with edit true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2216,7 +2286,7 @@ exports[`TextInput should render correctly with edit true 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -2296,7 +2366,7 @@ exports[`TextInput should render correctly with fillAvailable true 1`] = `
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2310,7 +2380,16 @@ exports[`TextInput should render correctly with fillAvailable true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2347,7 +2426,7 @@ exports[`TextInput should render correctly with fillAvailable true 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -2443,7 +2522,7 @@ exports[`TextInput should render correctly with generated true 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2457,7 +2536,16 @@ exports[`TextInput should render correctly with generated true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2498,7 +2586,7 @@ exports[`TextInput should render correctly with generated true 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -2594,7 +2682,7 @@ exports[`TextInput should render correctly with height prop 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2608,7 +2696,16 @@ exports[`TextInput should render correctly with height prop 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2649,7 +2746,7 @@ exports[`TextInput should render correctly with height prop 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
       >
         Test
       </label>
@@ -2671,7 +2768,7 @@ exports[`TextInput should render correctly with multiple right components 1`] = 
   position: relative;
 }
 
-.cache-y70r2e-StyledInput {
+.cache-rjtrot-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -2697,40 +2794,40 @@ exports[`TextInput should render correctly with multiple right components 1`] = 
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(5.5 * 32px);
+  padding-right: calc(2 * 8px + 4.5 * 32px);
 }
 
-.cache-y70r2e-StyledInput::-webkit-input-placeholder {
+.cache-rjtrot-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-y70r2e-StyledInput::-moz-placeholder {
+.cache-rjtrot-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-y70r2e-StyledInput:-ms-input-placeholder {
+.cache-rjtrot-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-y70r2e-StyledInput::placeholder {
+.cache-rjtrot-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-y70r2e-StyledInput:hover,
-.cache-y70r2e-StyledInput:focus {
+.cache-rjtrot-StyledInput:hover,
+.cache-rjtrot-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-y70r2e-StyledInput:focus {
+.cache-rjtrot-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -2744,7 +2841,16 @@ exports[`TextInput should render correctly with multiple right components 1`] = 
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -2937,13 +3043,13 @@ exports[`TextInput should render correctly with multiple right components 1`] = 
       <input
         aria-label="Multiple"
         autocomplete="on"
-        class="cache-y70r2e-StyledInput el3h3g92"
+        class="cache-rjtrot-StyledInput el3h3g92"
         type="password"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         Multiple
       </label>
@@ -3101,7 +3207,7 @@ exports[`TextInput should render correctly with notice 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -3115,7 +3221,16 @@ exports[`TextInput should render correctly with notice 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -3186,7 +3301,7 @@ exports[`TextInput should render correctly with notice 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
       >
         Test
       </label>
@@ -3295,7 +3410,7 @@ exports[`TextInput should render correctly with null right component 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -3309,7 +3424,16 @@ exports[`TextInput should render correctly with null right component 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -3381,7 +3505,7 @@ exports[`TextInput should render correctly with null right component 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -3467,7 +3591,7 @@ exports[`TextInput should render correctly with readOnly true 1`] = `
   border-color: #792dd4;
 }
 
-.cache-1gl61bk-StyledLabel-StyledLabel {
+.cache-1f96hye-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -3481,7 +3605,16 @@ exports[`TextInput should render correctly with readOnly true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -3520,7 +3653,7 @@ exports[`TextInput should render correctly with readOnly true 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1gl61bk-StyledLabel-StyledLabel el3h3g96"
+        class="cache-1f96hye-StyledLabel-StyledLabel el3h3g96"
         readonly=""
       >
         test
@@ -3543,7 +3676,7 @@ exports[`TextInput should render correctly with unit is px 1`] = `
   position: relative;
 }
 
-.cache-5lyde6-StyledInput {
+.cache-zikp4r-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -3569,40 +3702,40 @@ exports[`TextInput should render correctly with unit is px 1`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(1.5 * 32px);
+  padding-right: calc(2 * 8px + 0.5 * 32px);
 }
 
-.cache-5lyde6-StyledInput::-webkit-input-placeholder {
+.cache-zikp4r-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5lyde6-StyledInput::-moz-placeholder {
+.cache-zikp4r-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5lyde6-StyledInput:-ms-input-placeholder {
+.cache-zikp4r-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5lyde6-StyledInput::placeholder {
+.cache-zikp4r-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5lyde6-StyledInput:hover,
-.cache-5lyde6-StyledInput:focus {
+.cache-zikp4r-StyledInput:hover,
+.cache-zikp4r-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-5lyde6-StyledInput:focus {
+.cache-zikp4r-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -3616,7 +3749,16 @@ exports[`TextInput should render correctly with unit is px 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -3723,14 +3865,14 @@ exports[`TextInput should render correctly with unit is px 1`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-5lyde6-StyledInput el3h3g92"
+        class="cache-zikp4r-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -3770,7 +3912,7 @@ exports[`TextInput should render correctly with unit is px and required 1`] = `
   position: relative;
 }
 
-.cache-11xi0nx-StyledInput {
+.cache-4y3dc5-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -3796,40 +3938,40 @@ exports[`TextInput should render correctly with unit is px and required 1`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(2.5 * 32px);
+  padding-right: calc(2 * 8px + 1.5 * 32px);
 }
 
-.cache-11xi0nx-StyledInput::-webkit-input-placeholder {
+.cache-4y3dc5-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput::-moz-placeholder {
+.cache-4y3dc5-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput:-ms-input-placeholder {
+.cache-4y3dc5-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput::placeholder {
+.cache-4y3dc5-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput:hover,
-.cache-11xi0nx-StyledInput:focus {
+.cache-4y3dc5-StyledInput:hover,
+.cache-4y3dc5-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-11xi0nx-StyledInput:focus {
+.cache-4y3dc5-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -3843,7 +3985,16 @@ exports[`TextInput should render correctly with unit is px and required 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -3959,14 +4110,14 @@ exports[`TextInput should render correctly with unit is px and required 1`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-11xi0nx-StyledInput el3h3g92"
+        class="cache-4y3dc5-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -4014,7 +4165,7 @@ exports[`TextInput should render correctly with valid false 1`] = `
   position: relative;
 }
 
-.cache-1f4cp0i-StyledInput {
+.cache-1kf0sup-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -4040,40 +4191,39 @@ exports[`TextInput should render correctly with valid false 1`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1f4cp0i-StyledInput::-webkit-input-placeholder {
+.cache-1kf0sup-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::-moz-placeholder {
+.cache-1kf0sup-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:-ms-input-placeholder {
+.cache-1kf0sup-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::placeholder {
+.cache-1kf0sup-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:hover,
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:hover,
+.cache-1kf0sup-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -4087,7 +4237,16 @@ exports[`TextInput should render correctly with valid false 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -4176,14 +4335,14 @@ exports[`TextInput should render correctly with valid false 1`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-1f4cp0i-StyledInput el3h3g92"
+        class="cache-1kf0sup-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -4221,7 +4380,7 @@ exports[`TextInput should render correctly with valid false 2`] = `
   position: relative;
 }
 
-.cache-1f4cp0i-StyledInput {
+.cache-1kf0sup-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -4247,40 +4406,39 @@ exports[`TextInput should render correctly with valid false 2`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1f4cp0i-StyledInput::-webkit-input-placeholder {
+.cache-1kf0sup-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::-moz-placeholder {
+.cache-1kf0sup-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:-ms-input-placeholder {
+.cache-1kf0sup-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::placeholder {
+.cache-1kf0sup-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:hover,
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:hover,
+.cache-1kf0sup-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -4294,7 +4452,16 @@ exports[`TextInput should render correctly with valid false 2`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -4383,14 +4550,14 @@ exports[`TextInput should render correctly with valid false 2`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-1f4cp0i-StyledInput el3h3g92"
+        class="cache-1kf0sup-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -4428,7 +4595,7 @@ exports[`TextInput should render correctly with valid true 1`] = `
   position: relative;
 }
 
-.cache-1f4cp0i-StyledInput {
+.cache-1kf0sup-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -4454,40 +4621,39 @@ exports[`TextInput should render correctly with valid true 1`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1f4cp0i-StyledInput::-webkit-input-placeholder {
+.cache-1kf0sup-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::-moz-placeholder {
+.cache-1kf0sup-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:-ms-input-placeholder {
+.cache-1kf0sup-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::placeholder {
+.cache-1kf0sup-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:hover,
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:hover,
+.cache-1kf0sup-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -4501,7 +4667,16 @@ exports[`TextInput should render correctly with valid true 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -4590,14 +4765,14 @@ exports[`TextInput should render correctly with valid true 1`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-1f4cp0i-StyledInput el3h3g92"
+        class="cache-1kf0sup-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -4635,7 +4810,7 @@ exports[`TextInput should render correctly with valid true 2`] = `
   position: relative;
 }
 
-.cache-1f4cp0i-StyledInput {
+.cache-1kf0sup-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -4661,40 +4836,39 @@ exports[`TextInput should render correctly with valid true 2`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1f4cp0i-StyledInput::-webkit-input-placeholder {
+.cache-1kf0sup-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::-moz-placeholder {
+.cache-1kf0sup-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:-ms-input-placeholder {
+.cache-1kf0sup-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput::placeholder {
+.cache-1kf0sup-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1f4cp0i-StyledInput:hover,
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:hover,
+.cache-1kf0sup-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1f4cp0i-StyledInput:focus {
+.cache-1kf0sup-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -4708,7 +4882,16 @@ exports[`TextInput should render correctly with valid true 2`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -4797,14 +4980,14 @@ exports[`TextInput should render correctly with valid true 2`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-1f4cp0i-StyledInput el3h3g92"
+        class="cache-1kf0sup-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>
@@ -5040,7 +5223,7 @@ exports[`TextInput should render on focus 1`] = `
   opacity: 1;
 }
 
-.cache-1p16fwx-StyledLabel-StyledLabel {
+.cache-pp3wl3-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -5054,7 +5237,16 @@ exports[`TextInput should render on focus 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -5095,7 +5287,7 @@ exports[`TextInput should render on focus 1`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1p16fwx-StyledLabel-StyledLabel el3h3g96"
+        class="cache-pp3wl3-StyledLabel-StyledLabel el3h3g96"
         for="test"
       >
         Test
@@ -5118,7 +5310,7 @@ exports[`TextInput should render random 1`] = `
   position: relative;
 }
 
-.cache-1ciudd4-StyledInput {
+.cache-1ws5f5r-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -5145,52 +5337,51 @@ exports[`TextInput should render random 1`] = `
   padding-right: 20px;
   padding-top: 14px;
   padding: 8px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:hover,
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:hover,
+.cache-1ws5f5r-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   opacity: 1;
 }
 
@@ -5332,7 +5523,7 @@ exports[`TextInput should render random 1`] = `
     >
       <input
         autocomplete="on"
-        class="cache-1ciudd4-StyledInput el3h3g92"
+        class="cache-1ws5f5r-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
@@ -5377,7 +5568,7 @@ exports[`TextInput should render random 2`] = `
   position: relative;
 }
 
-.cache-5yew97-StyledInput {
+.cache-xw9g6j-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -5408,40 +5599,39 @@ exports[`TextInput should render random 2`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-5yew97-StyledInput::-webkit-input-placeholder {
+.cache-xw9g6j-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5yew97-StyledInput::-moz-placeholder {
+.cache-xw9g6j-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5yew97-StyledInput:-ms-input-placeholder {
+.cache-xw9g6j-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5yew97-StyledInput::placeholder {
+.cache-xw9g6j-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-5yew97-StyledInput:hover,
-.cache-5yew97-StyledInput:focus {
+.cache-xw9g6j-StyledInput:hover,
+.cache-xw9g6j-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-5yew97-StyledInput:focus {
+.cache-xw9g6j-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-1m6vn0h-StyledLabel-StyledLabel {
+.cache-1uzanyx-StyledLabel-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -5455,7 +5645,16 @@ exports[`TextInput should render random 2`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -5595,7 +5794,7 @@ exports[`TextInput should render random 2`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-5yew97-StyledInput el3h3g92"
+        class="cache-xw9g6j-StyledInput el3h3g92"
         disabled=""
         name="test"
         type="text"
@@ -5603,7 +5802,7 @@ exports[`TextInput should render random 2`] = `
       />
       <label
         aria-live="assertive"
-        class="cache-1m6vn0h-StyledLabel-StyledLabel el3h3g96"
+        class="cache-1uzanyx-StyledLabel-StyledLabel el3h3g96"
         disabled=""
       >
         test
@@ -5944,7 +6143,7 @@ exports[`TextInput should render toggleable password 1`] = `
   position: relative;
 }
 
-.cache-1ciudd4-StyledInput {
+.cache-1ws5f5r-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -5971,52 +6170,51 @@ exports[`TextInput should render toggleable password 1`] = `
   padding-right: 20px;
   padding-top: 14px;
   padding: 8px;
-  padding-right: calc(1 * 32px);
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-1ciudd4-StyledInput:hover,
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:hover,
+.cache-1ws5f5r-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput:focus {
+.cache-1ws5f5r-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-1ciudd4-StyledInput::-webkit-input-placeholder {
+.cache-1ws5f5r-StyledInput::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::-moz-placeholder {
+.cache-1ws5f5r-StyledInput::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput:-ms-input-placeholder {
+.cache-1ws5f5r-StyledInput:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-1ciudd4-StyledInput::placeholder {
+.cache-1ws5f5r-StyledInput::placeholder {
   opacity: 1;
 }
 
@@ -6158,7 +6356,7 @@ exports[`TextInput should render toggleable password 1`] = `
     >
       <input
         autocomplete="on"
-        class="cache-1ciudd4-StyledInput el3h3g92"
+        class="cache-1ws5f5r-StyledInput el3h3g92"
         name="password"
         type="password"
         value=""
@@ -6498,7 +6696,7 @@ exports[`TextInput should render unit with required 1`] = `
   position: relative;
 }
 
-.cache-11xi0nx-StyledInput {
+.cache-4y3dc5-StyledInput {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -6524,40 +6722,40 @@ exports[`TextInput should render unit with required 1`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: calc(2.5 * 32px);
+  padding-right: calc(2 * 8px + 1.5 * 32px);
 }
 
-.cache-11xi0nx-StyledInput::-webkit-input-placeholder {
+.cache-4y3dc5-StyledInput::-webkit-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput::-moz-placeholder {
+.cache-4y3dc5-StyledInput::-moz-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput:-ms-input-placeholder {
+.cache-4y3dc5-StyledInput:-ms-input-placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput::placeholder {
+.cache-4y3dc5-StyledInput::placeholder {
   color: #727683;
   opacity: 0;
 }
 
-.cache-11xi0nx-StyledInput:hover,
-.cache-11xi0nx-StyledInput:focus {
+.cache-4y3dc5-StyledInput:hover,
+.cache-4y3dc5-StyledInput:focus {
   border-color: #792dd4;
 }
 
-.cache-11xi0nx-StyledInput:focus {
+.cache-4y3dc5-StyledInput:focus {
   box-shadow: 0px 0px 0px 3px #8c40ef40;
   border-color: #792dd4;
 }
 
-.cache-wtloc3-StyledLabel {
+.cache-a0fgh0-StyledLabel {
   display: block;
   position: absolute;
   left: 0;
@@ -6571,7 +6769,16 @@ exports[`TextInput should render unit with required 1`] = `
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size:font-family: Inter,Asap;
+  font-size: 14px;
+  font-weight: Regular;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  weight: 400;
   -webkit-transition: -webkit-transform 150ms;
   transition: transform 150ms;
   -webkit-transform: translate(0, 12px) scale(1);
@@ -6687,14 +6894,14 @@ exports[`TextInput should render unit with required 1`] = `
       <input
         aria-label="test"
         autocomplete="on"
-        class="cache-11xi0nx-StyledInput el3h3g92"
+        class="cache-4y3dc5-StyledInput el3h3g92"
         name="test"
         type="text"
         value=""
       />
       <label
         aria-live="assertive"
-        class="cache-wtloc3-StyledLabel el3h3g96"
+        class="cache-a0fgh0-StyledLabel el3h3g96"
       >
         test
       </label>

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -128,7 +128,7 @@ const StyledLabel = styled('label', {
   text-overflow: ellipsis;
   width: 100%;
   height: 48px;
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.typography.bodySmall};
   transition: transform 150ms;
   transform: translate(0, 12px) scale(1);
 
@@ -181,6 +181,8 @@ type StyledInputProps = {
   multiline?: boolean
   resizable?: boolean
   inputSize: TextInputSizes
+  unit?: string
+  rightComponentLength: number
 } & (
   | InputHTMLAttributes<HTMLInputElement>
   | TextareaHTMLAttributes<HTMLTextAreaElement>
@@ -203,6 +205,8 @@ const StyledInput = styled('input', {
       'resizable',
       'inputSize',
       'paddingRightFactor',
+      'rightComponentLength',
+      'unit',
     ].includes(prop),
 })<StyledInputProps>`
   transition:
@@ -294,10 +298,15 @@ const StyledInput = styled('input', {
     padding-top: ${theme.space['1']};
   `}
 
-  ${({ paddingRightFactor, theme }) =>
+  ${({ paddingRightFactor, rightComponentLength, unit, theme }) =>
     paddingRightFactor > 0 &&
     `
-    padding-right: calc(${paddingRightFactor} * ${theme.space['4']});
+    padding-right: calc(${
+      unit ? `${unit.length} * ${theme.space['1']} + ` : ''
+    }${
+      paddingRightFactor +
+      (unit ? rightComponentLength - 1 : rightComponentLength)
+    } * ${theme.space['4']});
   `}
 `
 
@@ -553,10 +562,7 @@ export const TextInput = forwardRef<
     ])
 
     const showSeparator = (required && hasRightElement) || unit
-    const paddingRightFactor =
-      rightComponentsArray.length +
-      (required ? 1 : 0) +
-      (showSeparator ? 0.5 : 0)
+    const paddingRightFactor = (required ? 1 : 0) + (showSeparator ? 0.5 : 0)
 
     return (
       <div className={className}>
@@ -576,6 +582,8 @@ export const TextInput = forwardRef<
             fillAvailable={fillAvailable}
             hasLabel={hasLabel}
             paddingRightFactor={paddingRightFactor}
+            rightComponentLength={rightComponentsArray.length}
+            unit={unit}
             id={id}
             inputSize={inputSize}
             isPlaceholderVisible={isPlaceholderVisible}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Current `<TextInput />` has an issue when we have too long unit lenght. The padding inside the input follows the size of the elements on the right it includes the unit length. So far we were just checking how many element there was on the right without counting the number of character in unit creating overflow issue as you can see on screenshots. 

It has been solve to take in account the unit size. It also fixe `<EstimateCost.Unit />` and I increased slightly the size of the unit.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| TextInput  | <img width="1056" alt="Screenshot 2023-12-20 at 11 15 24" src="https://github.com/scaleway/ultraviolet/assets/15812968/e2378ffb-17e6-48ec-a3cd-ed7883fce84e"> | <img width="1061" alt="Screenshot 2023-12-20 at 11 15 17" src="https://github.com/scaleway/ultraviolet/assets/15812968/92409825-0ae2-4c49-ac72-2361c01628c1"> |
| EstimateCost.Unit  | <img width="967" alt="Screenshot 2023-12-20 at 11 17 02" src="https://github.com/scaleway/ultraviolet/assets/15812968/ae0ac6d5-37e6-4e94-8f0c-6ded3540ec52"> | <img width="960" alt="Screenshot 2023-12-20 at 11 17 10" src="https://github.com/scaleway/ultraviolet/assets/15812968/92d0aa09-811f-426e-b9b7-e3f2bbf30c79"> |
