### PR TITLE
fix(MenuV2): fix tooltip on menu item

### DIFF
--- a/.changeset/stupid-shoes-report.md
+++ b/.changeset/stupid-shoes-report.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix alignement on `MenuV2.Item` when using prop `tooltip`

--- a/packages/ui/src/components/MenuV2/Item.tsx
+++ b/packages/ui/src/components/MenuV2/Item.tsx
@@ -107,44 +107,48 @@ const Item = forwardRef<HTMLElement, ItemProps>(
   ) => {
     if (href && !disabled) {
       return (
+        <div>
+          <Tooltip text={tooltip}>
+            <StyledLinkItem
+              borderless
+              href={href}
+              ref={ref as Ref<HTMLAnchorElement>}
+              onClick={
+                disabled
+                  ? undefined
+                  : (onClick as MouseEventHandler<HTMLAnchorElement>)
+              }
+              role="menuitem"
+              disabled={disabled}
+              sentiment={sentiment}
+              className={className}
+              data-testid={dataTestId}
+            >
+              {children}
+            </StyledLinkItem>
+          </Tooltip>
+        </div>
+      )
+    }
+
+    return (
+      <div>
         <Tooltip text={tooltip}>
-          <StyledLinkItem
-            borderless
-            href={href}
-            ref={ref as Ref<HTMLAnchorElement>}
-            onClick={
-              disabled
-                ? undefined
-                : (onClick as MouseEventHandler<HTMLAnchorElement>)
-            }
+          <StyledItem
+            type="button"
+            ref={ref as Ref<HTMLButtonElement>}
             role="menuitem"
             disabled={disabled}
+            onClick={onClick}
+            borderless={borderless}
             sentiment={sentiment}
             className={className}
             data-testid={dataTestId}
           >
             {children}
-          </StyledLinkItem>
+          </StyledItem>
         </Tooltip>
-      )
-    }
-
-    return (
-      <Tooltip text={tooltip}>
-        <StyledItem
-          type="button"
-          ref={ref as Ref<HTMLButtonElement>}
-          role="menuitem"
-          disabled={disabled}
-          onClick={onClick}
-          borderless={borderless}
-          sentiment={sentiment}
-          className={className}
-          data-testid={dataTestId}
-        >
-          {children}
-        </StyledItem>
-      </Tooltip>
+      </div>
     )
   },
 )

