### PR TITLE
fix: radio and checkbox to have correct sentiment and variant

### DIFF
--- a/.changeset/loud-spies-brake.md
+++ b/.changeset/loud-spies-brake.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+Fix `Radio` and `Checkbox` helper to have correct sentiment and variant

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -76,7 +76,7 @@ export const globalStyles = (mode: 'light' | 'dark') => () => css`
   }
 
   p {
-    margin: 0 !important;
+    margin: 0;
   }
 
   @font-face {

--- a/packages/form/src/components/CheckboxField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/CheckboxField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2386,13 +2386,13 @@ exports[`CheckboxField should render correctly with errors 1`] = `
   min-height: 10px;
 }
 
-.cache-1ycfzva {
+.cache-1o32707 {
   color: #b3144d;
-  font-size: 14px;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2468,11 +2468,11 @@ exports[`CheckboxField should render correctly with errors 1`] = `
             </svg>
           </sup>
         </div>
-        <p
-          class="eqr7bqq7 cache-1ycfzva e13y3mga0"
+        <span
+          class="eqr7bqq7 cache-1o32707 e13y3mga0"
         >
           This field is required
-        </p>
+        </span>
       </div>
     </div>
     <div>

--- a/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
@@ -1304,13 +1304,13 @@ exports[`Checkbox renders correctly checked with helper 1`] = `
   width: 100%;
 }
 
-.cache-1b19kf2-StyledText {
+.cache-ioay7l-StyledText {
   color: #727683;
-  font-size: 14px;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1372,11 +1372,11 @@ exports[`Checkbox renders correctly checked with helper 1`] = `
           Checkbox Label
         </label>
       </div>
-      <p
-        class="cache-1b19kf2-StyledText e13y3mga0"
+      <span
+        class="cache-ioay7l-StyledText e13y3mga0"
       >
         helper
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>
@@ -4051,13 +4051,13 @@ exports[`Checkbox renders correctly with an error 1`] = `
   width: 100%;
 }
 
-.cache-tzulkh-StyledText-ErrorText {
+.cache-1f5u2re-StyledText-ErrorText {
   color: #b3144d;
-  font-size: 14px;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4120,11 +4120,11 @@ exports[`Checkbox renders correctly with an error 1`] = `
           Checkbox Label
         </label>
       </div>
-      <p
-        class="eqr7bqq7 cache-tzulkh-StyledText-ErrorText e13y3mga0"
+      <span
+        class="eqr7bqq7 cache-1f5u2re-StyledText-ErrorText e13y3mga0"
       >
         test error
-      </p>
+      </span>
     </div>
   </div>
 </DocumentFragment>

--- a/packages/ui/src/components/Checkbox/index.tsx
+++ b/packages/ui/src/components/Checkbox/index.tsx
@@ -412,8 +412,8 @@ export const Checkbox = forwardRef(
 
             {helper ? (
               <Text
-                variant="bodySmall"
-                as="p"
+                variant="caption"
+                as="span"
                 prominence="weak"
                 sentiment="neutral"
               >
@@ -422,7 +422,7 @@ export const Checkbox = forwardRef(
             ) : null}
 
             {error ? (
-              <ErrorText variant="bodySmall" as="p" sentiment="danger">
+              <ErrorText variant="caption" as="span" sentiment="danger">
                 {error}
               </ErrorText>
             ) : null}

--- a/packages/ui/src/components/Radio/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Radio/__tests__/__snapshots__/index.test.tsx.snap
@@ -1015,12 +1015,13 @@ exports[`Radio renders correctly when helper 1`] = `
   flex: 1;
 }
 
-.cache-1r2kjby-StyledText-MargedText {
-  font-size: 14px;
+.cache-by24pi-StyledText-MargedText {
+  color: #727683;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1076,11 +1077,11 @@ exports[`Radio renders correctly when helper 1`] = `
         Choice
       </label>
     </div>
-    <p
-      class="ehkrmld0 cache-1r2kjby-StyledText-MargedText e13y3mga0"
+    <span
+      class="ehkrmld0 cache-by24pi-StyledText-MargedText e13y3mga0"
     >
       Helper
-    </p>
+    </span>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/Radio/index.tsx
+++ b/packages/ui/src/components/Radio/index.tsx
@@ -235,7 +235,12 @@ export const Radio = forwardRef(
             ) : null}
           </RadioContainer>
           {helper ? (
-            <MargedText as="p" variant="bodySmall" prominence="weak">
+            <MargedText
+              as="span"
+              variant="caption"
+              prominence="weak"
+              sentiment="neutral"
+            >
               {helper}
             </MargedText>
           ) : null}

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -1620,13 +1620,13 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   flex: 1;
 }
 
-.cache-tzulkh-StyledText-ErrorText {
+.cache-1f5u2re-StyledText-ErrorText {
   color: #b3144d;
-  font-size: 14px;
+  font-size: 12px;
   font-family: Inter,Asap;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1690,8 +1690,8 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
         <div
           class="cache-17l4vsh-Stack ehpbis70"
         />
-        <p
-          class="eqr7bqq7 cache-tzulkh-StyledText-ErrorText e13y3mga0"
+        <span
+          class="eqr7bqq7 cache-1f5u2re-StyledText-ErrorText e13y3mga0"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Helper / error and success should always be caption variant and helper should always be weak prominence. Also there was some margin missing on radio story due to global style applied on all stories.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2024-02-05 at 15 48 57](https://github.com/scaleway/ultraviolet/assets/15812968/6d86e65f-5e75-4b44-bcb0-8c1053c181bc) | ![Screenshot 2024-02-05 at 15 49 00](https://github.com/scaleway/ultraviolet/assets/15812968/dbce5b26-c998-4ed4-b985-b74d8baad43c) |
| url  | ![Screenshot 2024-02-05 at 15 49 34](https://github.com/scaleway/ultraviolet/assets/15812968/3f419769-ca4d-4ac4-8f71-e9a4ba597900) | ![Screenshot 2024-02-05 at 15 50 32](https://github.com/scaleway/ultraviolet/assets/15812968/93d086a7-c4bb-4048-b589-474a15e2dfae) |
