### PR TITLE
fix(TextInputFieldV2): fix type prop

### DIFF
--- a/.changeset/real-spoons-cough.md
+++ b/.changeset/real-spoons-cough.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": minor
+---
+
+Prop `type` working properly

--- a/.changeset/real-spoons-cough.md
+++ b/.changeset/real-spoons-cough.md
@@ -2,4 +2,4 @@
 "@ultraviolet/form": minor
 ---
 
-Prop `type` working properly
+Fix prop `type` on component `<TextInputFieldV2 />` that wasn't working properly

--- a/packages/form/src/components/TextInputFieldV2/index.tsx
+++ b/packages/form/src/components/TextInputFieldV2/index.tsx
@@ -43,6 +43,7 @@ export const TextInputField = <
   required,
   success,
   tooltip,
+  type,
   validate,
   regex: regexes,
 }: TextInputFieldProps<TFieldValues, TName>) => {
@@ -116,6 +117,7 @@ export const TextInputField = <
       success={success}
       tabIndex={tabIndex}
       tooltip={tooltip}
+      type={type}
       value={field.value}
     />
   )


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

The prop "type" in `TextInputField` is now working.
#### What is expected?

When choosing a type for an text input field, it can be a password (with the style of a TextInputV2 field), email, url or text. 
#### The following changes were made:

(Describe what you did)

1. Edit the component (add type)
