### PR TITLE
fix(MenuV2): to spread onclick of the disclosure

### DIFF
--- a/.changeset/chatty-snakes-vanish.md
+++ b/.changeset/chatty-snakes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<MenuV2 />` component to spread `onClick` of the disclosure

--- a/packages/ui/src/components/MenuV2/index.tsx
+++ b/packages/ui/src/components/MenuV2/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import type {
   ButtonHTMLAttributes,
   ComponentProps,
+  MouseEvent,
   ReactElement,
   ReactNode,
   Ref,
@@ -124,7 +125,10 @@ const FwdMenu = forwardRef(
     useImperativeHandle(ref, () => innerRef.current)
 
     const finalDisclosure = cloneElement(target, {
-      onClick: () => setIsVisible(!isVisible),
+      onClick: (event: MouseEvent<HTMLButtonElement>) => {
+        target.props.onClick?.(event)
+        setIsVisible(!isVisible)
+      },
       'aria-haspopup': 'dialog',
       'aria-expanded': isVisible,
       // @ts-expect-error not sure how to fix this


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

MenuV2 misses the spread of onClick from disclosure when you want to add some custom actions.
