### PR TITLE
fix(Breadcrumbs): to be vertically center aligned

### DIFF
--- a/.changeset/large-trains-speak.md
+++ b/.changeset/large-trains-speak.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `Breadcrumbs` to be vertically centered

--- a/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Breadcrumbs renders correctly with default values 1`] = `
 <DocumentFragment>
-  .cache-198ohfb-StyledOl {
+  .cache-lyg2hx-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -10,6 +10,10 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .cache-rtqykd-ItemContainer {
@@ -109,7 +113,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-198ohfb-StyledOl ej0p0s41"
+      class="cache-lyg2hx-StyledOl ej0p0s41"
     >
       <li
         aria-disabled="false"
@@ -149,7 +153,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
 
 exports[`Breadcrumbs renders correctly with invalid child 1`] = `
 <DocumentFragment>
-  .cache-198ohfb-StyledOl {
+  .cache-lyg2hx-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -157,13 +161,17 @@ exports[`Breadcrumbs renders correctly with invalid child 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <nav
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-198ohfb-StyledOl ej0p0s41"
+      class="cache-lyg2hx-StyledOl ej0p0s41"
     >
       Invalid child
     </ol>
@@ -173,7 +181,7 @@ exports[`Breadcrumbs renders correctly with invalid child 1`] = `
 
 exports[`Breadcrumbs renders correctly with onClick 1`] = `
 <DocumentFragment>
-  .cache-198ohfb-StyledOl {
+  .cache-lyg2hx-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -181,6 +189,10 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .cache-rtqykd-ItemContainer {
@@ -298,7 +310,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-198ohfb-StyledOl ej0p0s41"
+      class="cache-lyg2hx-StyledOl ej0p0s41"
     >
       <li
         aria-disabled="false"
@@ -338,7 +350,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
 
 exports[`Breadcrumbs renders correctly with selected item 1`] = `
 <DocumentFragment>
-  .cache-198ohfb-StyledOl {
+  .cache-lyg2hx-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -346,6 +358,10 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .cache-rtqykd-ItemContainer {
@@ -445,7 +461,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-198ohfb-StyledOl ej0p0s41"
+      class="cache-lyg2hx-StyledOl ej0p0s41"
     >
       <li
         aria-disabled="false"

--- a/packages/ui/src/components/Breadcrumbs/index.tsx
+++ b/packages/ui/src/components/Breadcrumbs/index.tsx
@@ -16,6 +16,7 @@ const StyledOl = styled.ol`
   margin: 0;
   padding: 0;
   display: flex;
+  align-items: center;
 `
 
 const ItemContainer = styled.li`


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

In some cases breacrumbs children are miss aligned vertically to avoid it I added `align-items: center;` on the parent.
