### PR TITLE
feat: 🎸 illustration export index of all illustration assets

### DIFF
--- a/packages/illustrations/package.json
+++ b/packages/illustrations/package.json
@@ -35,9 +35,17 @@
       "types": "./dist/products/*/index.d.ts",
       "default": "./dist/products/*/index.js"
     },
+    "./products": {
+      "types": "./dist/products/index.d.ts",
+      "default": "./dist/products/index.js"
+    },
     "./various/*": {
       "types": "./dist/various/*/index.d.ts",
       "default": "./dist/various/*/index.js"
+    },
+    "./various": {
+      "types": "./dist/various/index.d.ts",
+      "default": "./dist/various/index.js"
     }
   },
   "devDependencies": {

--- a/packages/illustrations/rollup.config.mjs
+++ b/packages/illustrations/rollup.config.mjs
@@ -28,11 +28,18 @@ const external = id =>
     ...Object.keys(pkg.peerDependencies || {}),
   ].find(dep => new RegExp(dep).test(id))
 
+const input = [
+  'src/products/*/index.ts',
+  'src/products/index.ts',
+  './src/various/*/index.ts',
+  'src/various/index.ts',
+]
+
 export default [
   {
     external,
     preserveSymlinks: true,
-    input: ['src/products/*/index.ts', './src/various/*/index.ts'],
+    input,
     output: {
       dir: 'dist',
       format: 'es',
@@ -90,7 +97,7 @@ export default [
     ].filter(Boolean),
   },
   {
-    input: ['./src/products/*/index.ts', './src/various/*/index.ts'],
+    input,
     output: [{ dir: 'dist', format: 'es' }],
     plugins: [
       multiInput.default(),


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely

- add missing configuration in rollup to build index files

#### What is expected?

(Description of the new behavior)

- `@ultraviolet/illustrations/products` now export list of all defined illustration at once

#### The following changes where made:

(Describe what you did)

1. change configuration of rollup

2. change configuration of package.json exports

## How to check

- Fetch PR
- `pnpm run build`
- `cd packages/illustrations`
- `npm pack`
- check that new files are in the archive ready to be uploaded on NPM 