### PR TITLE
fix(TextInput): to spread required prop to the dom

### DIFF
--- a/.changeset/wild-carrots-deliver.md
+++ b/.changeset/wild-carrots-deliver.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+Fix `<TextInput />` component to spread required in the DOM

--- a/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1051,6 +1051,7 @@ exports[`TextInputField should render correctly required 1`] = `
           autocomplete="on"
           class="cache-2i7sd1 el3h3g92"
           name="test"
+          required=""
           type="text"
           value=""
         />

--- a/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1664,6 +1664,7 @@ exports[`TextInput should render correctly required true 1`] = `
         aria-label="Test"
         autocomplete="on"
         class="cache-1wosbvv-StyledInput el3h3g92"
+        required=""
         type="text"
         value="test"
       />
@@ -3044,6 +3045,7 @@ exports[`TextInput should render correctly with multiple right components 1`] = 
         aria-label="Multiple"
         autocomplete="on"
         class="cache-rjtrot-StyledInput el3h3g92"
+        required=""
         type="password"
         value=""
       />
@@ -4112,6 +4114,7 @@ exports[`TextInput should render correctly with unit is px and required 1`] = `
         autocomplete="on"
         class="cache-4y3dc5-StyledInput el3h3g92"
         name="test"
+        required=""
         type="text"
         value=""
       />
@@ -6087,6 +6090,7 @@ exports[`TextInput should render random with required 1`] = `
         autocomplete="on"
         class="cache-9whvt5-StyledInput el3h3g92"
         name="test"
+        required=""
         type="text"
         value=""
       />
@@ -6640,6 +6644,7 @@ exports[`TextInput should render toggleable password with required 1`] = `
         autocomplete="on"
         class="cache-9whvt5-StyledInput el3h3g92"
         name="password"
+        required=""
         type="password"
         value=""
       />
@@ -6896,6 +6901,7 @@ exports[`TextInput should render unit with required 1`] = `
         autocomplete="on"
         class="cache-4y3dc5-StyledInput el3h3g92"
         name="test"
+        required=""
         type="text"
         value=""
       />

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -606,6 +606,7 @@ export const TextInput = forwardRef<
             wrap={wrap}
             min={min}
             max={max}
+            required={required}
             {...inputProps}
           />
           {hasLabel && (


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<TextInput />` component to spread required in the DOM
