### PR TITLE
fix(Toaster): breaking change since last major

### DIFF
--- a/.changeset/brave-guests-brake.md
+++ b/.changeset/brave-guests-brake.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `Toaster` to be closing on close button and when time elapsed

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -69,7 +69,7 @@
     "react-datepicker": "4.25.0",
     "react-flatten-children": "1.1.2",
     "react-select": "5.8.0",
-    "react-toastify": "10.0.0",
+    "react-toastify": "10.0.4",
     "react-use-clipboard": "1.0.9",
     "reakit": "1.3.11"
   }

--- a/packages/ui/src/components/Toaster/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Toaster/__tests__/__snapshots__/index.test.tsx.snap
@@ -216,43 +216,46 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
   right: calc(0% + 16px);
 }
 
-.cache-11q7wrm-toast {
+.cache-81melq-toast {
   border-radius: 4px;
   box-shadow: 0px 4px 24px 6px #d9dadd66;
   min-height: 44px;
   margin-bottom: 16px;
 }
 
-.cache-11q7wrm-toast .Toastify__toast-body {
+.cache-81melq-toast .Toastify__toast-body {
   margin: 0;
   padding: 0;
 }
 
-.cache-11q7wrm-toast.Toastify__toast--success {
+.cache-81melq-toast.Toastify__toast--success {
   background-color: #daf6ec;
   color: #22674e;
 }
 
-.cache-11q7wrm-toast.Toastify__toast--success .Toastify__progress-bar {
+.cache-81melq-toast.Toastify__toast--success .Toastify__progress-bar--success {
   background-color: #2c8564;
+  height: 4px;
 }
 
-.cache-11q7wrm-toast.Toastify__toast--info {
+.cache-81melq-toast.Toastify__toast--info {
   background-color: #e0f2ff;
   color: #005da3;
 }
 
-.cache-11q7wrm-toast.Toastify__toast--info .Toastify__progress-bar {
+.cache-81melq-toast.Toastify__toast--info .Toastify__progress-bar--info {
   background-color: #0078d2;
+  height: 4px;
 }
 
-.cache-11q7wrm-toast.Toastify__toast--error {
+.cache-81melq-toast.Toastify__toast--error {
   background-color: #ffebf2;
   color: #b3144d;
 }
 
-.cache-11q7wrm-toast.Toastify__toast--error .Toastify__progress-bar {
+.cache-81melq-toast.Toastify__toast--error .Toastify__progress-bar--danger {
   background-color: #e51963;
+  height: 4px;
 }
 
 .cache-4lkpn5-Stack {
@@ -347,10 +350,10 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
     class="Toastify"
   >
     <div
-      class="Toastify__toast-container Toastify__toast-container--undefined cache-se1d56-ToastContainer"
+      class="Toastify__toast-container Toastify__toast-container--top-right cache-se1d56-ToastContainer"
     >
       <div
-        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--info cache-11q7wrm-toast Toastify--animate Toastify__bounce-enter--undefined"
+        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--info cache-81melq-toast Toastify--animate Toastify__bounce-enter--top-right"
         data-in="true"
         id="info"
       >
@@ -408,7 +411,7 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
         </div>
       </div>
       <div
-        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--success cache-11q7wrm-toast Toastify--animate Toastify__bounce-enter--undefined"
+        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--success cache-81melq-toast Toastify--animate Toastify__bounce-enter--top-right"
         data-in="true"
         id="success"
       >
@@ -466,7 +469,7 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
         </div>
       </div>
       <div
-        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--error cache-11q7wrm-toast Toastify--animate Toastify__bounce-enter--undefined"
+        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--error cache-81melq-toast Toastify--animate Toastify__bounce-enter--top-right"
         data-in="true"
         id="error"
       >

--- a/packages/ui/src/components/Toaster/index.tsx
+++ b/packages/ui/src/components/Toaster/index.tsx
@@ -38,8 +38,9 @@ const styles = {
       background-color: ${theme.colors.success.background};
       color: ${theme.colors.success.text};
 
-      ${PREFIX}__progress-bar {
+      ${PREFIX}__progress-bar--success {
         background-color: ${theme.colors.success.backgroundStrong};
+        height: 4px;
       }
     }
 
@@ -47,8 +48,9 @@ const styles = {
       background-color: ${theme.colors.info.background};
       color: ${theme.colors.info.text};
 
-      ${PREFIX}__progress-bar {
+      ${PREFIX}__progress-bar--info {
         background-color: ${theme.colors.info.backgroundStrong};
+        height: 4px;
       }
     }
 
@@ -56,8 +58,9 @@ const styles = {
       background-color: ${theme.colors.danger.background};
       color: ${theme.colors.danger.text};
 
-      ${PREFIX}__progress-bar {
+      ${PREFIX}__progress-bar--danger {
         background-color: ${theme.colors.danger.backgroundStrong};
+        height: 4px;
       }
     }
   `,
@@ -142,7 +145,7 @@ type ToastContainerProps = {
 export const ToastContainer = ({
   newestOnTop,
   limit,
-  position,
+  position = 'top-right',
   'data-testid': dataTestId,
 }: ToastContainerProps) => {
   const theme = useTheme()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         specifier: 5.8.0
         version: 5.8.0(@types/react@18.2.48)(react-dom@18.2.0)(react@18.2.0)
       react-toastify:
-        specifier: 10.0.0
-        version: 10.0.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 10.0.4
+        version: 10.0.4(react-dom@18.2.0)(react@18.2.0)
       react-use-clipboard:
         specifier: 1.0.9
         version: 1.0.9(react-dom@18.2.0)(react@18.2.0)
@@ -14557,8 +14557,8 @@ packages:
       refractor: 3.6.0
     dev: false
 
-  /react-toastify@10.0.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-nTKun8snjXcdmaYJIwgeXQ1IKkUBDkCt7O3K1y/XdrFh8o+MZwO1mY79cZ+qsXX92KFz6psUxHUZcLHCVkA/Sw==}
+  /react-toastify@10.0.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==}
     peerDependencies:
       react: '>=16 || 18'
       react-dom: '>=16 || 18'


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Toaster is not working properly since the last major update, the close button doesn't work. I fixed it by defining a default positioning but also by changing the class properties in custom style as they changed. I also updated react-toastify to the last patched version.

## Relevant logs and/or screenshots

Before:

https://github.com/scaleway/ultraviolet/assets/15812968/3ecb5325-3596-4575-8ae0-91e17e5e03fc

After:

https://github.com/scaleway/ultraviolet/assets/15812968/649ea24d-83ba-4949-a616-f059896545b5