--- a/packages/ui/src/components/MenuV2/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/MenuV2/__stories__/Sentiments.stories.tsx
@@ -16,6 +16,7 @@ export const Sentiments: StoryFn<typeof MenuV2> = () => (
     <MenuV2.Item
       sentiment="danger"
       href="/?/?path=/docs/components-navigation-menu"
+      tooltip="test"
     >
       Link Danger
     </MenuV2.Item>

--- a/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -29,13 +29,15 @@ exports[`Menu Menu.Item render with borderless props 1`] = `
   fill: #222638;
 }
 
-<button
-    class="cache-1dn316x-StyledItem ei26g5y1"
-    role="menuitem"
-    type="button"
-  >
-    Borderless Props
-  </button>
+<div>
+    <button
+      class="cache-1dn316x-StyledItem ei26g5y1"
+      role="menuitem"
+      type="button"
+    >
+      Borderless Props
+    </button>
+  </div>
 </DocumentFragment>
 `;
 
@@ -69,13 +71,15 @@ exports[`Menu Menu.Item render with default props 1`] = `
   fill: #222638;
 }
 
-<button
-    class="cache-1g2q9ft-StyledItem ei26g5y1"
-    role="menuitem"
-    type="button"
-  >
-    Default Props
-  </button>
+<div>
+    <button
+      class="cache-1g2q9ft-StyledItem ei26g5y1"
+      role="menuitem"
+      type="button"
+    >
+      Default Props
+    </button>
+  </div>
 </DocumentFragment>
 `;
 
@@ -100,14 +104,16 @@ exports[`Menu Menu.Item render with disabled props 1`] = `
   fill: #b5b7bd;
 }
 
-<button
-    class="cache-mgnrz8-StyledItem ei26g5y1"
-    disabled=""
-    role="menuitem"
-    type="button"
-  >
-    Disabled Props
-  </button>
+<div>
+    <button
+      class="cache-mgnrz8-StyledItem ei26g5y1"
+      disabled=""
+      role="menuitem"
+      type="button"
+    >
+      Disabled Props
+    </button>
+  </div>
 </DocumentFragment>
 `;
 
@@ -141,13 +147,15 @@ exports[`Menu Menu.Item render with sentiment danger 1`] = `
   fill: #92103f;
 }
 
-<button
-    class="cache-1goa4p3-StyledItem ei26g5y1"
-    role="menuitem"
-    type="button"
-  >
-    Danger
-  </button>
+<div>
+    <button
+      class="cache-1goa4p3-StyledItem ei26g5y1"
+      role="menuitem"
+      type="button"
+    >
+      Danger
+    </button>
+  </div>
 </DocumentFragment>
 `;
 
@@ -321,13 +329,15 @@ exports[`Menu placement renders bottom 1`] = `
         class="cache-7sm35h-Stack-MenuList e1jn11gg0"
         role="menu"
       >
-        <button
-          class="cache-1g2q9ft-StyledItem ei26g5y1"
-          role="menuitem"
-          type="button"
-        >
-          bottom
-        </button>
+        <div>
+          <button
+            class="cache-1g2q9ft-StyledItem ei26g5y1"
+            role="menuitem"
+            type="button"
+          >
+            bottom
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -504,13 +514,15 @@ exports[`Menu placement renders left 1`] = `
         class="cache-7sm35h-Stack-MenuList e1jn11gg0"
         role="menu"
       >
-        <button
-          class="cache-1g2q9ft-StyledItem ei26g5y1"
-          role="menuitem"
-          type="button"
-        >
-          left
-        </button>
+        <div>
+          <button
+            class="cache-1g2q9ft-StyledItem ei26g5y1"
+            role="menuitem"
+            type="button"
+          >
+            left
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -687,13 +699,15 @@ exports[`Menu placement renders right 1`] = `
         class="cache-7sm35h-Stack-MenuList e1jn11gg0"
         role="menu"
       >
-        <button
-          class="cache-1g2q9ft-StyledItem ei26g5y1"
-          role="menuitem"
-          type="button"
-        >
-          right
-        </button>
+        <div>
+          <button
+            class="cache-1g2q9ft-StyledItem ei26g5y1"
+            role="menuitem"
+            type="button"
+          >
+            right
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -870,13 +884,15 @@ exports[`Menu placement renders top 1`] = `
         class="cache-7sm35h-Stack-MenuList e1jn11gg0"
         role="menu"
       >
-        <button
-          class="cache-1g2q9ft-StyledItem ei26g5y1"
-          role="menuitem"
-          type="button"
-        >
-          top
-        </button>
+        <div>
+          <button
+            class="cache-1g2q9ft-StyledItem ei26g5y1"
+            role="menuitem"
+            type="button"
+          >
+            top
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -1053,13 +1069,15 @@ exports[`Menu renders with Menu.Item 1`] = `
         class="cache-7sm35h-Stack-MenuList e1jn11gg0"
         role="menu"
       >
-        <button
-          class="cache-1g2q9ft-StyledItem ei26g5y1"
-          role="menuitem"
-          type="button"
-        >
-          Menu.Item
-        </button>
+        <div>
+          <button
+            class="cache-1g2q9ft-StyledItem ei26g5y1"
+            role="menuitem"
+            type="button"
+          >
+            Menu.Item
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -1227,22 +1245,26 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         class="cache-7sm35h-Stack-MenuList e1jn11gg0"
         role="menu"
       >
-        <button
-          class="cache-mgnrz8-StyledItem ei26g5y1"
-          disabled=""
-          role="menuitem"
-          type="button"
-        >
-          Menu.Item disabled
-        </button>
-        <button
-          class="cache-mgnrz8-StyledItem ei26g5y1"
-          disabled=""
-          role="menuitem"
-          type="button"
-        >
-          Menu.Item Link disabled
-        </button>
+        <div>
+          <button
+            class="cache-mgnrz8-StyledItem ei26g5y1"
+            disabled=""
+            role="menuitem"
+            type="button"
+          >
+            Menu.Item disabled
+          </button>
+        </div>
+        <div>
+          <button
+            class="cache-mgnrz8-StyledItem ei26g5y1"
+            disabled=""
+            role="menuitem"
+            type="button"
+          >
+            Menu.Item Link disabled
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -1424,13 +1446,15 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
         class="cache-7sm35h-Stack-MenuList e1jn11gg0"
         role="menu"
       >
-        <a
-          class="cache-s7n5ht-StyledLinkItem ei26g5y0"
-          href="/link"
-          role="menuitem"
-        >
-          Menu.Item as Link
-        </a>
+        <div>
+          <a
+            class="cache-s7n5ht-StyledLinkItem ei26g5y0"
+            href="/link"
+            role="menuitem"
+          >
+            Menu.Item as Link
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -874,42 +874,52 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       class="cache-7sm35h-Stack-MenuList e1jn11gg0"
       role="menu"
     >
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test
-      </button>
-      <button
-        class="eeet93f0 cache-1m6x1vf-StyledItem-StyledMenuItem ei26g5y1"
-        disabled=""
-        role="menuitem"
-        type="button"
-      >
-        Test
-      </button>
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test
-      </button>
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test 2
-      </button>
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test 2
-      </button>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test
+        </button>
+      </div>
+      <div>
+        <button
+          class="eeet93f0 cache-1m6x1vf-StyledItem-StyledMenuItem ei26g5y1"
+          disabled=""
+          role="menuitem"
+          type="button"
+        >
+          Test
+        </button>
+      </div>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test
+        </button>
+      </div>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test 2
+        </button>
+      </div>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test 2
+        </button>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -2226,20 +2236,24 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       class="cache-7sm35h-Stack-MenuList e1jn11gg0"
       role="menu"
     >
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test
-      </button>
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test 2
-      </button>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test
+        </button>
+      </div>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test 2
+        </button>
+      </div>
     </div>
   </div>
   @keyframes animation-0 {
@@ -3292,20 +3306,24 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       class="cache-7sm35h-Stack-MenuList e1jn11gg0"
       role="menu"
     >
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test
-      </button>
-      <button
-        class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
-        role="menuitem"
-        type="button"
-      >
-        Test 2
-      </button>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test
+        </button>
+      </div>
+      <div>
+        <button
+          class="eeet93f0 cache-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          role="menuitem"
+          type="button"
+        >
+          Test 2
+        </button>
+      </div>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

On MenuV2.Item if you set a tooltip the structure can be visually broken. I fixed it by adding a `div` wrapper around the tooltip so it inherit the correct display.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="130" alt="Screenshot 2024-02-01 at 16 14 53" src="https://github.com/scaleway/ultraviolet/assets/15812968/596bb578-2b29-4ca0-bad2-ba571fa325c2"> | <img width="130" alt="Screenshot 2024-02-01 at 16 15 08" src="https://github.com/scaleway/ultraviolet/assets/15812968/dabbd50e-bd16-4440-92a6-f67b558656cc"> |
