### PR TITLE
fix(RadioGroup): children radio name optional as parent spread it

### DIFF
--- a/.changeset/cyan-rocks-hug.md
+++ b/.changeset/cyan-rocks-hug.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": minor
+"@ultraviolet/ui": minor
+---
+
+Fix `<RadioGroup.Radio />` by setting name optional as the parent will git it

--- a/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
@@ -74,6 +74,10 @@ export default {
         component: 'A NumberInput field',
       },
     },
+    deprecated: true,
+    deprecatedReason:
+      'This component is deprecated, use NumberInputFieldV2 instead.',
+    migrationLink: 'Migrations/NumberInput to NumberInputV2',
   },
   title: 'Form/Components/Fields/NumberInputField',
 } as Meta

--- a/packages/form/src/components/NumberInputField/index.tsx
+++ b/packages/form/src/components/NumberInputField/index.tsx
@@ -27,6 +27,9 @@ type NumberInputValueFieldProps<
     onFocus?: FocusEventHandler<HTMLInputElement>
   }
 
+/**
+ * @deprecated This component is deprecated, use `NumberInputFieldV2` instead.
+ */
 export const NumberInputField = <
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,

--- a/packages/form/src/components/RadioField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/RadioField/__stories__/index.stories.tsx
@@ -74,6 +74,9 @@ export default {
         component: 'A radio field',
       },
     },
+    deprecated: true,
+    deprecatedReason:
+      'This component is deprecated, use RadioGroupField instead.',
   },
   title: 'Form/Components/Fields/RadioField',
 } as Meta

--- a/packages/form/src/components/RadioField/index.tsx
+++ b/packages/form/src/components/RadioField/index.tsx
@@ -24,6 +24,9 @@ type RadioFieldProps<
     className?: string
   }
 
+/**
+ * @deprecated This component is deprecated, use `RadioGroupField` instead.
+ */
 export const RadioField = <
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,

