### PR TITLE
fix: add flex-wrap to breadcrumb list

### DIFF
--- a/.changeset/purple-ducks-impress.md
+++ b/.changeset/purple-ducks-impress.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+add flex-wrap to breadcrumb list

--- a/.changeset/purple-ducks-impress.md
+++ b/.changeset/purple-ducks-impress.md
@@ -2,4 +2,4 @@
 "@ultraviolet/ui": patch
 ---
 
-add flex-wrap to breadcrumb list
+Add `flex-wrap` on component `<Breadcrumbs />`

--- a/packages/ui/src/components/Breadcrumbs/__stories__/Template.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/Template.tsx
@@ -6,6 +6,7 @@ export const Template: StoryFn<ComponentProps<typeof Breadcrumbs>> = props => (
   <Breadcrumbs {...props}>
     <Breadcrumbs.Item to="/step1">Step 1</Breadcrumbs.Item>
     <Breadcrumbs.Item to="/step1/step2">Step 2</Breadcrumbs.Item>
-    <Breadcrumbs.Item>Step 3</Breadcrumbs.Item>
+    <Breadcrumbs.Item to="/step1/step2/step3">Step 3</Breadcrumbs.Item>
+    <Breadcrumbs.Item>Step 4</Breadcrumbs.Item>
   </Breadcrumbs>
 )

--- a/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Breadcrumbs renders correctly with default values 1`] = `
 <DocumentFragment>
-  .cache-lyg2hx-StyledOl {
+  .cache-1cihhn6-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -10,6 +10,10 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -113,7 +117,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-lyg2hx-StyledOl ej0p0s41"
+      class="cache-1cihhn6-StyledOl ej0p0s41"
     >
       <li
         aria-disabled="false"
@@ -153,7 +157,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
 
 exports[`Breadcrumbs renders correctly with invalid child 1`] = `
 <DocumentFragment>
-  .cache-lyg2hx-StyledOl {
+  .cache-1cihhn6-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -161,6 +165,10 @@ exports[`Breadcrumbs renders correctly with invalid child 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -171,7 +179,7 @@ exports[`Breadcrumbs renders correctly with invalid child 1`] = `
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-lyg2hx-StyledOl ej0p0s41"
+      class="cache-1cihhn6-StyledOl ej0p0s41"
     >
       Invalid child
     </ol>
@@ -181,7 +189,7 @@ exports[`Breadcrumbs renders correctly with invalid child 1`] = `
 
 exports[`Breadcrumbs renders correctly with onClick 1`] = `
 <DocumentFragment>
-  .cache-lyg2hx-StyledOl {
+  .cache-1cihhn6-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -189,6 +197,10 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -310,7 +322,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-lyg2hx-StyledOl ej0p0s41"
+      class="cache-1cihhn6-StyledOl ej0p0s41"
     >
       <li
         aria-disabled="false"
@@ -350,7 +362,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
 
 exports[`Breadcrumbs renders correctly with selected item 1`] = `
 <DocumentFragment>
-  .cache-lyg2hx-StyledOl {
+  .cache-1cihhn6-StyledOl {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -358,6 +370,10 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -461,7 +477,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
     aria-label="breadcrumb"
   >
     <ol
-      class="cache-lyg2hx-StyledOl ej0p0s41"
+      class="cache-1cihhn6-StyledOl ej0p0s41"
     >
       <li
         aria-disabled="false"

--- a/packages/ui/src/components/Breadcrumbs/index.tsx
+++ b/packages/ui/src/components/Breadcrumbs/index.tsx
@@ -16,6 +16,7 @@ const StyledOl = styled.ol`
   margin: 0;
   padding: 0;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
 `
 


### PR DESCRIPTION
## Summary

Add a flex-wrap to the breadcrumb `ol`

## Type

- Bug

### Summarise concisely:

#### What is expected?

on mobile device, the breadcrumb should be wrapped gracefully

## Relevant logs and/or screenshots

| Page | Before | After |
| :--- | :-----:| -----:|
| [url](https://storybook.ultraviolet.scaleway.com/?path=/docs/components-navigation-breadcrumbs--docs) | ![Capture d’écran 2024-02-14 à 16 52 25](https://github.com/scaleway/ultraviolet/assets/25226974/3881f713-9406-4f0f-9e4f-25ac02a35b6b) | ![Capture d’écran 2024-02-14 à 16 54 00](https://github.com/scaleway/ultraviolet/assets/25226974/40d9b2d1-37fa-4479-b622-567162197eb4) |
