### PR TITLE
feat(ProductIcon): new product icon variant original

### DIFF
--- a/.changeset/dull-cougars-appear.md
+++ b/.changeset/dull-cougars-appear.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/themes": minor
+---
+
+New token `theme.colors.other.icon.product.original`, it contains all colors for the new product icon variant `original`.

--- a/.changeset/dull-cougars-disappear.md
+++ b/.changeset/dull-cougars-disappear.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/icons": minor
+---
+
+New `<ProductIcon />` variant available: `original`

--- a/packages/icons/src/components/ProductIcon/__stories__/Disabled.stories.tsx
+++ b/packages/icons/src/components/ProductIcon/__stories__/Disabled.stories.tsx
@@ -1,0 +1,18 @@
+import { Template } from './Template.stories'
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+  name: 'console',
+  variant: 'primary',
+  size: 'large',
+  disabled: true,
+}
+
+Disabled.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use `disabled` prop to change the icon color to disabled. It will work on any variant and will always give the same disable colors.',
+    },
+  },
+}

--- a/packages/icons/src/components/ProductIcon/__stories__/Playground.stories.tsx
+++ b/packages/icons/src/components/ProductIcon/__stories__/Playground.stories.tsx
@@ -4,5 +4,5 @@ export const Playground = Template.bind({})
 Playground.args = {
   name: 'console',
   variant: 'primary',
-  size: 'medium',
+  size: 'large',
 }

--- a/packages/icons/src/components/ProductIcon/__stories__/Variants.stories.tsx
+++ b/packages/icons/src/components/ProductIcon/__stories__/Variants.stories.tsx
@@ -1,0 +1,16 @@
+import type { StoryFn } from '@storybook/react'
+import { Stack, Text } from '@ultraviolet/ui'
+import { ProductIcon } from '..'
+
+export const Variants: StoryFn<typeof ProductIcon> = props => (
+  <Stack gap={1}>
+    {(['primary', 'original', 'danger', 'warning'] as const).map(variant => (
+      <Stack direction="row" gap={1} alignItems="center">
+        <ProductIcon {...props} name="console" variant={variant} size="large" />
+        <Text as="span" variant="bodyStrong">
+          {variant}
+        </Text>
+      </Stack>
+    ))}
+  </Stack>
+)

--- a/packages/icons/src/components/ProductIcon/__stories__/index.stories.tsx
+++ b/packages/icons/src/components/ProductIcon/__stories__/index.stories.tsx
@@ -15,5 +15,7 @@ export default {
 } as Meta
 
 export { Playground } from './Playground.stories'
+export { Variants } from './Variants.stories'
+export { Disabled } from './Disabled.stories'
 export { Sizes } from './Sizes.stories'
 export { List } from './List.stories'

--- a/packages/icons/src/components/ProductIcon/index.tsx
+++ b/packages/icons/src/components/ProductIcon/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import type { FunctionComponent, SVGProps } from 'react'
 import { PRODUCT_ICONS } from './Icons'
 
-type Variants = 'primary' | 'danger' | 'warning'
+type Variants = 'primary' | 'danger' | 'warning' | 'original'
 
 const SIZES = {
   small: 32,

--- a/packages/themes/src/themes/console/dark.ts
+++ b/packages/themes/src/themes/console/dark.ts
@@ -172,6 +172,14 @@ export const darkTheme = {
             fillWeak: '#e71964',
             fillWeakDisabled: '#191f33',
           },
+          original: {
+            fill: '#ffffff',
+            fillDisabled: '#252a3b',
+            fillStrong: '#bf96f8',
+            fillStrongDisabled: '#252a3b',
+            fillWeak: '#4f1c89',
+            fillWeakDisabled: '#191f33',
+          },
           primary: {
             fill: '#a061f4',
             fillDisabled: '#484b5a',

--- a/packages/themes/src/themes/console/darker.ts
+++ b/packages/themes/src/themes/console/darker.ts
@@ -172,6 +172,14 @@ export const darkerTheme = {
             fillWeak: '#cd1759',
             fillWeakDisabled: '#0c0f1a',
           },
+          original: {
+            fill: '#ffffff',
+            fillDisabled: '#212638',
+            fillStrong: '#bf95fd',
+            fillStrongDisabled: '#212638',
+            fillWeak: '#4f1c89',
+            fillWeakDisabled: '#0c0f1a',
+          },
           primary: {
             fill: '#954cf7',
             fillDisabled: '#3b3f4f',

--- a/packages/themes/src/themes/console/light.ts
+++ b/packages/themes/src/themes/console/light.ts
@@ -172,6 +172,14 @@ export const lightTheme = {
             fillWeak: '#e51963',
             fillWeakDisabled: '#f3f3f4',
           },
+          original: {
+            fill: '#ffffff',
+            fillDisabled: '#d9dadd',
+            fillStrong: '#bf95f9',
+            fillStrongDisabled: '#d9dadd',
+            fillWeak: '#521094',
+            fillWeakDisabled: '#f3f3f4',
+          },
           primary: {
             fill: '#521094',
             fillDisabled: '#d9dadd',


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

#### What is expected?

- New token `theme.colors.other.icon.product.original`, it contains all colors for the new product icon variant `original`.
- New `<ProductIcon />` variant available: `original`

## Relevant logs and/or screenshots

<img width="1031" alt="Screenshot 2024-02-19 at 13 45 34" src="https://github.com/scaleway/ultraviolet/assets/15812968/5fb499b2-cb07-4d67-af4a-bebed265986a">

