### PR TITLE
fix(EstimateCost): time unit spacing to be auto for fixing firefox

### DIFF
--- a/.changeset/khaki-cows-flash.md
+++ b/.changeset/khaki-cows-flash.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<EstimateCost />` time unit spacing on firefox

--- a/packages/plus/src/components/EstimateCost/Components/CustomUnitInput.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/CustomUnitInput.tsx
@@ -53,7 +53,6 @@ export const CustomUnitInput = ({
       minValue={1}
       size="medium"
       options={options}
-      selectInputWidth={300}
     />
   )
 }

--- a/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/UnitInput.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { SelectInput, Stack, TextInput } from '@ultraviolet/ui'
+import { Row, SelectInput, TextInput } from '@ultraviolet/ui'
 import type { ComponentProps, FocusEvent } from 'react'
 
 type SelectOption = Exclude<
@@ -84,7 +84,6 @@ type UnitInputProps = {
   onChangeUnitValue: (value: UnitInputValue['unit']) => void
   options: SelectOption[]
   placeholder?: string
-  selectInputWidth?: number
   size?: string
   textBoxWidth?: string | number
   'data-testid'?: string
@@ -108,7 +107,6 @@ export const UnitInput = ({
   value,
   unitValue,
   textBoxWidth = 100,
-  selectInputWidth = 200,
   disabled = false,
   options,
   className,
@@ -120,7 +118,7 @@ export const UnitInput = ({
   type = 'number',
   'data-testid': dataTestId,
 }: UnitInputProps) => (
-  <Stack direction="row" data-testid={dataTestId}>
+  <Row templateColumns="1fr auto" data-testid={dataTestId}>
     <CustomTextInput
       height={sizesHeight[size]}
       width={textBoxWidth}
@@ -154,7 +152,6 @@ export const UnitInput = ({
       error={valueError}
     />
     <CustomSelectInput
-      width={selectInputWidth}
       noTopLabel
       height={sizesHeight[size]}
       id={`${name}-unit`}
@@ -168,5 +165,5 @@ export const UnitInput = ({
       customStyle={customSelectStyle(sizesHeight[size])}
       disabled={disabled || options.length === 1}
     />
-  </Stack>
+  </Row>
 )

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/CustomUnitInput.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/CustomUnitInput.spec.tsx.snap
@@ -2,15 +2,9 @@
 
 exports[`EstimateCost - CustomUnitInput render default values 1`] = `
 <DocumentFragment>
