### PR TITLE
fix(ContentCard): fix role when onClick and href is provided

### DIFF
--- a/.changeset/three-suits-nail.md
+++ b/.changeset/three-suits-nail.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+fix(ContentCard): fix role when onClick and href is provided

--- a/packages/plus/src/components/ContentCard/index.tsx
+++ b/packages/plus/src/components/ContentCard/index.tsx
@@ -162,7 +162,7 @@ export const ContentCard = forwardRef<
         target={target}
         onClick={onClick}
         href={href}
-        role={onClick ? 'button' : undefined}
+        role={onClick && !href ? 'button' : undefined}
         ref={ref}
         className={className}
       >


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Component should have link role instead of button when href is provided with onClick.

#### The following changes where made:

1. Edit the component

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
