### PR TITLE
fix(SelectInput): to have prop empty state

### DIFF
--- a/.changeset/popular-chairs-laugh.md
+++ b/.changeset/popular-chairs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Fix `<SelectInputField />` component to have `emptyState` prop instead of `noOptionsMessage`

--- a/packages/form/src/components/SelectInputField/index.tsx
+++ b/packages/form/src/components/SelectInputField/index.tsx
@@ -124,7 +124,7 @@ export type SelectInputFieldProps<
       | 'required'
       | 'value'
       | 'noTopLabel'
-      | 'noOptionsMessage'
+      | 'emptyState'
       | 'customStyle'
       | 'data-testid'
     >
@@ -173,7 +173,7 @@ export const SelectInputField = <
   required,
   rules,
   noTopLabel,
-  noOptionsMessage,
+  emptyState,
   customStyle,
   shouldUnregister = false,
   'data-testid': dataTestId,
@@ -291,7 +291,7 @@ export const SelectInputField = <
       noTopLabel={noTopLabel}
       required={required}
       value={format(field.value)}
-      noOptionsMessage={noOptionsMessage}
+      emptyState={emptyState}
       data-testid={dataTestId}
     >
       {children}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<SelectInputField />` component to have `emptyState` prop instead of `noOptionsMessage`
