### PR TITLE
feat(themes): update gradient structure and new radial gradients

### DIFF
--- a/.changeset/long-parents-bathe.md
+++ b/.changeset/long-parents-bathe.md
@@ -1,0 +1,8 @@
+---
+"@ultraviolet/themes": minor
+---
+
+Gradients have been updated, the structure and access to it had been improved. Here is what changed:
+- Previously you were accessing to this token: `color.other.gradient.background.fuschia` and now you can access it like this: `color.other.gradient.background.linear.fuschia`. The same applies to all other gradients. 
+Keep in mind that for now the old way still works as this update is NOT breaking change but it will be removed in the future.
+- New gradient have been added and are accessible via `color.other.gradient.background.radial`.

--- a/packages/themes/src/themes/console/dark.ts
+++ b/packages/themes/src/themes/console/dark.ts
@@ -131,18 +131,33 @@ export const darkTheme = {
       },
       gradients: {
         background: {
-          accent:
-            'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
-          aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
-          blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
-          emerald:
-            'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
-          fuschia:
-            'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
-          magenta:
-            'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
-          primary:
-            'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #0c0f1a 75.01%);',
+          linear: {
+            accent:
+              'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            emerald:
+              'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            fuschia:
+              'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            magenta:
+              'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            primary:
+              'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          },
+          radial: {
+            aquaFuschia:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(249, 27, 108, 0.54) 0%, rgba(249, 27, 108, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #03cfda 0%, rgba(3, 207, 218, 0.30) 59.06%, rgba(3, 207, 218, 0.00) 100%), var(--palette-dark-neutral-200, #110b1e);',
+            aquaPurple:
+              'radial-gradient( 32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient( 45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient( 58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.72) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient( 87.18% 38.05% at 82.33% 0%, rgba(3, 207, 218, 0.30) 59.06%, rgba(3, 207, 218, 0.00) 100%), #110b1e;',
+            fuschiaPurple:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.72) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #f91b6c 0%, rgba(249, 27, 108, 0.30) 59.06%, rgba(249, 27, 108, 0.00) 100%), var(--palette-dark-neutral-200, #110b1e);',
+            lime: 'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(82, 16, 148, 0.40) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(82, 16, 148, 0.40) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(116, 179, 33, 0.36) 0%, rgba(116, 179, 33, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #74b321 0%, rgba(116, 179, 33, 0.30) 59.06%, rgba(116, 179, 33, 0.00) 100%), var(--palette-dark-neutral-200, #110b1e);',
+            magenta:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(236, 11, 195, 0.54) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #ec0bc3 0%, rgba(236, 11, 195, 0.30) 59.06%, rgba(236, 11, 195, 0.00) 100%), var(--palette-dark-neutral-200, #110b1e);',
+            purple:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.54) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #792dd4 0%, rgba(121, 45, 212, 0.30) 59.06%, rgba(121, 45, 212, 0.00) 100%), var(--palette-dark-neutral-200, #110b1e);',
+          },
         },
         text: { dark: '#0c0f1a', light: '#ffffff' },
       },

