### PR TITLE
fix: input value for controlled fields

### DIFF
--- a/.changeset/cuddly-hotels-ring.md
+++ b/.changeset/cuddly-hotels-ring.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+Fix input value for controlled fields

--- a/packages/form/src/components/TextInputField/__tests__/index.spec.tsx
+++ b/packages/form/src/components/TextInputField/__tests__/index.spec.tsx
@@ -64,5 +64,10 @@ describe('TextInputField', () => {
           })
         },
       },
+      {
+        initialValues: {
+          test: null,
+        },
+      },
     ))
 })

--- a/packages/form/src/components/TextInputFieldV2/__tests__/index.spec.tsx
+++ b/packages/form/src/components/TextInputFieldV2/__tests__/index.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, jest, test } from '@jest/globals'
-import { screen, waitFor } from '@testing-library/react'
+import { renderHook, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
 import { TextInputField } from '..'
 import { Submit } from '../..'
 import {
@@ -17,10 +18,13 @@ describe('TextInputFieldV2', () => {
     ))
 
   test('should render correctly generated', async () => {
-    const onSubmit = jest.fn<(values: { test: string }) => void>()
+    const onSubmit = jest.fn<(values: { test: string | null }) => void>()
+    const { result } = renderHook(() =>
+      useForm<{ test: string | null }>({ defaultValues: { test: null } }),
+    )
 
     renderWithTheme(
-      <Form onRawSubmit={onSubmit} errors={mockErrors}>
+      <Form onRawSubmit={onSubmit} errors={mockErrors} methods={result.current}>
         <TextInputField label="Test" name="test" required clearable />
         <Submit>Submit</Submit>
       </Form>,

--- a/packages/ui/src/components/NumberInput/index.tsx
+++ b/packages/ui/src/components/NumberInput/index.tsx
@@ -393,9 +393,7 @@ export const NumberInput = ({
               style={{
                 width: inputWidth,
               }}
-              value={
-                currentValue !== undefined ? currentValue.toString() : undefined
-              } // A dom element can only have string attributes.
+              value={currentValue !== undefined ? currentValue.toString() : ''} // A dom element can only have string attributes.
               type="number"
               id={id || uniqueId}
               aria-label={!label && !ariaLabel ? 'Number Input' : ariaLabel}

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -602,7 +602,7 @@ export const TextInput = forwardRef<
             style={{ height }}
             tabIndex={tabIndex}
             type={getType()}
-            value={value}
+            value={value === null ? '' : value}
             wrap={wrap}
             min={min}
             max={max}

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -254,7 +254,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
               autoFocus={autoFocus}
               disabled={disabled}
               ref={ref}
-              value={value}
+              value={value === null ? '' : value}
               onChange={event => {
                 onChange(event.currentTarget.value)
               }}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

When an input is controlled, the `value` should be not empty or `''`