-  .cache-gy0d8m {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  .cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -19,10 +13,6 @@ exports[`EstimateCost - CustomUnitInput render default values 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
 }
 
 .cache-igijr9-CustomTextInput input {
@@ -143,26 +133,24 @@ exports[`EstimateCost - CustomUnitInput render default values 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -421,7 +409,7 @@ exports[`EstimateCost - CustomUnitInput render default values 1`] = `
 }
 
 <div
-    class="cache-gy0d8m ehpbis70"
+    class="cache-e8qtir e3f5lzv0"
   >
     <div
       class="cache-igijr9-CustomTextInput epio27v1"
@@ -450,7 +438,7 @@ exports[`EstimateCost - CustomUnitInput render default values 1`] = `
       </div>
     </div>
     <div
-      class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+      class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
       data-testid="select-input-iteration-unit"
     >
       <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Item.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Item.spec.tsx.snap
@@ -347,6 +347,19 @@ exports[`EstimateCost - Item render with labelTextVariant 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -465,26 +478,24 @@ exports[`EstimateCost - Item render with labelTextVariant 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -953,7 +964,7 @@ exports[`EstimateCost - Item render with labelTextVariant 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -982,7 +993,7 @@ exports[`EstimateCost - Item render with labelTextVariant 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -1502,6 +1513,19 @@ exports[`EstimateCost - Item render with noPrice and noBorder 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -1620,26 +1644,24 @@ exports[`EstimateCost - Item render with noPrice and noBorder 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -2095,7 +2117,7 @@ exports[`EstimateCost - Item render with noPrice and noBorder 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -2124,7 +2146,7 @@ exports[`EstimateCost - Item render with noPrice and noBorder 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -2650,6 +2672,19 @@ exports[`EstimateCost - Item render with notice 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -2768,26 +2803,24 @@ exports[`EstimateCost - Item render with notice 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -3261,7 +3294,7 @@ exports[`EstimateCost - Item render with notice 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -3290,7 +3323,7 @@ exports[`EstimateCost - Item render with notice 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -3815,6 +3848,19 @@ exports[`EstimateCost - Item render with priceText 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -3933,26 +3979,24 @@ exports[`EstimateCost - Item render with priceText 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -4421,7 +4465,7 @@ exports[`EstimateCost - Item render with priceText 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -4450,7 +4494,7 @@ exports[`EstimateCost - Item render with priceText 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -4970,6 +5014,19 @@ exports[`EstimateCost - Item render with tabulation 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -5088,26 +5145,24 @@ exports[`EstimateCost - Item render with tabulation 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -5576,7 +5631,7 @@ exports[`EstimateCost - Item render with tabulation 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -5605,7 +5660,7 @@ exports[`EstimateCost - Item render with tabulation 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -6146,6 +6201,19 @@ exports[`EstimateCost - Item render with tooltipInfo 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -6264,26 +6332,24 @@ exports[`EstimateCost - Item render with tooltipInfo 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -6771,7 +6837,7 @@ exports[`EstimateCost - Item render with tooltipInfo 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -6800,7 +6866,7 @@ exports[`EstimateCost - Item render with tooltipInfo 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Region.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Region.spec.tsx.snap
@@ -341,6 +341,19 @@ exports[`EstimateCost - Region render region component 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -459,26 +472,24 @@ exports[`EstimateCost - Region render region component 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -952,7 +963,7 @@ exports[`EstimateCost - Region render region component 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -981,7 +992,7 @@ exports[`EstimateCost - Region render region component 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.spec.tsx.snap
@@ -324,6 +324,19 @@ exports[`EstimateCost - Regular Item render basic props 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -442,26 +455,24 @@ exports[`EstimateCost - Regular Item render basic props 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -918,7 +929,7 @@ exports[`EstimateCost - Regular Item render basic props 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -947,7 +958,7 @@ exports[`EstimateCost - Regular Item render basic props 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -1440,6 +1451,19 @@ exports[`EstimateCost - Regular Item render basic props with is not defined 1`] 
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -1558,26 +1582,24 @@ exports[`EstimateCost - Regular Item render basic props with is not defined 1`] 
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -2015,7 +2037,7 @@ exports[`EstimateCost - Regular Item render basic props with is not defined 1`] 
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -2044,7 +2066,7 @@ exports[`EstimateCost - Regular Item render basic props with is not defined 1`] 
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -2548,6 +2570,19 @@ exports[`EstimateCost - Regular Item render basic props with long fractions digi
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -2666,26 +2701,24 @@ exports[`EstimateCost - Regular Item render basic props with long fractions digi
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -3142,7 +3175,7 @@ exports[`EstimateCost - Regular Item render basic props with long fractions digi
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -3171,7 +3204,7 @@ exports[`EstimateCost - Regular Item render basic props with long fractions digi
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -3679,6 +3712,19 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -3797,26 +3843,24 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -4285,7 +4329,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -4314,7 +4358,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -4827,6 +4871,19 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice and longFr
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -4945,26 +5002,24 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice and longFr
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -5433,7 +5488,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice and longFr
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -5462,7 +5517,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice and longFr
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -6017,6 +6072,19 @@ exports[`EstimateCost - Regular Item render basic props with overlay 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -6135,26 +6203,24 @@ exports[`EstimateCost - Regular Item render basic props with overlay 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -6717,7 +6783,7 @@ exports[`EstimateCost - Regular Item render basic props with overlay 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -6746,7 +6812,7 @@ exports[`EstimateCost - Regular Item render basic props with overlay 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -7377,6 +7443,19 @@ exports[`EstimateCost - Regular Item render basic props with overlay beta 1`] = 
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -7495,26 +7574,24 @@ exports[`EstimateCost - Regular Item render basic props with overlay beta 1`] = 
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -8062,7 +8139,7 @@ exports[`EstimateCost - Regular Item render basic props with overlay beta 1`] = 
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -8091,7 +8168,7 @@ exports[`EstimateCost - Regular Item render basic props with overlay beta 1`] = 
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -8623,6 +8700,19 @@ exports[`EstimateCost - Regular Item render basic props with sublabel 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -8741,26 +8831,24 @@ exports[`EstimateCost - Regular Item render basic props with sublabel 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -9231,7 +9319,7 @@ exports[`EstimateCost - Regular Item render basic props with sublabel 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -9260,7 +9348,7 @@ exports[`EstimateCost - Regular Item render basic props with sublabel 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -9773,6 +9861,19 @@ exports[`EstimateCost - Regular Item render basic props with textNotDefined 1`] 
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -9891,26 +9992,24 @@ exports[`EstimateCost - Regular Item render basic props with textNotDefined 1`] 
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -10367,7 +10466,7 @@ exports[`EstimateCost - Regular Item render basic props with textNotDefined 1`] 
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -10396,7 +10495,7 @@ exports[`EstimateCost - Regular Item render basic props with textNotDefined 1`] 
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -10919,6 +11018,19 @@ exports[`EstimateCost - Regular Item render basic with ellipsis 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -11037,26 +11149,24 @@ exports[`EstimateCost - Regular Item render basic with ellipsis 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -11534,7 +11644,7 @@ exports[`EstimateCost - Regular Item render basic with ellipsis 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -11563,7 +11673,7 @@ exports[`EstimateCost - Regular Item render basic with ellipsis 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -12194,6 +12304,19 @@ exports[`EstimateCost - Regular Item render with alert 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -12312,26 +12435,24 @@ exports[`EstimateCost - Regular Item render with alert 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -12817,7 +12938,7 @@ exports[`EstimateCost - Regular Item render with alert 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -12846,7 +12967,7 @@ exports[`EstimateCost - Regular Item render with alert 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -13339,6 +13460,19 @@ exports[`EstimateCost - Regular Item render with isDisabledOnOverlay 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -13457,26 +13591,24 @@ exports[`EstimateCost - Regular Item render with isDisabledOnOverlay 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -13927,7 +14059,7 @@ exports[`EstimateCost - Regular Item render with isDisabledOnOverlay 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -13956,7 +14088,7 @@ exports[`EstimateCost - Regular Item render with isDisabledOnOverlay 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.spec.tsx.snap
@@ -324,6 +324,19 @@ exports[`EstimateCost - NumberInput Item render basic props 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -442,26 +455,24 @@ exports[`EstimateCost - NumberInput Item render basic props 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -1136,7 +1147,7 @@ exports[`EstimateCost - NumberInput Item render basic props 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -1165,7 +1176,7 @@ exports[`EstimateCost - NumberInput Item render basic props 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -1732,6 +1743,19 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -1850,26 +1874,24 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -2544,7 +2566,7 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -2573,7 +2595,7 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -3140,6 +3162,19 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -3258,26 +3293,24 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -3952,7 +3985,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -3981,7 +4014,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -4548,6 +4581,19 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -4666,26 +4712,24 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -5386,7 +5430,7 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -5415,7 +5459,7 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Strong.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Strong.spec.tsx.snap
@@ -336,6 +336,19 @@ exports[`EstimateCost - Strong Item render basic props 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -454,26 +467,24 @@ exports[`EstimateCost - Strong Item render basic props 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -942,7 +953,7 @@ exports[`EstimateCost - Strong Item render basic props 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -971,7 +982,7 @@ exports[`EstimateCost - Strong Item render basic props 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -1464,6 +1475,19 @@ exports[`EstimateCost - Strong Item render with isDisabledOnOverlay 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -1582,26 +1606,24 @@ exports[`EstimateCost - Strong Item render with isDisabledOnOverlay 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -2064,7 +2086,7 @@ exports[`EstimateCost - Strong Item render with isDisabledOnOverlay 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -2093,7 +2115,7 @@ exports[`EstimateCost - Strong Item render with isDisabledOnOverlay 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -2613,6 +2635,19 @@ exports[`EstimateCost - Strong Item render with small variant 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -2731,26 +2766,24 @@ exports[`EstimateCost - Strong Item render with small variant 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -3219,7 +3252,7 @@ exports[`EstimateCost - Strong Item render with small variant 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -3248,7 +3281,7 @@ exports[`EstimateCost - Strong Item render with small variant 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.spec.tsx.snap
@@ -324,6 +324,19 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -442,26 +455,24 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -1071,7 +1082,7 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -1100,7 +1111,7 @@ exports[`EstimateCost - Unit Item render basic props 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -1648,6 +1659,19 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -1766,26 +1790,24 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -2395,7 +2417,7 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -2424,7 +2446,7 @@ exports[`EstimateCost - Unit Item render basic props with monthly price 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -2972,6 +2994,19 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -3090,26 +3125,24 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -3719,7 +3752,7 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -3748,7 +3781,7 @@ exports[`EstimateCost - Unit Item render basic props with overlay 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -4296,6 +4329,19 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -4414,26 +4460,24 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -5069,7 +5113,7 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -5098,7 +5142,7 @@ exports[`EstimateCost - Unit Item render basic props with values 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -5656,6 +5700,19 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -5774,26 +5831,24 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -6429,7 +6484,7 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -6458,7 +6513,7 @@ exports[`EstimateCost - Unit Item render basic props with values and no iteratio
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -7029,6 +7084,19 @@ exports[`EstimateCost - Unit Item render test 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -7147,26 +7215,24 @@ exports[`EstimateCost - Unit Item render test 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -7889,7 +7955,7 @@ exports[`EstimateCost - Unit Item render test 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -7918,7 +7984,7 @@ exports[`EstimateCost - Unit Item render test 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -8579,6 +8645,19 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -8697,26 +8776,24 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -9324,7 +9401,7 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -9353,7 +9430,7 @@ exports[`EstimateCost - Unit Item render with 0 amount 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -9901,6 +9978,19 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -10019,26 +10109,24 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -10660,7 +10748,7 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -10689,7 +10777,7 @@ exports[`EstimateCost - Unit Item render with 10 amount 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -11242,6 +11330,19 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -11360,26 +11461,24 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -11989,7 +12088,7 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -12018,7 +12117,7 @@ exports[`EstimateCost - Unit Item render with getAmountValue 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Zone.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Zone.spec.tsx.snap
@@ -359,6 +359,19 @@ exports[`EstimateCost - Zone render region component, with animation 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -477,26 +490,24 @@ exports[`EstimateCost - Zone render region component, with animation 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -970,7 +981,7 @@ exports[`EstimateCost - Zone render region component, with animation 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -999,7 +1010,7 @@ exports[`EstimateCost - Zone render region component, with animation 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -1529,6 +1540,19 @@ exports[`EstimateCost - Zone render zone component 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -1647,26 +1671,24 @@ exports[`EstimateCost - Zone render zone component 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -2140,7 +2162,7 @@ exports[`EstimateCost - Zone render zone component 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -2169,7 +2191,7 @@ exports[`EstimateCost - Zone render zone component 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.spec.tsx.snap
@@ -378,6 +378,19 @@ exports[`EstimateCost - index render isBeta with discount 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -496,26 +509,24 @@ exports[`EstimateCost - index render isBeta with discount 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -1030,7 +1041,7 @@ exports[`EstimateCost - index render isBeta with discount 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -1059,7 +1070,7 @@ exports[`EstimateCost - index render isBeta with discount 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -1627,6 +1638,19 @@ exports[`EstimateCost - index render isBeta with discount equal to 100% 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -1745,26 +1769,24 @@ exports[`EstimateCost - index render isBeta with discount equal to 100% 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -2284,7 +2306,7 @@ exports[`EstimateCost - index render isBeta with discount equal to 100% 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -2313,7 +2335,7 @@ exports[`EstimateCost - index render isBeta with discount equal to 100% 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -2881,6 +2903,19 @@ exports[`EstimateCost - index render isBeta with discount more than 100% 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -2999,26 +3034,24 @@ exports[`EstimateCost - index render isBeta with discount more than 100% 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -3538,7 +3571,7 @@ exports[`EstimateCost - index render isBeta with discount more than 100% 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -3567,7 +3600,7 @@ exports[`EstimateCost - index render isBeta with discount more than 100% 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -4140,6 +4173,19 @@ exports[`EstimateCost - index render isBeta without discount 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -4258,26 +4304,24 @@ exports[`EstimateCost - index render isBeta without discount 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -4792,7 +4836,7 @@ exports[`EstimateCost - index render isBeta without discount 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -4821,7 +4865,7 @@ exports[`EstimateCost - index render isBeta without discount 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -5347,6 +5391,19 @@ exports[`EstimateCost - index render with all timeUnits values 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -5465,26 +5522,24 @@ exports[`EstimateCost - index render with all timeUnits values 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -5953,7 +6008,7 @@ exports[`EstimateCost - index render with all timeUnits values 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -5982,7 +6037,7 @@ exports[`EstimateCost - index render with all timeUnits values 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -6502,6 +6557,19 @@ exports[`EstimateCost - index render with commitmentFees 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -6620,26 +6688,24 @@ exports[`EstimateCost - index render with commitmentFees 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -7099,7 +7165,7 @@ exports[`EstimateCost - index render with commitmentFees 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -7128,7 +7194,7 @@ exports[`EstimateCost - index render with commitmentFees 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -7664,6 +7730,19 @@ exports[`EstimateCost - index render with commitmentFees and iscommitmentFeesCre
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -7782,26 +7861,24 @@ exports[`EstimateCost - index render with commitmentFees and iscommitmentFeesCre
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -8261,7 +8338,7 @@ exports[`EstimateCost - index render with commitmentFees and iscommitmentFeesCre
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -8290,7 +8367,7 @@ exports[`EstimateCost - index render with commitmentFees and iscommitmentFeesCre
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -8826,6 +8903,19 @@ exports[`EstimateCost - index render with description as node 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -8944,26 +9034,24 @@ exports[`EstimateCost - index render with description as node 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -9430,7 +9518,7 @@ exports[`EstimateCost - index render with description as node 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -9459,7 +9547,7 @@ exports[`EstimateCost - index render with description as node 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -9979,6 +10067,19 @@ exports[`EstimateCost - index render with discount 0 and defaultTimeUnit months 
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -10097,26 +10198,24 @@ exports[`EstimateCost - index render with discount 0 and defaultTimeUnit months 
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -10597,7 +10696,7 @@ exports[`EstimateCost - index render with discount 0 and defaultTimeUnit months 
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -10626,7 +10725,7 @@ exports[`EstimateCost - index render with discount 0 and defaultTimeUnit months 
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -11155,6 +11254,19 @@ exports[`EstimateCost - index render with discount 0.5 and defaultTimeUnit month
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -11273,26 +11385,24 @@ exports[`EstimateCost - index render with discount 0.5 and defaultTimeUnit month
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -11773,7 +11883,7 @@ exports[`EstimateCost - index render with discount 0.5 and defaultTimeUnit month
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -11802,7 +11912,7 @@ exports[`EstimateCost - index render with discount 0.5 and defaultTimeUnit month
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -12331,6 +12441,19 @@ exports[`EstimateCost - index render with discount 1 and defaultTimeUnit months 
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -12449,26 +12572,24 @@ exports[`EstimateCost - index render with discount 1 and defaultTimeUnit months 
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -12937,7 +13058,7 @@ exports[`EstimateCost - index render with discount 1 and defaultTimeUnit months 
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -12966,7 +13087,7 @@ exports[`EstimateCost - index render with discount 1 and defaultTimeUnit months 
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -13528,6 +13649,19 @@ exports[`EstimateCost - index render with discount 1, isBeta and defaultTimeUnit
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -13646,26 +13780,24 @@ exports[`EstimateCost - index render with discount 1, isBeta and defaultTimeUnit
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -14185,7 +14317,7 @@ exports[`EstimateCost - index render with discount 1, isBeta and defaultTimeUnit
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -14214,7 +14346,7 @@ exports[`EstimateCost - index render with discount 1, isBeta and defaultTimeUnit
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -14740,6 +14872,19 @@ exports[`EstimateCost - index render with discount 100% but no isBeta 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -14858,26 +15003,24 @@ exports[`EstimateCost - index render with discount 100% but no isBeta 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -15346,7 +15489,7 @@ exports[`EstimateCost - index render with discount 100% but no isBeta 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -15375,7 +15518,7 @@ exports[`EstimateCost - index render with discount 100% but no isBeta 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -16478,6 +16621,19 @@ exports[`EstimateCost - index render with hideTotal 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -16596,26 +16752,24 @@ exports[`EstimateCost - index render with hideTotal 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -17048,7 +17202,7 @@ exports[`EstimateCost - index render with hideTotal 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -17077,7 +17231,7 @@ exports[`EstimateCost - index render with hideTotal 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -17611,6 +17765,19 @@ exports[`EstimateCost - index render with isBeta but undefined discount 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -17729,26 +17896,24 @@ exports[`EstimateCost - index render with isBeta but undefined discount 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -18263,7 +18428,7 @@ exports[`EstimateCost - index render with isBeta but undefined discount 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -18292,7 +18457,7 @@ exports[`EstimateCost - index render with isBeta but undefined discount 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -18865,6 +19030,19 @@ exports[`EstimateCost - index render with isBeta, discount 0 and defaultTimeUnit
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -18983,26 +19161,24 @@ exports[`EstimateCost - index render with isBeta, discount 0 and defaultTimeUnit
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -19529,7 +19705,7 @@ exports[`EstimateCost - index render with isBeta, discount 0 and defaultTimeUnit
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -19558,7 +19734,7 @@ exports[`EstimateCost - index render with isBeta, discount 0 and defaultTimeUnit
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -20135,6 +20311,19 @@ exports[`EstimateCost - index render with isBeta, discount 0.5 and defaultTimeUn
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -20253,26 +20442,24 @@ exports[`EstimateCost - index render with isBeta, discount 0.5 and defaultTimeUn
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -20799,7 +20986,7 @@ exports[`EstimateCost - index render with isBeta, discount 0.5 and defaultTimeUn
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -20828,7 +21015,7 @@ exports[`EstimateCost - index render with isBeta, discount 0.5 and defaultTimeUn
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -21405,6 +21592,19 @@ exports[`EstimateCost - index render with isBeta, price, discount 50% 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -21523,26 +21723,24 @@ exports[`EstimateCost - index render with isBeta, price, discount 50% 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -22057,7 +22255,7 @@ exports[`EstimateCost - index render with isBeta, price, discount 50% 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -22086,7 +22284,7 @@ exports[`EstimateCost - index render with isBeta, price, discount 50% 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -22612,6 +22810,19 @@ exports[`EstimateCost - index render with item discount 50% 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -22730,26 +22941,24 @@ exports[`EstimateCost - index render with item discount 50% 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -23218,7 +23427,7 @@ exports[`EstimateCost - index render with item discount 50% 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -23247,7 +23456,7 @@ exports[`EstimateCost - index render with item discount 50% 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -23767,6 +23976,19 @@ exports[`EstimateCost - index render with item discount 50% and defaultTimeUnit 
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -23885,26 +24107,24 @@ exports[`EstimateCost - index render with item discount 50% and defaultTimeUnit 
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -24385,7 +24605,7 @@ exports[`EstimateCost - index render with item discount 50% and defaultTimeUnit 
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -24414,7 +24634,7 @@ exports[`EstimateCost - index render with item discount 50% and defaultTimeUnit 
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span
@@ -24984,6 +25204,19 @@ exports[`EstimateCost - index render with item discount 50% and text 1`] = `
   float: right;
 }
 
+.cache-e8qtir {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+}
+
 .cache-igijr9-CustomTextInput input {
   border-radius: 4px 0 0 4px;
   min-width: 60px;
@@ -25102,26 +25335,24 @@ exports[`EstimateCost - index render with item discount 50% and text 1`] = `
   padding-top: 2px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput {
   width: 100%;
   position: relative;
   box-sizing: border-box;
-  width: 300px;
   height: 40px;
-  width: 300px;
   height: 40px;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
   box-shadow: none;
 }
 
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
-.cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:hover,
+.cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   border-color: #521094;
@@ -25595,7 +25826,7 @@ exports[`EstimateCost - index render with item discount 50% and text 1`] = `
                 class="cache-1e9mbjr-TimeCell e1xb5k8j6"
               >
                 <div
-                  class="cache-gy0d8m ehpbis70"
+                  class="cache-e8qtir e3f5lzv0"
                 >
                   <div
                     class="cache-igijr9-CustomTextInput epio27v1"
@@ -25624,7 +25855,7 @@ exports[`EstimateCost - index render with item discount 50% and text 1`] = `
                     </div>
                   </div>
                   <div
-                    class="epio27v0 epio27v0 cache-1syoyzt-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
+                    class="epio27v0 epio27v0 cache-1r22via-container-StyledContainer-CustomSelectInput-CustomSelectInput e11gt5pw4"
                     data-testid="select-input-iteration-unit"
                   >
                     <span


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<EstimateCost />` time unit spacing on firefox that was too small for unit part.

## Relevant logs and/or screenshots

| |   Before   |      After |
| :--- | :--------: | ---------: |
|  | ![Screenshot 2024-01-22 at 17 08 32](https://github.com/scaleway/ultraviolet/assets/15812968/c32bf495-1ba6-4c86-a16a-e2ed747aed0f) | ![Screenshot 2024-01-22 at 17 08 32](https://github.com/scaleway/ultraviolet/assets/15812968/5eb72ba8-7527-4b1f-b5a3-cdb6e473635a) |
|  | ![Screenshot 2024-01-22 at 17 12 16](https://github.com/scaleway/ultraviolet/assets/15812968/3a8e9a03-3c95-4bbf-ab16-610204bd9572) | ![Screenshot 2024-01-22 at 17 12 35](https://github.com/scaleway/ultraviolet/assets/15812968/40cc7cdb-385e-4836-aabc-82961865b18a) |
