### PR TITLE
fix(Banner): default illustration to be correctly imported

### DIFF
--- a/.changeset/brown-otters-repair.md
+++ b/.changeset/brown-otters-repair.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Banner />` default illustration to be correctly imported

--- a/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Banner/__tests__/__snapshots__/index.tsx.snap
@@ -279,10 +279,7 @@ exports[`Banner renders correctly with a button 1`] = `
     <div
       class="cache-hmn6z8-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-19d60zd-Stack ehpbis70"
@@ -654,10 +651,7 @@ exports[`Banner renders correctly with a link 1`] = `
     <div
       class="cache-hmn6z8-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-19d60zd-Stack ehpbis70"
@@ -1107,10 +1101,7 @@ exports[`Banner renders correctly with closable to false 1`] = `
     <div
       class="cache-hmn6z8-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-wbv6k9-Stack ehpbis70"
@@ -1338,10 +1329,7 @@ exports[`Banner renders correctly with default values 1`] = `
     <div
       class="cache-hmn6z8-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-19d60zd-Stack ehpbis70"
@@ -1583,10 +1571,7 @@ exports[`Banner renders correctly with direction row 1`] = `
     <div
       class="cache-hmn6z8-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-wbv6k9-Stack ehpbis70"
@@ -1828,10 +1813,7 @@ exports[`Banner sizes and variants renders correctly with size medium and varian
     <div
       class="cache-hmn6z8-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-19d60zd-Stack ehpbis70"
@@ -2073,10 +2055,7 @@ exports[`Banner sizes and variants renders correctly with size medium and varian
     <div
       class="cache-hmn6z8-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-19d60zd-Stack ehpbis70"
@@ -2318,10 +2297,7 @@ exports[`Banner sizes and variants renders correctly with size small and variant
     <div
       class="cache-37jj6f-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-19d60zd-Stack ehpbis70"
@@ -2563,10 +2539,7 @@ exports[`Banner sizes and variants renders correctly with size small and variant
     <div
       class="cache-37jj6f-Stack-ImageStack e1kdwp5x0"
     >
-      <img
-        alt=""
-        src="test-file-stub"
-      />
+      <test-file-stub />
     </div>
     <div
       class="cache-19d60zd-Stack ehpbis70"

--- a/packages/ui/src/components/Banner/index.tsx
+++ b/packages/ui/src/components/Banner/index.tsx
@@ -134,7 +134,7 @@ export const Banner = ({
   'data-testid': dataTestId,
 }: BannerProps) => {
   const { theme } = useTheme()
-  const defaultImage =
+  const DefaultImage =
     size === 'small' ? defaultIllustrationSmall : defaultIllustration
 
   const [opened, setOpened] = useState(true)
@@ -149,7 +149,7 @@ export const Banner = ({
       data-testid={dataTestId}
     >
       <ImageStack size={size} justifyContent="center">
-        {image ?? <img src={defaultImage} alt="" />}
+        {image ?? <DefaultImage />}
       </ImageStack>
       <Stack
         direction={direction}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There is an issue with banner and the default image, it seems not to be displayed correctly. This is because now svg files are considered as React Component and should be used like that.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| Banner  | <img width="1041" alt="Screenshot 2024-01-09 at 10 01 51" src="https://github.com/scaleway/ultraviolet/assets/15812968/e7e3458b-2605-42c0-bd70-53e1ff87c869"> | <img width="1019" alt="Screenshot 2024-01-09 at 10 01 59" src="https://github.com/scaleway/ultraviolet/assets/15812968/a60ad3cb-3188-4e0c-8613-91dee9b3cde6"> |