--- a/packages/themes/src/themes/console/darker.ts
+++ b/packages/themes/src/themes/console/darker.ts
@@ -131,18 +131,33 @@ export const darkerTheme = {
       },
       gradients: {
         background: {
-          accent:
-            'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          emerald:
-            'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          fuschia:
-            'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          magenta:
-            'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          primary:
-            'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          linear: {
+            accent:
+              'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            emerald:
+              'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            fuschia:
+              'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            magenta:
+              'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            primary:
+              'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          },
+          radial: {
+            aquaFuschia:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(249, 27, 108, 0.54) 0%, rgba(249, 27, 108, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #03cfda 0%, rgba(3, 207, 218, 0.30) 59.06%, rgba(3, 207, 218, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            aquaPurple:
+              'radial-gradient( 32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient( 45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient( 58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.72) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient( 87.18% 38.05% at 82.33% 0%, rgba(3, 207, 218, 0.30) 59.06%, rgba(3, 207, 218, 0.00) 100%), #110b1e;',
+            fuschiaPurple:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.72) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #f91b6c 0%, rgba(249, 27, 108, 0.30) 59.06%, rgba(249, 27, 108, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            lime: 'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(82, 16, 148, 0.40) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(82, 16, 148, 0.40) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(116, 179, 33, 0.36) 0%, rgba(116, 179, 33, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #74b321 0%, rgba(116, 179, 33, 0.30) 59.06%, rgba(116, 179, 33, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            magenta:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(236, 11, 195, 0.54) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #ec0bc3 0%, rgba(236, 11, 195, 0.30) 59.06%, rgba(236, 11, 195, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            purple:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.54) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #792dd4 0%, rgba(121, 45, 212, 0.30) 59.06%, rgba(121, 45, 212, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+          },
         },
         text: { dark: '#000000', light: '#e2e4e4' },
       },

--- a/packages/themes/src/themes/console/deprecated/dark.ts
+++ b/packages/themes/src/themes/console/deprecated/dark.ts
@@ -93,6 +93,18 @@ export const deprecatedDarkTokens = {
           gold: 'linear-gradient(180deg, #fbc600 0%, #521094 88.87%)',
           purple: 'linear-gradient(180deg, #c43bff 0%, #521094 88.87%)',
           strong: 'linear-gradient(180deg, #521094 0%, #151a2d 100%)',
+          accent:
+            'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          emerald:
+            'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          fuschia:
+            'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          magenta:
+            'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          primary:
+            'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
         },
       },
     },

--- a/packages/themes/src/themes/console/deprecated/darker.ts
+++ b/packages/themes/src/themes/console/deprecated/darker.ts
@@ -93,6 +93,18 @@ export const deprecatedDarkerTokens = {
           gold: 'linear-gradient(180deg, #fbc600 0%, #521094 88.87%)',
           purple: 'linear-gradient(180deg, #c43bff 0%, #521094 88.87%)',
           strong: 'linear-gradient(180deg, #521094 0%, #151a2d 100%)',
+          accent:
+            'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          emerald:
+            'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          fuschia:
+            'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          magenta:
+            'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          primary:
+            'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
         },
       },
     },

--- a/packages/themes/src/themes/console/deprecated/light.ts
+++ b/packages/themes/src/themes/console/deprecated/light.ts
@@ -93,6 +93,18 @@ export const deprecatedLightTokens = {
           gold: 'linear-gradient(180deg, #fbc600 0%, #521094 88.87%)',
           purple: 'linear-gradient(180deg, #c43bff 0%, #521094 88.87%)',
           strong: 'linear-gradient(180deg, #521094 0%, #151a2d 100%)',
+          accent:
+            'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          emerald:
+            'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          fuschia:
+            'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          magenta:
+            'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          primary:
+            'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
         },
       },
     },