--- a/packages/form/src/components/RadioGroupField/__stories__/Required.stories.tsx
+++ b/packages/form/src/components/RadioGroupField/__stories__/Required.stories.tsx
@@ -6,8 +6,8 @@ import { Submit } from '../..'
 export const RequiredStory: StoryFn<typeof RadioGroupField> = args => (
   <Stack gap={1}>
     <RadioGroupField {...args}>
-      <RadioGroupField.Radio name="radio-1" value="radio-1" label="Radio 1" />
-      <RadioGroupField.Radio name="radio-2" value="radio-2" label="Radio 2" />
+      <RadioGroupField.Radio value="radio-1" label="Radio 1" />
+      <RadioGroupField.Radio value="radio-2" label="Radio 2" />
     </RadioGroupField>
     <Submit>Submit</Submit>
   </Stack>

--- a/packages/form/src/components/RadioGroupField/__stories__/Template.stories.tsx
+++ b/packages/form/src/components/RadioGroupField/__stories__/Template.stories.tsx
@@ -1,37 +1,17 @@
 import type { StoryFn } from '@storybook/react'
-import { Stack } from '@ultraviolet/ui'
 import type { ComponentProps } from 'react'
-import { useFormContext } from 'react-hook-form'
-import { Form, RadioGroupField } from '../..'
-import { mockErrors } from '../../../mocks'
-
-const RadioGroupFieldStory: StoryFn<
-  ComponentProps<typeof RadioGroupField>
-> = args => {
-  const { watch } = useFormContext()
-
-  return (
-    <Stack gap={2}>
-      <RadioGroupField {...args}>
-        <RadioGroupField.Radio name="radio-1" value="radio-1" label="Radio 1" />
-        <RadioGroupField.Radio name="radio-2" value="radio-2" label="Radio 2" />
-      </RadioGroupField>
-      <span>
-        <b>Form content:</b> {JSON.stringify(watch())}
-      </span>
-    </Stack>
-  )
-}
+import { RadioGroupField } from '../..'
 
 export const Template: StoryFn<
   ComponentProps<typeof RadioGroupField>
 > = args => (
-  <Form onRawSubmit={() => {}} errors={mockErrors}>
-    <RadioGroupFieldStory {...args} />
-  </Form>
+  <RadioGroupField {...args}>
+    <RadioGroupField.Radio value="radio 1" label="Radio 1" />
+    <RadioGroupField.Radio value="radio 2" label="Radio 2" />
+  </RadioGroupField>
 )
 
 Template.args = {
-  name: 'template',
+  name: 'myRadioGroup',
   legend: 'Legend label',
 }

--- a/packages/form/src/components/RadioGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/RadioGroupField/__stories__/index.stories.tsx
@@ -6,6 +6,7 @@ import { mockErrors } from '../../../mocks'
 
 export default {
   component: RadioGroupField,
+  subcomponents: { 'RadioGroupField.Radio': RadioGroupField.Radio },
   decorators: [
     ChildStory => {
       const methods = useForm()
@@ -24,7 +25,7 @@ export default {
       } = methods.formState
 
       return (
-        <Form onRawSubmit={() => {}} errors={mockErrors}>
+        <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
             {ChildStory()}
             <Stack gap={1}>

--- a/packages/form/src/components/RadioGroupField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/RadioGroupField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -253,8 +253,8 @@ exports[`RadioField should render correctly checked 1`] = `
                   aria-disabled="false"
                   aria-invalid="false"
                   class="cache-1dt4s2g ehkrmld3"
-                  id="radio-value-1-value-1"
-                  name="radio-value-1"
+                  id="radio-value-1"
+                  name="radio"
                   type="radio"
                   value="value-1"
                 />
@@ -285,7 +285,7 @@ exports[`RadioField should render correctly checked 1`] = `
                 </svg>
                 <label
                   class="cache-82a6rk ehkrmld1"
-                  for="radio-value-1-value-1"
+                  for="radio-value-1"
                 >
                   Radio 1
                 </label>
@@ -303,8 +303,8 @@ exports[`RadioField should render correctly checked 1`] = `
                   aria-disabled="false"
                   aria-invalid="false"
                   class="cache-1dt4s2g ehkrmld3"
-                  id="radio-value-2-value-2"
-                  name="radio-value-2"
+                  id="radio-value-2"
+                  name="radio"
                   type="radio"
                   value="value-2"
                 />
@@ -335,7 +335,7 @@ exports[`RadioField should render correctly checked 1`] = `
                 </svg>
                 <label
                   class="cache-82a6rk ehkrmld1"
-                  for="radio-value-2-value-2"
+                  for="radio-value-2"
                 >
                   Radio 2
                 </label>
@@ -602,8 +602,8 @@ exports[`RadioField should trigger events correctly 1`] = `
                   aria-disabled="false"
                   aria-invalid="false"
                   class="cache-1dt4s2g ehkrmld3"
-                  id="test-value-1-value-1"
-                  name="test-value-1"
+                  id="test-value-1"
+                  name="test"
                   type="radio"
                   value="value-1"
                 />
@@ -634,7 +634,7 @@ exports[`RadioField should trigger events correctly 1`] = `
                 </svg>
                 <label
                   class="cache-82a6rk ehkrmld1"
-                  for="test-value-1-value-1"
+                  for="test-value-1"
                 >
                   Radio 1
                 </label>
@@ -652,8 +652,8 @@ exports[`RadioField should trigger events correctly 1`] = `
                   aria-disabled="false"
                   aria-invalid="false"
                   class="cache-1dt4s2g ehkrmld3"
-                  id="test-value-2-value-2"
-                  name="test-value-2"
+                  id="test-value-2"
+                  name="test"
                   type="radio"
                   value="value-2"
                 />
@@ -684,7 +684,7 @@ exports[`RadioField should trigger events correctly 1`] = `
                 </svg>
                 <label
                   class="cache-82a6rk ehkrmld1"
-                  for="test-value-2-value-2"
+                  for="test-value-2"
                 >
                   Radio 2
                 </label>

--- a/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
@@ -70,6 +70,10 @@ export default {
         component: 'A switch field that act like a checkbox',
       },
     },
+    deprecated: true,
+    deprecatedReason:
+      'This component is deprecated, please use TextInputFieldV2 instead',
+    migrationLink: 'Migrations/TextInput to TextInputV2',
   },
   title: 'Form/Components/Fields/TextInputField',
 } as Meta

--- a/packages/form/src/components/TextInputField/index.tsx
+++ b/packages/form/src/components/TextInputField/index.tsx
@@ -56,6 +56,9 @@ type TextInputFieldProps<
     innerRef?: Ref<HTMLInputElement>
   }
 
+/**
+ * @deprecated This component is deprecated, please use `TextInputFieldV2` instead
+ */
 export const TextInputField = <
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,

--- a/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
@@ -15,6 +15,12 @@ export default {
       </div>
     ),
   ],
