### PR TITLE
fix: v2 inputs to have body strong variant

### DIFF
--- a/.changeset/quick-panthers-punch.md
+++ b/.changeset/quick-panthers-punch.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+Fix `NumberInputV2`, `TextInputV2` and `TextArea` label to have `bodyStrong` instead of `bodySmallStrong` label

--- a/packages/form/src/components/NumberInputFieldV2/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/NumberInputFieldV2/__tests__/__snapshots__/index.spec.tsx.snap
@@ -71,13 +71,13 @@ exports[`NumberInputFieldV2 should render correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1qrwkk1 {
+.cache-fxvpe6 {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -338,7 +338,7 @@ exports[`NumberInputFieldV2 should render correctly 1`] = `
           class="cache-1l08jzy ehpbis70"
         >
           <label
-            class="cache-1qrwkk1 e13y3mga0"
+            class="cache-fxvpe6 e13y3mga0"
             for=":r0:"
           />
         </div>
@@ -483,13 +483,13 @@ exports[`NumberInputFieldV2 should render correctly disabled 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1qrwkk1 {
+.cache-fxvpe6 {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -741,7 +741,7 @@ exports[`NumberInputFieldV2 should render correctly disabled 1`] = `
           class="cache-1l08jzy ehpbis70"
         >
           <label
-            class="cache-1qrwkk1 e13y3mga0"
+            class="cache-fxvpe6 e13y3mga0"
             for=":r5:"
           />
         </div>
@@ -890,13 +890,13 @@ exports[`NumberInputFieldV2 should trigger event onMinCrossed & onMaxCrossed 1`]
   flex-wrap: nowrap;
 }
 
-.cache-1qrwkk1 {
+.cache-fxvpe6 {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1202,7 +1202,7 @@ exports[`NumberInputFieldV2 should trigger event onMinCrossed & onMaxCrossed 1`]
           class="cache-1l08jzy ehpbis70"
         >
           <label
-            class="cache-1qrwkk1 e13y3mga0"
+            class="cache-fxvpe6 e13y3mga0"
             for=":ra:"
           />
         </div>

--- a/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -71,13 +71,13 @@ exports[`TextAreaField should render correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1qrwkk1 {
+.cache-fxvpe6 {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -199,7 +199,7 @@ exports[`TextAreaField should render correctly 1`] = `
           class="cache-1l08jzy ehpbis70"
         >
           <label
-            class="cache-1qrwkk1 e13y3mga0"
+            class="cache-fxvpe6 e13y3mga0"
             for=":r0:"
           >
             Test

--- a/packages/form/src/components/TextInputFieldV2/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TextInputFieldV2/__tests__/__snapshots__/index.spec.tsx.snap
@@ -71,13 +71,13 @@ exports[`TextInputFieldV2 should render correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1qrwkk1 {
+.cache-fxvpe6 {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -181,7 +181,7 @@ exports[`TextInputFieldV2 should render correctly 1`] = `
           class="cache-1l08jzy ehpbis70"
         >
           <label
-            class="cache-1qrwkk1 e13y3mga0"
+            class="cache-fxvpe6 e13y3mga0"
             for=":r0:"
           >
             Test

--- a/packages/ui/src/components/NumberInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/NumberInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -71,13 +71,13 @@ exports[`NumberInputV2 should click on min button 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -337,7 +337,7 @@ exports[`NumberInputV2 should click on min button 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r26:"
         />
       </div>
@@ -481,13 +481,13 @@ exports[`NumberInputV2 should click on plus button with a step value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -747,7 +747,7 @@ exports[`NumberInputV2 should click on plus button with a step value 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r2b:"
         />
       </div>
@@ -891,13 +891,13 @@ exports[`NumberInputV2 should click on plus button with a step value and an in-b
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1157,7 +1157,7 @@ exports[`NumberInputV2 should click on plus button with a step value and an in-b
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r2l:"
         />
       </div>
@@ -1301,13 +1301,13 @@ exports[`NumberInputV2 should focus input and modify value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1567,7 +1567,7 @@ exports[`NumberInputV2 should focus input and modify value 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r2g:"
         />
       </div>
@@ -1711,13 +1711,13 @@ exports[`NumberInputV2 should renders correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1977,7 +1977,7 @@ exports[`NumberInputV2 should renders correctly 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r0:"
         />
       </div>
@@ -2120,13 +2120,13 @@ exports[`NumberInputV2 should renders correctly all sizes with size large 1`] = 
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2386,7 +2386,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size large 1`] = 
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r15:"
         />
       </div>
@@ -2529,13 +2529,13 @@ exports[`NumberInputV2 should renders correctly all sizes with size large and un
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2817,7 +2817,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size large and un
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r1a:"
         />
       </div>
@@ -2965,13 +2965,13 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium 1`] =
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3231,7 +3231,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium 1`] =
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r1g:"
         />
       </div>
@@ -3374,13 +3374,13 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium and u
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3662,7 +3662,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium and u
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r1l:"
         />
       </div>
@@ -3810,13 +3810,13 @@ exports[`NumberInputV2 should renders correctly all sizes with size small 1`] = 
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4076,7 +4076,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size small 1`] = 
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r1r:"
         />
       </div>
@@ -4219,13 +4219,13 @@ exports[`NumberInputV2 should renders correctly all sizes with size small and un
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4507,7 +4507,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size small and un
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r20:"
         />
       </div>
@@ -4655,13 +4655,13 @@ exports[`NumberInputV2 should renders correctly disabled 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4912,7 +4912,7 @@ exports[`NumberInputV2 should renders correctly disabled 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r5:"
         />
       </div>
@@ -5058,13 +5058,13 @@ exports[`NumberInputV2 should renders correctly max value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5324,7 +5324,7 @@ exports[`NumberInputV2 should renders correctly max value 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r10:"
         />
       </div>
@@ -5467,13 +5467,13 @@ exports[`NumberInputV2 should renders correctly min value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5733,7 +5733,7 @@ exports[`NumberInputV2 should renders correctly min value 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rr:"
         />
       </div>
@@ -5876,13 +5876,13 @@ exports[`NumberInputV2 should renders correctly with error 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6154,7 +6154,7 @@ exports[`NumberInputV2 should renders correctly with error 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":ra:"
         />
       </div>
@@ -6302,13 +6302,13 @@ exports[`NumberInputV2 should renders correctly with placeholder 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6568,7 +6568,7 @@ exports[`NumberInputV2 should renders correctly with placeholder 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rm:"
         />
       </div>
@@ -6711,13 +6711,13 @@ exports[`NumberInputV2 should renders correctly with success 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6989,7 +6989,7 @@ exports[`NumberInputV2 should renders correctly with success 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rg:"
         />
       </div>

--- a/packages/ui/src/components/NumberInputV2/index.tsx
+++ b/packages/ui/src/components/NumberInputV2/index.tsx
@@ -321,7 +321,7 @@ export const NumberInputV2 = forwardRef(
           <Stack direction="row" gap="0.5" alignItems="start">
             <Text
               as="label"
-              variant="bodySmallStrong"
+              variant="bodyStrong"
               sentiment="neutral"
               htmlFor={id ?? localId}
             >

--- a/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
@@ -71,13 +71,13 @@ exports[`TextArea should render correctly when input  has a error sentiment 1`] 
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -233,7 +233,7 @@ exports[`TextArea should render correctly when input  has a error sentiment 1`] 
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rk:"
         >
           Test
@@ -354,13 +354,13 @@ exports[`TextArea should render correctly when input has a success sentiment 1`]
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -516,7 +516,7 @@ exports[`TextArea should render correctly when input has a success sentiment 1`]
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rg:"
         >
           Test
@@ -637,13 +637,13 @@ exports[`TextArea should render correctly when input is disabled 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -764,7 +764,7 @@ exports[`TextArea should render correctly when input is disabled 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":ra:"
         >
           Test
@@ -866,13 +866,13 @@ exports[`TextArea should render correctly when input is readOnly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -993,7 +993,7 @@ exports[`TextArea should render correctly when input is readOnly 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rd:"
         >
           Test
@@ -1094,13 +1094,13 @@ exports[`TextArea should render correctly with basic props 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1221,7 +1221,7 @@ exports[`TextArea should render correctly with basic props 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r0:"
         >
           Test

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -182,7 +182,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           <Stack direction="row" gap="0.5" alignItems="start">
             <Text
               as="label"
-              variant="bodySmallStrong"
+              variant="bodyStrong"
               sentiment="neutral"
               htmlFor={id ?? localId}
             >

--- a/packages/ui/src/components/TextInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -71,13 +71,13 @@ exports[`TextInput should render correctly when input  has a error sentiment 1`]
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -225,7 +225,7 @@ exports[`TextInput should render correctly when input  has a error sentiment 1`]
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rk:"
         >
           Test
@@ -339,13 +339,13 @@ exports[`TextInput should render correctly when input has a success sentiment 1`
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -493,7 +493,7 @@ exports[`TextInput should render correctly when input has a success sentiment 1`
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rg:"
         >
           Test
@@ -607,13 +607,13 @@ exports[`TextInput should render correctly when input is disabled 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -716,7 +716,7 @@ exports[`TextInput should render correctly when input is disabled 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":ra:"
         >
           Test
@@ -814,13 +814,13 @@ exports[`TextInput should render correctly when input is readOnly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -923,7 +923,7 @@ exports[`TextInput should render correctly when input is readOnly 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":rd:"
         >
           Test
@@ -1021,13 +1021,13 @@ exports[`TextInput should render correctly with basic props 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1u2bv2v-StyledText {
+.cache-4gfeok-StyledText {
   color: #3f4250;
-  font-size: 14px;
+  font-size: 16px;
   font-family: Inter,Asap;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 24px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1130,7 +1130,7 @@ exports[`TextInput should render correctly with basic props 1`] = `
         class="cache-135dzb3-Stack ehpbis70"
       >
         <label
-          class="cache-1u2bv2v-StyledText e13y3mga0"
+          class="cache-4gfeok-StyledText e13y3mga0"
           for=":r0:"
         >
           Test

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -214,7 +214,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           <Stack direction="row" gap="0.5" alignItems="start">
             <Text
               as="label"
-              variant="bodySmallStrong"
+              variant="bodyStrong"
               sentiment="neutral"
               htmlFor={id ?? localId}
             >


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

The old labels of input use to have bodyStrong, in order to avoid having different labels size and style during the migration we decided to set the same to V2 components:`NumberInputV2`, `TextInputV2` and `TextArea` 

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2024-01-19 at 16 38 17](https://github.com/scaleway/ultraviolet/assets/15812968/dccc70c9-884a-46ce-9dae-e88d05ab8f28) | ![Screenshot 2024-01-19 at 16 38 20](https://github.com/scaleway/ultraviolet/assets/15812968/bf8c2334-e419-4fbf-be1f-0a53840aa45f) |