--- a/packages/themes/src/themes/console/light.ts
+++ b/packages/themes/src/themes/console/light.ts
@@ -131,18 +131,33 @@ export const lightTheme = {
       },
       gradients: {
         background: {
-          accent:
-            'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          emerald:
-            'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          fuschia:
-            'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          magenta:
-            'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
-          primary:
-            'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          linear: {
+            accent:
+              'linear-gradient(151deg, #ff602e 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            aqua: 'linear-gradient(151deg, #03cfda 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            blue: 'linear-gradient(151deg, #47b0ff 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            emerald:
+              'linear-gradient(151deg, #45d19f 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            fuschia:
+              'linear-gradient(151deg, #f91b6c 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            magenta:
+              'linear-gradient(151deg, #ec0bc3 0%, #3d1862 28.91%, #151a2d 75.01%);',
+            primary:
+              'linear-gradient(151deg, #792dd4 0%, #3d1862 28.91%, #151a2d 75.01%);',
+          },
+          radial: {
+            aquaFuschia:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(249, 27, 108, 0.54) 0%, rgba(249, 27, 108, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #03cfda 0%, rgba(3, 207, 218, 0.30) 59.06%, rgba(3, 207, 218, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            aquaPurple:
+              'radial-gradient( 32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient( 45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient( 58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.72) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient( 87.18% 38.05% at 82.33% 0%, rgba(3, 207, 218, 0.30) 59.06%, rgba(3, 207, 218, 0.00) 100%), #110b1e;',
+            fuschiaPurple:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.72) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #f91b6c 0%, rgba(249, 27, 108, 0.30) 59.06%, rgba(249, 27, 108, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            lime: 'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(82, 16, 148, 0.40) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(82, 16, 148, 0.40) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(116, 179, 33, 0.36) 0%, rgba(116, 179, 33, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #74b321 0%, rgba(116, 179, 33, 0.30) 59.06%, rgba(116, 179, 33, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            magenta:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(236, 11, 195, 0.54) 0%, rgba(121, 45, 212, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #ec0bc3 0%, rgba(236, 11, 195, 0.30) 59.06%, rgba(236, 11, 195, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+            purple:
+              'radial-gradient(32.85% 10.4% at 0% 54.09%, rgba(251, 198, 0, 0.20) 0%, rgba(251, 198, 0, 0.00) 100%), radial-gradient(45.5% 19.24% at 0% 32.17%, rgba(255, 96, 46, 0.30) 0%, rgba(255, 96, 46, 0.00) 100%), radial-gradient(58.2% 33.79% at 100% 36.38%, rgba(121, 45, 212, 0.54) 0%, rgba(82, 16, 148, 0.00) 100%), radial-gradient(87.18% 38.05% at 88.33% 0%, #792dd4 0%, rgba(121, 45, 212, 0.30) 59.06%, rgba(121, 45, 212, 0.00) 100%), var(--palette-dark-neutral-200, #151a2d);',
+          },
         },
         text: { dark: '#222638', light: '#ffffff' },
       },

--- a/packages/ui/src/components/Banner/index.tsx
+++ b/packages/ui/src/components/Banner/index.tsx
@@ -35,7 +35,8 @@ const styles = ({
     if (variant === 'promotional') {
       return css`
         background-position: left, right;
-        background-image: ${theme.colors.other.gradients.background.aqua};
+        background-image: ${theme.colors.other.gradients.background.linear
+          .aqua};
         background-repeat: no-repeat, no-repeat;
         background-size: contain, contain;
       `
@@ -54,7 +55,8 @@ const styles = ({
 
     if (variant === 'promotional') {
       return css`
-        background-image: ${theme.colors.other.gradients.background.aqua};
+        background-image: ${theme.colors.other.gradients.background.linear
+          .aqua};
         background-position: right;
         background-repeat: no-repeat;
         background-size: contain;

--- a/packages/ui/src/components/GlobalAlert/index.tsx
+++ b/packages/ui/src/components/GlobalAlert/index.tsx
@@ -33,7 +33,8 @@ const Container = styled(Stack)`
   }
 
   &[data-variant='promotional'] {
-    background: ${({ theme }) => theme.colors.other.gradients.background.aqua};
+    background: ${({ theme }) =>
+      theme.colors.other.gradients.background.linear.aqua};
   }
 `
 


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

(Description of the new behavior)

Gradients have been updated, the structure and access to it had been improved. Here is what changed:
- Previously you were accessing to this token: `color.other.gradient.background.fuschia` and now you can access it like this: `color.other.gradient.background.linear.fuschia`. The same applies to all other gradients. 
Keep in mind that for now the old way still works as this update is NOT breaking change but it will be removed in the future.
- New gradient have been added and are accessible via `color.other.gradient.background.radial`.
