### PR TITLE
fix(estimatecost): missing discount value

### DIFF
--- a/.changeset/friendly-clouds-approve.md
+++ b/.changeset/friendly-clouds-approve.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+fix(estimatecost): discount value was missing

--- a/.changeset/friendly-clouds-approve.md
+++ b/.changeset/friendly-clouds-approve.md
@@ -2,4 +2,4 @@
 "@ultraviolet/plus": patch
 ---
 
-fix(estimatecost): discount value was missing
+Fix `<EstimateCost />` component, discount value was missing in the overlay

--- a/packages/plus/src/components/EstimateCost/OverlayComponent.tsx
+++ b/packages/plus/src/components/EstimateCost/OverlayComponent.tsx
@@ -144,6 +144,7 @@ export const OverlayComponent = ({
               </Strong>
               {isBeta ? (
                 <StyledBadge prominence="strong" sentiment="warning">
+                  {discount > 0 ? discount * 100 : ''}
                   {
                     locales[
                       `estimate.cost.beta.${discount > 0 ? 'discount' : 'free'}`

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.spec.tsx.snap
@@ -985,7 +985,7 @@ exports[`EstimateCost - index render isBeta with discount 1`] = `
             <span
               class="e1xb5k8j0 ej33bna0 cache-1gumfee-StyledBadge e13y3mga0"
             >
-              % off during Beta
+              50% off during Beta
             </span>
           </div>
         </li>
@@ -2242,7 +2242,7 @@ exports[`EstimateCost - index render isBeta with discount equal to 100% 1`] = `
             <span
               class="e1xb5k8j0 ej33bna0 cache-1gumfee-StyledBadge e13y3mga0"
             >
-              % off during Beta
+              100% off during Beta
             </span>
           </div>
         </li>
@@ -3499,7 +3499,7 @@ exports[`EstimateCost - index render isBeta with discount more than 100% 1`] = `
             <span
               class="e1xb5k8j0 ej33bna0 cache-1gumfee-StyledBadge e13y3mga0"
             >
-              % off during Beta
+              200% off during Beta
             </span>
           </div>
         </li>
@@ -14173,7 +14173,7 @@ exports[`EstimateCost - index render with discount 1, isBeta and defaultTimeUnit
             <span
               class="e1xb5k8j0 ej33bna0 cache-1gumfee-StyledBadge e13y3mga0"
             >
-              % off during Beta
+              100% off during Beta
             </span>
           </div>
         </li>
@@ -20802,7 +20802,7 @@ exports[`EstimateCost - index render with isBeta, discount 0.5 and defaultTimeUn
             <span
               class="e1xb5k8j0 ej33bna0 cache-1gumfee-StyledBadge e13y3mga0"
             >
-              % off during Beta
+              50% off during Beta
             </span>
           </div>
         </li>
@@ -22063,7 +22063,7 @@ exports[`EstimateCost - index render with isBeta, price, discount 50% 1`] = `
             <span
               class="e1xb5k8j0 ej33bna0 cache-1gumfee-StyledBadge e13y3mga0"
             >
-              % off during Beta
+              50% off during Beta
             </span>
           </div>
         </li>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Discount value was'nt showing in overlay

#### The following changes where made:

(Describe what you did)

1.

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
