### PR TITLE
fix(TextInputV2): remove some props and add some others

### DIFF
--- a/.changeset/eighty-rockets-explode.md
+++ b/.changeset/eighty-rockets-explode.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `TextInputV2` to implement more props and remove `iconName`

--- a/packages/ui/src/__stories__/migrations/MigrationTextInputV2.stories.mdx
+++ b/packages/ui/src/__stories__/migrations/MigrationTextInputV2.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta } from '@storybook/blocks'
+
+<Meta title="Migrations/TextInput to TextInputV2" />
+
+# Migrate NumberInput to NumberInputV2
+
+## Properties to migrate
+
+- `type` (string) => `type` (text | password | url | email)
+- `random` (string) => `onRandomize` (`() => void`): the function will be triggered when the random button is clicked
+- `notice` (string) => `helper` (string)
+- `height` (string | number) => `size` (small | medium | large)
+- `defaultValue` (string | number) => `value`
+- `unit` (string) => `suffix` (string)
+- `valid` (boolean) => `success` (string | boolean): note that only `success` prop allows both `string` and `boolean` values
+
+## Removed properties
+
+- `min` (string | number): if the need is to set a minLength, use the `minLength` (number) prop
+- `max` (string | number): if the need is to set a maxLength, use the `maxLength` (number) prop
+- `cols` (number): not relevant for this component, if needed use `TextArea` component
+- `edit` (boolean)
+- `fillAvailable` (boolean)
+- `generated` (boolean)
+- `multiline` (boolean): not relevant for this component, use `TextArea` component instead
+- `noTopLabel` (boolean): just don't set the `label` prop if you don't want a label, you will still need to set `aria-label` or `aria-labelledby` to make the input accessible
+- `resizable` (boolean): not relevant for this component, use `TextArea` component instead
+- `rows` (number): not relevant for this component, if needed use `TextArea` component
+- `wrap` (string)
+- `inputProps` (object)

--- a/packages/ui/src/components/DateInput/index.tsx
+++ b/packages/ui/src/components/DateInput/index.tsx
@@ -202,7 +202,7 @@ type DateInputProps = Pick<
   excludeDates?: Date[]
   id?: string
   labelDescription?: ReactNode
-  success?: string
+  success?: string | boolean
   helper?: string
   size?: 'small' | 'medium' | 'large'
   readOnly?: boolean

--- a/packages/ui/src/components/NumberInputV2/index.tsx
+++ b/packages/ui/src/components/NumberInputV2/index.tsx
@@ -185,7 +185,7 @@ type NumberInputProps = {
    */
   labelDescription?: ReactNode
   error?: string
-  success?: string
+  success?: string | boolean
   helper?: ReactNode
   value?: string | number
 } & Pick<
@@ -438,7 +438,7 @@ export const NumberInputV2 = forwardRef(
             </Container>
           </Tooltip>
         </div>
-        {error || success || helper ? (
+        {error || typeof success === 'string' || typeof helper === 'string' ? (
           <Text
             variant="caption"
             as="span"
@@ -449,6 +449,9 @@ export const NumberInputV2 = forwardRef(
             {error || success || helper}
           </Text>
         ) : null}
+        {!error && !success && typeof helper !== 'string' && helper
+          ? helper
+          : null}
       </Stack>
     )
   },

--- a/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
@@ -5,7 +5,7 @@ import { TextInputV2 } from '..'
 export const Template: StoryFn<typeof TextInputV2> = ({ ...args }) => {
   const [value, setValue] = useState<string | undefined>(args.value)
 
-  return <TextInputV2 {...args} value={value} onChange={setValue} />
+  return <TextInputV2 {...args} value={value} onChange={setValue} success />
 }
 
 Template.args = {

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { Icon } from '@ultraviolet/icons'
-import type { ComponentProps, InputHTMLAttributes, ReactNode } from 'react'
+import type { InputHTMLAttributes, ReactNode } from 'react'
 import { forwardRef, useId, useMemo, useState } from 'react'
 import { Button } from '../Button'
 import { Loader } from '../Loader'
@@ -123,7 +123,6 @@ type TextInputProps = {
   'data-testid'?: string
   error?: string
   helper?: ReactNode
-  iconName?: ComponentProps<typeof Icon>['name']
   label?: string
   labelDescription?: ReactNode
   loading?: boolean
@@ -133,9 +132,8 @@ type TextInputProps = {
   onChange?: (newValue: string) => void
   prefix?: ReactNode
   size?: TextInputSize
-  success?: string
+  success?: string | boolean
   suffix?: ReactNode
-  tabIndex?: number
   tooltip?: string
   type?: 'text' | 'password' | 'url' | 'email'
   value?: string
@@ -147,10 +145,12 @@ type TextInputProps = {
   | 'id'
   | 'placeholder'
   | 'aria-label'
+  | 'aria-labelledby'
   | 'disabled'
   | 'readOnly'
   | 'required'
   | 'autoFocus'
+  | 'tabIndex'
 >
 
 /**
@@ -183,12 +183,13 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
       type = 'text',
       prefix,
       suffix,
-      iconName,
       size = 'large',
       loading,
       onRandomize,
       minLength,
       maxLength,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-label': ariaLabel,
     },
     ref,
   ) => {
@@ -255,7 +256,6 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
                   )}
                 </BasicPrefixStack>
               ) : null}
-              {iconName ? <Icon name={iconName} size={16} /> : null}
               <StyledInput
                 type={computedType}
                 aria-invalid={!!error}
@@ -285,6 +285,8 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
                 readOnly={readOnly}
                 minLength={minLength}
                 maxLength={maxLength}
+                aria-labelledby={ariaLabelledBy}
+                aria-label={ariaLabel}
               />
               {success || error || loading || computedClearable ? (
                 <StateStack direction="row" gap={1} alignItems="center">

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -371,7 +371,7 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
             </StyledInputWrapper>
           </Tooltip>
         </div>
-        {error || success || typeof helper === 'string' ? (
+        {error || typeof success === 'string' || typeof helper === 'string' ? (
           <Text
             as="p"
             variant="caption"


### PR DESCRIPTION
## Summary

## Type

- Enhancement
- Documentation

### Summarise concisely:

#### What is expected?

- Fix `TextInputV2` to implement more props and remove `iconName`
- Add documentation to migrate `TextInput` to `TextInputV2`