### PR TITLE
docs: fix number and text input fields v2 to have better documentation

### DIFF
--- a/packages/form/src/components/NumberInputFieldV2/__stories__/index.stories.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/__stories__/index.stories.tsx
@@ -1,14 +1,30 @@
 import type { Meta } from '@storybook/react'
 import { Snippet, Stack, Text } from '@ultraviolet/ui'
+import { useForm } from 'react-hook-form'
 import { Form, NumberInputFieldV2 } from '../..'
 import { mockErrors } from '../../../mocks'
 
 export default {
   component: NumberInputFieldV2,
   decorators: [
-    ChildStory => (
-      <Form onRawSubmit={() => {}} errors={mockErrors}>
-        {values => (
+    ChildStory => {
+      const methods = useForm()
+      const {
+        errors,
+        isDirty,
+        isSubmitting,
+        touchedFields,
+        submitCount,
+        dirtyFields,
+        isValid,
+        isLoading,
+        isSubmitted,
+        isValidating,
+        isSubmitSuccessful,
+      } = methods.formState
+
+      return (
+        <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
             <div
               style={{
@@ -22,7 +38,7 @@ export default {
                 Form input values:
               </Text>
               <Snippet prefix="lines" initiallyExpanded>
-                {JSON.stringify(values.values, null, 1)}
+                {JSON.stringify(methods.watch(), null, 1)}
               </Snippet>
             </Stack>
             <Stack gap={1}>
@@ -30,13 +46,29 @@ export default {
                 Form values:
               </Text>
               <Snippet prefix="lines">
-                {JSON.stringify(values, null, 1)}
+                {JSON.stringify(
+                  {
+                    errors,
+                    isDirty,
+                    isSubmitting,
+                    touchedFields,
+                    submitCount,
+                    dirtyFields,
+                    isValid,
+                    isLoading,
+                    isSubmitted,
+                    isValidating,
+                    isSubmitSuccessful,
+                  },
+                  null,
+                  1,
+                )}
               </Snippet>
             </Stack>
           </Stack>
-        )}
-      </Form>
-    ),
+        </Form>
+      )
+    },
   ],
   parameters: {
     docs: {

--- a/packages/form/src/components/TextInputFieldV2/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextInputFieldV2/__stories__/index.stories.tsx
@@ -1,22 +1,68 @@
 import type { Meta } from '@storybook/react'
-import { TextInputField } from '..'
-import { Form } from '../..'
+import { Snippet, Stack, Text } from '@ultraviolet/ui'
+import { useForm } from 'react-hook-form'
+import { Form, TextInputFieldV2 } from '../..'
 import { mockErrors } from '../../../mocks'
 
 export default {
-  component: TextInputField,
+  component: TextInputFieldV2,
   decorators: [
-    ChildStory => (
-      <Form
-        onRawSubmit={() => {}}
-        errors={mockErrors}
-        initialValues={{
-          example: 'Text',
-        }}
-      >
-        {ChildStory()}
-      </Form>
-    ),
+    ChildStory => {
+      const methods = useForm()
+      const {
+        errors,
+        isDirty,
+        isSubmitting,
+        touchedFields,
+        submitCount,
+        dirtyFields,
+        isValid,
+        isLoading,
+        isSubmitted,
+        isValidating,
+        isSubmitSuccessful,
+      } = methods.formState
+
+      return (
+        <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
+          <Stack gap={2}>
+            {ChildStory()}
+            <Stack gap={1}>
+              <Text variant="bodyStrong" as="p">
+                Form input values:
+              </Text>
+              <Snippet prefix="lines" initiallyExpanded>
+                {JSON.stringify(methods.watch(), null, 1)}
+              </Snippet>
+            </Stack>
+            <Stack gap={1}>
+              <Text variant="bodyStrong" as="p">
+                Form values:
+              </Text>
+              <Snippet prefix="lines">
+                {JSON.stringify(
+                  {
+                    errors,
+                    isDirty,
+                    isSubmitting,
+                    touchedFields,
+                    submitCount,
+                    dirtyFields,
+                    isValid,
+                    isLoading,
+                    isSubmitted,
+                    isValidating,
+                    isSubmitSuccessful,
+                  },
+                  null,
+                  1,
+                )}
+              </Snippet>
+            </Stack>
+          </Stack>
+        </Form>
+      )
+    },
   ],
   title: 'Form/Components/Fields/TextInputFieldV2',
 } as Meta

--- a/packages/ui/src/components/Breadcrumbs/__stories__/To.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/To.stories.tsx
@@ -14,7 +14,7 @@ To.parameters = {
   docs: {
     description: {
       story:
-        'You can make `Breadcrumbs.Item` content be render as `a` tag with `to` prop. For relative url the `linkComponent` from your theme configuration is used.',
+        'You can make `Breadcrumbs.Item` content be render as `a` tag with `to` prop.',
     },
   },
 }


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

- Fix documentation of `NumberInputV2` and `TextInputV2` to have all props in form in a snippet
- Fix breadcrumbs to remove legacy documentation that is not true anymore

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| TextInput  | ![Screenshot 2024-01-15 at 17 03 43](https://github.com/scaleway/ultraviolet/assets/15812968/ce2fc32f-4b80-45b1-9375-4a64f60f50f3) | ![Screenshot 2024-01-15 at 17 03 46](https://github.com/scaleway/ultraviolet/assets/15812968/da1dc775-69dc-4d1e-9335-53411274e922) |
| NumberInput  | ![Screenshot 2024-01-15 at 17 21 18](https://github.com/scaleway/ultraviolet/assets/15812968/a548ff5b-90ce-40ad-b143-92bb60c94fc0) | ![Screenshot 2024-01-15 at 17 21 21](https://github.com/scaleway/ultraviolet/assets/15812968/b10de6b4-b1f2-4ad8-815d-a9fd8fe2b126) |
