### PR TITLE
fix: radio group and checkbox group to have the correct style

### DIFF
--- a/.changeset/grumpy-phones-own.md
+++ b/.changeset/grumpy-phones-own.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `RadioGroup` and `CheckboxGroup` helpers to have the correct style

--- a/packages/ui/src/components/CheckboxGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/CheckboxGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -1332,13 +1332,13 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
   width: 100%;
 }
 
-.cache-ce8hur-StyledText {
+.cache-vdlwt8-StyledText {
   color: #b3144d;
-  font-size: 14px;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1480,11 +1480,11 @@ exports[`CheckboxGroup renders correctly with error content 1`] = `
         </div>
       </div>
     </fieldset>
-    <p
-      class="cache-ce8hur-StyledText e13y3mga0"
+    <span
+      class="cache-vdlwt8-StyledText e13y3mga0"
     >
       Eror content
-    </p>
+    </span>
   </div>
 </DocumentFragment>
 `;
@@ -1832,12 +1832,13 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
   width: 100%;
 }
 
-.cache-3l2mjz-StyledText {
-  font-size: 14px;
+.cache-ioay7l-StyledText {
+  color: #727683;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1979,11 +1980,11 @@ exports[`CheckboxGroup renders correctly with helper content 1`] = `
         </div>
       </div>
     </fieldset>
-    <p
-      class="cache-3l2mjz-StyledText e13y3mga0"
+    <span
+      class="cache-ioay7l-StyledText e13y3mga0"
     >
       Helper content
-    </p>
+    </span>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/CheckboxGroup/index.tsx
+++ b/packages/ui/src/components/CheckboxGroup/index.tsx
@@ -138,12 +138,17 @@ export const CheckboxGroup = ({
           </Stack>
         </FieldSet>
         {helper ? (
-          <Text as="p" variant="bodySmall" prominence="weak">
+          <Text
+            as="span"
+            variant="caption"
+            prominence="weak"
+            sentiment="neutral"
+          >
             {helper}
           </Text>
         ) : null}
         {error ? (
-          <Text as="p" variant="bodySmall" sentiment="danger" prominence="weak">
+          <Text as="span" variant="caption" sentiment="danger">
             {error}
           </Text>
         ) : null}

--- a/packages/ui/src/components/RadioGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/RadioGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -942,13 +942,13 @@ exports[`RadioGroup renders correctly with error content 1`] = `
   flex: 1;
 }
 
-.cache-ce8hur-StyledText {
+.cache-vdlwt8-StyledText {
   color: #b3144d;
-  font-size: 14px;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1075,11 +1075,11 @@ exports[`RadioGroup renders correctly with error content 1`] = `
         </div>
       </div>
     </fieldset>
-    <p
-      class="cache-ce8hur-StyledText e13y3mga0"
+    <span
+      class="cache-vdlwt8-StyledText e13y3mga0"
     >
       Eror content
-    </p>
+    </span>
   </div>
 </DocumentFragment>
 `;
@@ -1307,12 +1307,13 @@ exports[`RadioGroup renders correctly with helper content 1`] = `
   flex: 1;
 }
 
-.cache-3l2mjz-StyledText {
-  font-size: 14px;
+.cache-ioay7l-StyledText {
+  color: #727683;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1439,11 +1440,11 @@ exports[`RadioGroup renders correctly with helper content 1`] = `
         </div>
       </div>
     </fieldset>
-    <p
-      class="cache-3l2mjz-StyledText e13y3mga0"
+    <span
+      class="cache-ioay7l-StyledText e13y3mga0"
     >
       Helper content
-    </p>
+    </span>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/RadioGroup/index.tsx
+++ b/packages/ui/src/components/RadioGroup/index.tsx
@@ -133,12 +133,17 @@ export const RadioGroup = ({
           </Stack>
         </FieldSet>
         {helper ? (
-          <Text as="p" variant="bodySmall" prominence="weak">
+          <Text
+            as="span"
+            variant="caption"
+            prominence="weak"
+            sentiment="neutral"
+          >
             {helper}
           </Text>
         ) : null}
         {error ? (
-          <Text as="p" variant="bodySmall" sentiment="danger" prominence="weak">
+          <Text as="span" variant="caption" sentiment="danger">
             {error}
           </Text>
         ) : null}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `CheckboxGroup` and `RadioGroup` to have the correct helper size, font and color.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| RadioGroup  | <img width="168" alt="Screenshot 2024-01-23 at 16 17 07" src="https://github.com/scaleway/ultraviolet/assets/15812968/c5f1f960-2a22-4905-9f45-b8a39ab45611"> | <img width="164" alt="Screenshot 2024-01-23 at 16 17 12" src="https://github.com/scaleway/ultraviolet/assets/15812968/9f7a32d6-1999-440c-800f-5af3f87c5281"> |
| CheckboxGroup  | <img width="387" alt="Screenshot 2024-01-23 at 16 18 01" src="https://github.com/scaleway/ultraviolet/assets/15812968/b1416deb-faee-4450-9318-42c6a2941a06"> | <img width="368" alt="Screenshot 2024-01-23 at 16 18 06" src="https://github.com/scaleway/ultraviolet/assets/15812968/72068cf2-e587-4d77-ade7-f7e99423ed04"> |