+  parameters: {
+    deprecated: true,
+    deprecatedReason:
+      'This component is deprecated. Please use NumberInputV2 instead.',
+    migrationLink: 'Migrations/NumberInput to NumberInputV2',
+  },
   title: 'Components/Data Entry/NumberInput',
 } as Meta<typeof NumberInput>
 

--- a/packages/ui/src/components/NumberInput/index.tsx
+++ b/packages/ui/src/components/NumberInput/index.tsx
@@ -164,8 +164,7 @@ type NumberInputProps = {
 >
 
 /**
- * NumberInput component is used to increment / decrement a number value by clicking on + / - buttons or
- * by typing into input.
+ * @deprecated This component is deprecated. Please use `NumberInputV2` instead.
  */
 export const NumberInput = ({
   disabled = false,

--- a/packages/ui/src/components/RadioGroup/__stories__/Controlled.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/Controlled.stories.tsx
@@ -15,8 +15,8 @@ export const Controlled: StoryFn = args => {
         onChange(e.currentTarget.value)
       }
     >
-      <RadioGroup.Radio name="label-1" value="label-1" label="Label 1" />
-      <RadioGroup.Radio name="label-2" value="label-2" label="Label 2" />
+      <RadioGroup.Radio value="label-1" label="Label 1" />
+      <RadioGroup.Radio value="label-2" label="Label 2" />
     </RadioGroup>
   )
 }

--- a/packages/ui/src/components/RadioGroup/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/Template.stories.tsx
@@ -3,8 +3,8 @@ import { RadioGroup } from '..'
 
 export const Template: StoryFn<typeof RadioGroup> = args => (
   <RadioGroup {...args}>
-    <RadioGroup.Radio name="value-1" value="value-1" label="Radio 1" />
-    <RadioGroup.Radio name="value-2" value="value-2" label="Radio 2" />
+    <RadioGroup.Radio value="value-1" label="Radio 1" />
+    <RadioGroup.Radio value="value-2" label="Radio 2" />
   </RadioGroup>
 )
 

--- a/packages/ui/src/components/RadioGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/RadioGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -253,8 +253,8 @@ exports[`RadioGroup renders correctly 1`] = `
                 aria-invalid="false"
                 checked=""
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-1-value-1"
-                name="radio-value-1"
+                id="radio-value-1"
+                name="radio"
                 type="radio"
                 value="value-1"
               />
@@ -285,7 +285,7 @@ exports[`RadioGroup renders correctly 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-1-value-1"
+                for="radio-value-1"
               >
                 Radio 1
               </label>
@@ -303,8 +303,8 @@ exports[`RadioGroup renders correctly 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-2-value-2"
-                name="radio-value-2"
+                id="radio-value-2"
+                name="radio"
                 type="radio"
                 value="value-2"
               />
@@ -335,7 +335,7 @@ exports[`RadioGroup renders correctly 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-2-value-2"
+                for="radio-value-2"
               >
                 Radio 2
               </label>
@@ -624,8 +624,8 @@ exports[`RadioGroup renders correctly with direction row 1`] = `
                 aria-invalid="false"
                 checked=""
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-1-value-1"
-                name="radio-value-1"
+                id="radio-value-1"
+                name="radio"
                 type="radio"
                 value="value-1"
               />
@@ -656,7 +656,7 @@ exports[`RadioGroup renders correctly with direction row 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-1-value-1"
+                for="radio-value-1"
               >
                 Radio 1
               </label>
@@ -674,8 +674,8 @@ exports[`RadioGroup renders correctly with direction row 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-2-value-2"
-                name="radio-value-2"
+                id="radio-value-2"
+                name="radio"
                 type="radio"
                 value="value-2"
               />
@@ -706,7 +706,7 @@ exports[`RadioGroup renders correctly with direction row 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-2-value-2"
+                for="radio-value-2"
               >
                 Radio 2
               </label>
@@ -984,8 +984,8 @@ exports[`RadioGroup renders correctly with error content 1`] = `
                 aria-invalid="false"
                 checked=""
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-1-value-1"
-                name="radio-value-1"
+                id="radio-value-1"
+                name="radio"
                 type="radio"
                 value="value-1"
               />
@@ -1016,7 +1016,7 @@ exports[`RadioGroup renders correctly with error content 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-1-value-1"
+                for="radio-value-1"
               >
                 Radio 1
               </label>
@@ -1034,8 +1034,8 @@ exports[`RadioGroup renders correctly with error content 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-2-value-2"
-                name="radio-value-2"
+                id="radio-value-2"
+                name="radio"
                 type="radio"
                 value="value-2"
               />
@@ -1066,7 +1066,7 @@ exports[`RadioGroup renders correctly with error content 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-2-value-2"
+                for="radio-value-2"
               >
                 Radio 2
               </label>
@@ -1349,8 +1349,8 @@ exports[`RadioGroup renders correctly with helper content 1`] = `
                 aria-invalid="false"
                 checked=""
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-1-value-1"
-                name="radio-value-1"
+                id="radio-value-1"
+                name="radio"
                 type="radio"
                 value="value-1"
               />
@@ -1381,7 +1381,7 @@ exports[`RadioGroup renders correctly with helper content 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-1-value-1"
+                for="radio-value-1"
               >
                 Radio 1
               </label>
@@ -1399,8 +1399,8 @@ exports[`RadioGroup renders correctly with helper content 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="cache-1ghsgz8-RadioInput ehkrmld3"
-                id="radio-value-2-value-2"
-                name="radio-value-2"
+                id="radio-value-2"
+                name="radio"
                 type="radio"
                 value="value-2"
               />
@@ -1431,7 +1431,7 @@ exports[`RadioGroup renders correctly with helper content 1`] = `
               </svg>
               <label
                 class="cache-shj57p-StyledLabel ehkrmld1"
-                for="radio-value-2-value-2"
+                for="radio-value-2"
               >
                 Radio 2
               </label>

--- a/packages/ui/src/components/RadioGroup/index.tsx
+++ b/packages/ui/src/components/RadioGroup/index.tsx
@@ -25,7 +25,12 @@ const RadioGroupContext = createContext<RadioGroupContextType | undefined>(
 type RadioGroupRadioProps = Omit<
   ComponentProps<typeof Radio>,
   'onChange' | 'checked' | 'required'
->
+> & {
+  /**
+   * @deprecated you don't need to use `name` anymore, the name will be passed from the parent `RadioGroup`.
+   */
+  name?: string
+}
 
 const RadioGroupRadio = ({
   onFocus,
@@ -48,17 +53,16 @@ const RadioGroupRadio = ({
   }
 
   const { groupName, onChange, groupValue } = context
-  const radioName = `${groupName}-${name ?? ''}`
 
   return (
     <Radio
       onChange={onChange}
-      checked={`${groupName}-${groupValue}` === radioName}
+      checked={groupValue === value}
       onFocus={onFocus}
       onBlur={onBlur}
       disabled={disabled}
       error={error}
-      name={radioName}
+      name={groupName ?? name}
       value={value}
       label={label}
       helper={helper}

--- a/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
@@ -4,6 +4,12 @@ import { TextInput } from '..'
 export default {
   component: TextInput,
   title: 'Components/Data Entry/TextInput',
+  parameters: {
+    deprecated: true,
+    deprecatedReason:
+      'This component is deprecated. Please use the TextInputV2 component instead.',
+    migrationLink: 'Migrations/TextInput to TextInputV2',
+  },
 } as Meta<typeof TextInput>
 
 export { Playground } from './Playground.stories'


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

- `RadioGroup.Radio` use to have the name as required while we don't need it, it's his parent `RadioGroup` who will spread the name among it's children. This only works because in a context of a radio we only need one value and so one key associated with it.
- Mark as deprecated `TextInput`, `TextInputField`, `NumberInput`, `NumberInputField` and `RadioField`
