### PR TITLE
fix(inputs): multiple inputs issue with required icon and no label

### DIFF
--- a/.changeset/strange-doors-study.md
+++ b/.changeset/strange-doors-study.md
@@ -1,0 +1,12 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/plus": patch
+"@ultraviolet/ui": patch
+---
+
+Fix multiple inputs that has bug when required and not label set the required icon was staying:
+- `<NumberInputV2 />`
+- `<TagInput />`
+- `<TextArea />`
+- `<TextInputV2 />`
+- `<DateInput />`

--- a/packages/form/src/components/DateField/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/form/src/components/DateField/__tests__/__snapshots__/index.tsx.snap
@@ -178,64 +178,6 @@ exports[`DateField should render correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-9bqyx6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-1fbmuwp {
   display: -webkit-box;
   display: -webkit-flex;
@@ -371,18 +313,6 @@ exports[`DateField should render correctly 1`] = `
           <div
             class=" cache-16otux ehpbis70"
           >
-            <div
-              class="cache-9bqyx6 ehpbis70"
-            >
-              <div
-                class="cache-1l08jzy ehpbis70"
-              >
-                <label
-                  class="cache-fxvpe6 e13y3mga0"
-                  for=":r1:"
-                />
-              </div>
-            </div>
             <div>
               <div
                 class="cache-1fbmuwp e7tir8v0"
@@ -599,64 +529,6 @@ exports[`DateField should render correctly disabled 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-9bqyx6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-1fbmuwp {
   display: -webkit-box;
   display: -webkit-flex;
@@ -792,18 +664,6 @@ exports[`DateField should render correctly disabled 1`] = `
           <div
             class=" cache-16otux ehpbis70"
           >
-            <div
-              class="cache-9bqyx6 ehpbis70"
-            >
-              <div
-                class="cache-1l08jzy ehpbis70"
-              >
-                <label
-                  class="cache-fxvpe6 e13y3mga0"
-                  for=":r5:"
-                />
-              </div>
-            </div>
             <div>
               <div
                 class="cache-1fbmuwp e7tir8v0"
@@ -816,7 +676,7 @@ exports[`DateField should render correctly disabled 1`] = `
                   aria-invalid="false"
                   class="cache-2aies0 e7tir8v1"
                   disabled=""
-                  id=":r5:"
+                  id=":r4:"
                   name="test"
                   type="text"
                   value=""
@@ -1021,64 +881,6 @@ exports[`DateField should trigger events 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-9bqyx6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-i5307t {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1216,18 +1018,6 @@ exports[`DateField should trigger events 1`] = `
           <div
             class=" cache-16otux ehpbis70"
           >
-            <div
-              class="cache-9bqyx6 ehpbis70"
-            >
-              <div
-                class="cache-1l08jzy ehpbis70"
-              >
-                <label
-                  class="cache-fxvpe6 e13y3mga0"
-                  for=":r9:"
-                />
-              </div>
-            </div>
             <div>
               <div
                 class="cache-i5307t e7tir8v0"
@@ -1239,7 +1029,7 @@ exports[`DateField should trigger events 1`] = `
                 <input
                   aria-invalid="false"
                   class="cache-2aies0 e7tir8v1"
-                  id=":r9:"
+                  id=":r7:"
                   name="test"
                   type="text"
                   value="08/28/2022"

--- a/packages/form/src/components/NumberInputFieldV2/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/NumberInputFieldV2/__tests__/__snapshots__/index.spec.tsx.snap
@@ -25,64 +25,6 @@ exports[`NumberInputFieldV2 should render correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-9bqyx6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-ztn6dz {
   display: -webkit-box;
   display: -webkit-flex;
@@ -331,18 +273,6 @@ exports[`NumberInputFieldV2 should render correctly 1`] = `
     <div
       class="cache-16otux ehpbis70"
     >
-      <div
-        class="cache-9bqyx6 ehpbis70"
-      >
-        <div
-          class="cache-1l08jzy ehpbis70"
-        >
-          <label
-            class="cache-fxvpe6 e13y3mga0"
-            for=":r0:"
-          />
-        </div>
-      </div>
       <div>
         <div
           class="cache-ztn6dz e1b9qdjy0"
@@ -437,64 +367,6 @@ exports[`NumberInputFieldV2 should render correctly disabled 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-9bqyx6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-ztn6dz {
   display: -webkit-box;
   display: -webkit-flex;
@@ -734,18 +606,6 @@ exports[`NumberInputFieldV2 should render correctly disabled 1`] = `
     <div
       class="cache-16otux ehpbis70"
     >
-      <div
-        class="cache-9bqyx6 ehpbis70"
-      >
-        <div
-          class="cache-1l08jzy ehpbis70"
-        >
-          <label
-            class="cache-fxvpe6 e13y3mga0"
-            for=":r5:"
-          />
-        </div>
-      </div>
       <div>
         <div
           class="cache-ztn6dz e1b9qdjy0"
@@ -783,7 +643,7 @@ exports[`NumberInputFieldV2 should render correctly disabled 1`] = `
               data-has-unit="false"
               data-size="large"
               disabled=""
-              id=":r5:"
+              id=":r4:"
               max="Infinity"
               min="0"
               name="test"
@@ -842,64 +702,6 @@ exports[`NumberInputFieldV2 should trigger event onMinCrossed & onMaxCrossed 1`]
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-9bqyx6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-ztn6dz {
@@ -1195,18 +997,6 @@ exports[`NumberInputFieldV2 should trigger event onMinCrossed & onMaxCrossed 1`]
     <div
       class="cache-16otux ehpbis70"
     >
-      <div
-        class="cache-9bqyx6 ehpbis70"
-      >
-        <div
-          class="cache-1l08jzy ehpbis70"
-        >
-          <label
-            class="cache-fxvpe6 e13y3mga0"
-            for=":ra:"
-          />
-        </div>
-      </div>
       <div>
         <div
           class="cache-ztn6dz e1b9qdjy0"
@@ -1242,7 +1032,7 @@ exports[`NumberInputFieldV2 should trigger event onMinCrossed & onMaxCrossed 1`]
               class="cache-jeg2os e1b9qdjy1"
               data-has-unit="false"
               data-size="large"
-              id=":ra:"
+              id=":r8:"
               max="20"
               min="5"
               name="test"

--- a/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -25,64 +25,6 @@ exports[`TagInputField should render correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-9bqyx6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-1hf5vja {
   display: -webkit-box;
   display: -webkit-flex;
@@ -181,18 +123,6 @@ exports[`TagInputField should render correctly 1`] = `
     <div
       class="cache-16otux ehpbis70"
     >
-      <div
-        class="cache-9bqyx6 ehpbis70"
-      >
-        <div
-          class="cache-1l08jzy ehpbis70"
-        >
-          <label
-            class="cache-fxvpe6 e13y3mga0"
-            for=":r0:"
-          />
-        </div>
-      </div>
       <div>
         <div
           class="cache-1hf5vja ea7vc6o3"

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.spec.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.spec.tsx.snap
@@ -754,41 +754,6 @@ exports[`EstimateCost - NumberInput Item render basic props 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-ztn6dz {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1361,18 +1326,6 @@ exports[`EstimateCost - NumberInput Item render basic props 1`] = `
                   <div
                     class="cache-16otux ehpbis70"
                   >
-                    <div
-                      class="cache-9bqyx6 ehpbis70"
-                    >
-                      <div
-                        class="cache-1l08jzy ehpbis70"
-                      >
-                        <label
-                          class="cache-fxvpe6 e13y3mga0"
-                          for=":r6:"
-                        />
-                      </div>
-                    </div>
                     <div>
                       <div
                         class="cache-ztn6dz e1b9qdjy0"
@@ -2244,41 +2197,6 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-ztn6dz {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2746,7 +2664,7 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-110bzf5 e11gt5pw2"
-                          for=":rj:"
+                          for=":ri:"
                         >
                           Select...
                         </label>
@@ -2768,7 +2686,7 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":rj:"
+                            id=":ri:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -2851,18 +2769,6 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
                   <div
                     class="cache-16otux ehpbis70"
                   >
-                    <div
-                      class="cache-9bqyx6 ehpbis70"
-                    >
-                      <div
-                        class="cache-1l08jzy ehpbis70"
-                      >
-                        <label
-                          class="cache-fxvpe6 e13y3mga0"
-                          for=":rm:"
-                        />
-                      </div>
-                    </div>
                     <div>
                       <div
                         class="cache-ztn6dz e1b9qdjy0"
@@ -2897,7 +2803,7 @@ exports[`EstimateCost - NumberInput Item render basic with overlay 1`] = `
                             class="cache-jeg2os e1b9qdjy1"
                             data-has-unit="false"
                             data-size="small"
-                            id=":rm:"
+                            id=":rl:"
                             max="100"
                             min="0"
                             placeholder=""
@@ -3734,41 +3640,6 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-ztn6dz {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4236,7 +4107,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-110bzf5 e11gt5pw2"
-                          for=":r1l:"
+                          for=":r1i:"
                         >
                           Select...
                         </label>
@@ -4258,7 +4129,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r1l:"
+                            id=":r1i:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -4341,18 +4212,6 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                   <div
                     class="cache-16otux ehpbis70"
                   >
-                    <div
-                      class="cache-9bqyx6 ehpbis70"
-                    >
-                      <div
-                        class="cache-1l08jzy ehpbis70"
-                      >
-                        <label
-                          class="cache-fxvpe6 e13y3mga0"
-                          for=":r1o:"
-                        />
-                      </div>
-                    </div>
                     <div>
                       <div
                         class="cache-ztn6dz e1b9qdjy0"
@@ -4387,7 +4246,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                             class="cache-jeg2os e1b9qdjy1"
                             data-has-unit="false"
                             data-size="small"
-                            id=":r1o:"
+                            id=":r1l:"
                             max="100"
                             min="0"
                             placeholder=""
@@ -5238,41 +5097,6 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-1l08jzy {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-fxvpe6 {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-ztn6dz {
   display: -webkit-box;
   display: -webkit-flex;
@@ -5752,7 +5576,7 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-110bzf5 e11gt5pw2"
-                          for=":r13:"
+                          for=":r11:"
                         >
                           Select...
                         </label>
@@ -5774,7 +5598,7 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r13:"
+                            id=":r11:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -5862,18 +5686,6 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
                   <div
                     class="cache-16otux ehpbis70"
                   >
-                    <div
-                      class="cache-9bqyx6 ehpbis70"
-                    >
-                      <div
-                        class="cache-1l08jzy ehpbis70"
-                      >
-                        <label
-                          class="cache-fxvpe6 e13y3mga0"
-                          for=":r17:"
-                        />
-                      </div>
-                    </div>
                     <div>
                       <div
                         class="cache-ztn6dz e1b9qdjy0"
@@ -5908,7 +5720,7 @@ exports[`EstimateCost - NumberInput Item render with values 1`] = `
                             class="cache-jeg2os e1b9qdjy1"
                             data-has-unit="false"
                             data-size="small"
-                            id=":r17:"
+                            id=":r15:"
                             max="51"
                             min="0"
                             placeholder=""

--- a/packages/ui/src/components/NumberInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/NumberInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,64 +25,6 @@ exports[`NumberInputV2 should click on min button 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -330,18 +272,6 @@ exports[`NumberInputV2 should click on min button 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r26:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -376,7 +306,7 @@ exports[`NumberInputV2 should click on min button 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":r26:"
+            id=":r1p:"
             max="100"
             min="0"
             placeholder=""
@@ -435,64 +365,6 @@ exports[`NumberInputV2 should click on plus button with a step value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -740,18 +612,6 @@ exports[`NumberInputV2 should click on plus button with a step value 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r2b:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -786,7 +646,7 @@ exports[`NumberInputV2 should click on plus button with a step value 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":r2b:"
+            id=":r1t:"
             max="100"
             min="0"
             placeholder=""
@@ -845,64 +705,6 @@ exports[`NumberInputV2 should click on plus button with a step value and an in-b
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1150,18 +952,6 @@ exports[`NumberInputV2 should click on plus button with a step value and an in-b
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r2l:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -1196,7 +986,7 @@ exports[`NumberInputV2 should click on plus button with a step value and an in-b
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":r2l:"
+            id=":r25:"
             max="100"
             min="0"
             placeholder=""
@@ -1255,64 +1045,6 @@ exports[`NumberInputV2 should focus input and modify value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1560,18 +1292,6 @@ exports[`NumberInputV2 should focus input and modify value 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r2g:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -1606,7 +1326,7 @@ exports[`NumberInputV2 should focus input and modify value 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":r2g:"
+            id=":r21:"
             max="100"
             min="0"
             placeholder=""
@@ -1665,64 +1385,6 @@ exports[`NumberInputV2 should renders correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1970,18 +1632,6 @@ exports[`NumberInputV2 should renders correctly 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r0:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -2074,64 +1724,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size large 1`] = 
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2379,18 +1971,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size large 1`] = 
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r15:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -2425,7 +2005,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size large 1`] = 
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":r15:"
+            id=":ru:"
             max="100"
             min="0"
             placeholder=""
@@ -2481,64 +2061,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size large and un
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -2810,18 +2332,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size large and un
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r1a:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -2856,7 +2366,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size large and un
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="true"
             data-size="large"
-            id=":r1a:"
+            id=":r12:"
             max="100"
             min="0"
             placeholder=""
@@ -2917,64 +2427,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium 1`] =
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -3224,18 +2676,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium 1`] =
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r1g:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -3270,7 +2710,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium 1`] =
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="medium"
-            id=":r1g:"
+            id=":r17:"
             max="100"
             min="0"
             placeholder=""
@@ -3326,64 +2766,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium and u
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -3655,18 +3037,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium and u
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r1l:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -3701,7 +3071,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size medium and u
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="true"
             data-size="medium"
-            id=":r1l:"
+            id=":r1b:"
             max="100"
             min="0"
             placeholder=""
@@ -3762,64 +3132,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size small 1`] = 
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -4069,18 +3381,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size small 1`] = 
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r1r:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -4115,7 +3415,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size small 1`] = 
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="small"
-            id=":r1r:"
+            id=":r1g:"
             max="100"
             min="0"
             placeholder=""
@@ -4171,64 +3471,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size small and un
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -4500,18 +3742,6 @@ exports[`NumberInputV2 should renders correctly all sizes with size small and un
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r20:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -4546,7 +3776,7 @@ exports[`NumberInputV2 should renders correctly all sizes with size small and un
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="true"
             data-size="small"
-            id=":r20:"
+            id=":r1k:"
             max="100"
             min="0"
             placeholder=""
@@ -4607,64 +3837,6 @@ exports[`NumberInputV2 should renders correctly disabled 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -4905,18 +4077,6 @@ exports[`NumberInputV2 should renders correctly disabled 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r5:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -4953,7 +4113,7 @@ exports[`NumberInputV2 should renders correctly disabled 1`] = `
             data-has-unit="false"
             data-size="large"
             disabled=""
-            id=":r5:"
+            id=":r4:"
             max="Infinity"
             min="0"
             placeholder=""
@@ -5012,64 +4172,6 @@ exports[`NumberInputV2 should renders correctly max value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -5317,18 +4419,6 @@ exports[`NumberInputV2 should renders correctly max value 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r10:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -5363,7 +4453,7 @@ exports[`NumberInputV2 should renders correctly max value 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":r10:"
+            id=":rq:"
             max="100"
             min="0"
             placeholder=""
@@ -5421,64 +4511,6 @@ exports[`NumberInputV2 should renders correctly min value 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-snr60n-Container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -5726,18 +4758,6 @@ exports[`NumberInputV2 should renders correctly min value 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":rr:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -5772,7 +4792,7 @@ exports[`NumberInputV2 should renders correctly min value 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":rr:"
+            id=":rm:"
             max="100"
             min="0"
             placeholder=""
@@ -5828,64 +4848,6 @@ exports[`NumberInputV2 should renders correctly with error 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -6147,18 +5109,6 @@ exports[`NumberInputV2 should renders correctly with error 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":ra:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -6193,7 +5143,7 @@ exports[`NumberInputV2 should renders correctly with error 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":ra:"
+            id=":r8:"
             max="Infinity"
             min="0"
             placeholder=""
@@ -6254,64 +5204,6 @@ exports[`NumberInputV2 should renders correctly with placeholder 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -6561,18 +5453,6 @@ exports[`NumberInputV2 should renders correctly with placeholder 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":rm:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -6607,7 +5487,7 @@ exports[`NumberInputV2 should renders correctly with placeholder 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":rm:"
+            id=":ri:"
             max="Infinity"
             min="0"
             placeholder="Enter a value here"
@@ -6663,64 +5543,6 @@ exports[`NumberInputV2 should renders correctly with success 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-snr60n-Container {
@@ -6982,18 +5804,6 @@ exports[`NumberInputV2 should renders correctly with success 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":rg:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-snr60n-Container e1b9qdjy0"
@@ -7028,7 +5838,7 @@ exports[`NumberInputV2 should renders correctly with success 1`] = `
             class="cache-h5mwdc-Input e1b9qdjy1"
             data-has-unit="false"
             data-size="large"
-            id=":rg:"
+            id=":rd:"
             max="Infinity"
             min="0"
             placeholder=""

--- a/packages/ui/src/components/NumberInputV2/index.tsx
+++ b/packages/ui/src/components/NumberInputV2/index.tsx
@@ -317,20 +317,26 @@ export const NumberInputV2 = forwardRef(
 
     return (
       <Stack gap="0.5" className={className}>
-        <Stack direction="row" gap="1" alignItems="center">
-          <Stack direction="row" gap="0.5" alignItems="start">
-            <Text
-              as="label"
-              variant="bodyStrong"
-              sentiment="neutral"
-              htmlFor={id ?? localId}
-            >
-              {label}
-            </Text>
-            {required ? <Icon name="asterisk" color="danger" size={8} /> : null}
+        {label || labelDescription ? (
+          <Stack direction="row" gap="1" alignItems="center">
+            {label ? (
+              <Stack direction="row" gap="0.5" alignItems="start">
+                <Text
+                  as="label"
+                  variant="bodyStrong"
+                  sentiment="neutral"
+                  htmlFor={id ?? localId}
+                >
+                  {label}
+                </Text>
+                {required ? (
+                  <Icon name="asterisk" color="danger" size={8} />
+                ) : null}
+              </Stack>
+            ) : null}
+            {labelDescription ?? null}
           </Stack>
-          {labelDescription ?? null}
-        </Stack>
+        ) : null}
         <div>
           <Tooltip text={tooltip}>
             <Container

--- a/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,64 +25,6 @@ exports[`TagInput should renders correctly 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-h4to4s-TagInputContainer {
   display: -webkit-box;
   display: -webkit-flex;
@@ -180,18 +122,6 @@ exports[`TagInput should renders correctly 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r0:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-h4to4s-TagInputContainer ea7vc6o3"
@@ -241,64 +171,6 @@ exports[`TagInput should renders correctly disabled 1`] = `
   flex-wrap: nowrap;
 }
 
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .cache-h4to4s-TagInputContainer {
   display: -webkit-box;
   display: -webkit-flex;
@@ -364,18 +236,6 @@ exports[`TagInput should renders correctly disabled 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r3:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-h4to4s-TagInputContainer ea7vc6o3"
@@ -416,64 +276,6 @@ exports[`TagInput should renders correctly readOnly 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-h4to4s-TagInputContainer {
@@ -573,18 +375,6 @@ exports[`TagInput should renders correctly readOnly 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r6:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-h4to4s-TagInputContainer ea7vc6o3"
@@ -598,7 +388,7 @@ exports[`TagInput should renders correctly readOnly 1`] = `
         >
           <input
             class="cache-45doph-StyledInput ea7vc6o0"
-            id=":r6:"
+            id=":r4:"
             readonly=""
             type="text"
             value=""
@@ -633,64 +423,6 @@ exports[`TagInput should renders correctly with error 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-h4to4s-TagInputContainer {
@@ -823,18 +555,6 @@ exports[`TagInput should renders correctly with error 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":r9:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-h4to4s-TagInputContainer ea7vc6o3"
@@ -848,7 +568,7 @@ exports[`TagInput should renders correctly with error 1`] = `
         >
           <input
             class="cache-45doph-StyledInput ea7vc6o0"
-            id=":r9:"
+            id=":r6:"
             type="text"
             value=""
           />
@@ -899,64 +619,6 @@ exports[`TagInput should renders correctly with placeholder 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-h4to4s-TagInputContainer {
@@ -1056,18 +718,6 @@ exports[`TagInput should renders correctly with placeholder 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":rh:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-h4to4s-TagInputContainer ea7vc6o3"
@@ -1081,7 +731,7 @@ exports[`TagInput should renders correctly with placeholder 1`] = `
         >
           <input
             class="cache-45doph-StyledInput ea7vc6o0"
-            id=":rh:"
+            id=":rc:"
             placeholder="Enter a value here"
             type="text"
             value=""
@@ -1116,64 +766,6 @@ exports[`TagInput should renders correctly with some tags 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-h4to4s-TagInputContainer {
@@ -1384,18 +976,314 @@ exports[`TagInput should renders correctly with some tags 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
+    <div>
       <div
-        class="cache-135dzb3-Stack ehpbis70"
+        class="cache-h4to4s-TagInputContainer ea7vc6o3"
+        data-disabled="false"
+        data-error="false"
+        data-readonly="false"
+        data-success="false"
       >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":rk:"
-        />
+        <div
+          class="cache-bi6n77-DataContainer ea7vc6o2"
+        >
+          <span
+            class="cache-1anauza-StyledContainer el6733p2"
+          >
+            <span
+              class="el6733p1 cache-1olt749-StyledText-StyledText e13y3mga0"
+            >
+              hello
+            </span>
+            <button
+              aria-label="Close tag"
+              class="el6733p0 cache-sitm2s-StyledGhostButton-StyledCloseButton e112qvla0"
+              data-testid="close-tag"
+              type="button"
+            >
+              <svg
+                class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                />
+              </svg>
+            </button>
+          </span>
+          <span
+            class="cache-1anauza-StyledContainer el6733p2"
+          >
+            <span
+              class="el6733p1 cache-1olt749-StyledText-StyledText e13y3mga0"
+            >
+              world
+            </span>
+            <button
+              aria-label="Close tag"
+              class="el6733p0 cache-sitm2s-StyledGhostButton-StyledCloseButton e112qvla0"
+              data-testid="close-tag"
+              type="button"
+            >
+              <svg
+                class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                />
+              </svg>
+            </button>
+          </span>
+          <input
+            aria-label="radio"
+            class="cache-45doph-StyledInput ea7vc6o0"
+            id=":re:"
+            name="radio"
+            placeholder=""
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TagInput should renders correctly with some tags objects 1`] = `
+<DocumentFragment>
+  .cache-ymc80m-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-h4to4s-TagInputContainer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  background-color: #ffffff;
+  padding: calc(12px - 1px) 16px;
+  cursor: text;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+}
+
+.cache-h4to4s-TagInputContainer:focus-within {
+  border-color: #792dd4;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.cache-h4to4s-TagInputContainer[data-success='true'] {
+  border-color: #22674e;
+}
+
+.cache-h4to4s-TagInputContainer[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.cache-h4to4s-TagInputContainer:hover {
+  border-color: #792dd4;
+}
+
+.cache-h4to4s-TagInputContainer[data-readonly='true'] {
+  border-color: #d9dadd;
+  background: #f9f9fa;
+}
+
+.cache-h4to4s-TagInputContainer[data-disabled='true'] {
+  border-color: #e9eaeb;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.cache-bi6n77-DataContainer {
+  height: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 8px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.cache-1anauza-StyledContainer {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 4px;
+  padding: 0 8px;
+  gap: 8px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: 24px;
+  color: #3f4250;
+  background: #ffffff;
+  border: solid 1px #d9dadd;
+}
+
+.cache-1olt749-StyledText-StyledText {
+  font-size: 12px;
+  font-family: Inter,Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
+}
+
+.cache-sitm2s-StyledGhostButton-StyledCloseButton {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 32px;
+  padding: 0 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: none;
+  color: #3f4250;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  padding: 2px;
+}
+
+.cache-sitm2s-StyledGhostButton-StyledCloseButton:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.cache-sitm2s-StyledGhostButton-StyledCloseButton:active {
+  box-shadow: 0px 0px 0px 3px #151a2d5c;
+}
+
+.cache-sitm2s-StyledGhostButton-StyledCloseButton:hover,
+.cache-sitm2s-StyledGhostButton-StyledCloseButton:active {
+  background: #e9eaeb;
+  color: #222638;
+}
+
+.cache-1ah7xw8-sizeStyles {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.cache-45doph-StyledInput {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  font-size: 16px;
+  background: inherit;
+  color: #3f4250;
+  border: none;
+  outline: none;
+  height: 100%;
+}
+
+.cache-45doph-StyledInput::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.cache-45doph-StyledInput::-moz-placeholder {
+  color: #727683;
+}
+
+.cache-45doph-StyledInput:-ms-input-placeholder {
+  color: #727683;
+}
+
+.cache-45doph-StyledInput::placeholder {
+  color: #727683;
+}
+
+<div
+    class="cache-ymc80m-Stack ehpbis70"
+  >
     <div>
       <div
         class="cache-h4to4s-TagInputContainer ea7vc6o3"
@@ -1471,384 +1359,6 @@ exports[`TagInput should renders correctly with some tags 1`] = `
 </DocumentFragment>
 `;
 
-exports[`TagInput should renders correctly with some tags objects 1`] = `
-<DocumentFragment>
-  .cache-ymc80m-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.cache-h4to4s-TagInputContainer {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  background-color: #ffffff;
-  padding: calc(12px - 1px) 16px;
-  cursor: text;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  border-radius: 4px;
-}
-
-.cache-h4to4s-TagInputContainer:focus-within {
-  border-color: #792dd4;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-}
-
-.cache-h4to4s-TagInputContainer[data-success='true'] {
-  border-color: #22674e;
-}
-
-.cache-h4to4s-TagInputContainer[data-error='true'] {
-  border-color: #b3144d;
-}
-
-.cache-h4to4s-TagInputContainer:hover {
-  border-color: #792dd4;
-}
-
-.cache-h4to4s-TagInputContainer[data-readonly='true'] {
-  border-color: #d9dadd;
-  background: #f9f9fa;
-}
-
-.cache-h4to4s-TagInputContainer[data-disabled='true'] {
-  border-color: #e9eaeb;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.cache-bi6n77-DataContainer {
-  height: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 8px;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.cache-1anauza-StyledContainer {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  white-space: nowrap;
-  border-radius: 4px;
-  padding: 0 8px;
-  gap: 8px;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: 24px;
-  color: #3f4250;
-  background: #ffffff;
-  border: solid 1px #d9dadd;
-}
-
-.cache-1olt749-StyledText-StyledText {
-  font-size: 12px;
-  font-family: Inter,Asap;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 16px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  max-width: 232px;
-}
-
-.cache-sitm2s-StyledGhostButton-StyledCloseButton {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  height: 32px;
-  padding: 0 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: 8px;
-  border-radius: 4px;
-  box-sizing: border-box;
-  width: 32px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  outline-offset: 2px;
-  white-space: nowrap;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 14px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 20px;
-  paragraph-spacing: 0;
-  text-case: none;
-  background: none;
-  border: none;
-  color: #3f4250;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
-  padding: 2px;
-}
-
-.cache-sitm2s-StyledGhostButton-StyledCloseButton:hover {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.cache-sitm2s-StyledGhostButton-StyledCloseButton:active {
-  box-shadow: 0px 0px 0px 3px #151a2d5c;
-}
-
-.cache-sitm2s-StyledGhostButton-StyledCloseButton:hover,
-.cache-sitm2s-StyledGhostButton-StyledCloseButton:active {
-  background: #e9eaeb;
-  color: #222638;
-}
-
-.cache-1ah7xw8-sizeStyles {
-  vertical-align: middle;
-  fill: currentColor;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
-}
-
-.cache-45doph-StyledInput {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  font-size: 16px;
-  background: inherit;
-  color: #3f4250;
-  border: none;
-  outline: none;
-  height: 100%;
-}
-
-.cache-45doph-StyledInput::-webkit-input-placeholder {
-  color: #727683;
-}
-
-.cache-45doph-StyledInput::-moz-placeholder {
-  color: #727683;
-}
-
-.cache-45doph-StyledInput:-ms-input-placeholder {
-  color: #727683;
-}
-
-.cache-45doph-StyledInput::placeholder {
-  color: #727683;
-}
-
-<div
-    class="cache-ymc80m-Stack ehpbis70"
-  >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":rr:"
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        class="cache-h4to4s-TagInputContainer ea7vc6o3"
-        data-disabled="false"
-        data-error="false"
-        data-readonly="false"
-        data-success="false"
-      >
-        <div
-          class="cache-bi6n77-DataContainer ea7vc6o2"
-        >
-          <span
-            class="cache-1anauza-StyledContainer el6733p2"
-          >
-            <span
-              class="el6733p1 cache-1olt749-StyledText-StyledText e13y3mga0"
-            >
-              hello
-            </span>
-            <button
-              aria-label="Close tag"
-              class="el6733p0 cache-sitm2s-StyledGhostButton-StyledCloseButton e112qvla0"
-              data-testid="close-tag"
-              type="button"
-            >
-              <svg
-                class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
-                />
-              </svg>
-            </button>
-          </span>
-          <span
-            class="cache-1anauza-StyledContainer el6733p2"
-          >
-            <span
-              class="el6733p1 cache-1olt749-StyledText-StyledText e13y3mga0"
-            >
-              world
-            </span>
-            <button
-              aria-label="Close tag"
-              class="el6733p0 cache-sitm2s-StyledGhostButton-StyledCloseButton e112qvla0"
-              data-testid="close-tag"
-              type="button"
-            >
-              <svg
-                class="cache-1ah7xw8-sizeStyles e1gt4cfo0"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
-                />
-              </svg>
-            </button>
-          </span>
-          <input
-            aria-label="radio"
-            class="cache-45doph-StyledInput ea7vc6o0"
-            id=":rr:"
-            name="radio"
-            placeholder=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`TagInput should renders correctly with success 1`] = `
 <DocumentFragment>
   .cache-ymc80m-Stack {
@@ -1872,64 +1382,6 @@ exports[`TagInput should renders correctly with success 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-}
-
-.cache-irytw7-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-135dzb3-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-4gfeok-StyledText {
-  color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 24px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .cache-h4to4s-TagInputContainer {
@@ -2062,18 +1514,6 @@ exports[`TagInput should renders correctly with success 1`] = `
 <div
     class="cache-ymc80m-Stack ehpbis70"
   >
-    <div
-      class="cache-irytw7-Stack ehpbis70"
-    >
-      <div
-        class="cache-135dzb3-Stack ehpbis70"
-      >
-        <label
-          class="cache-4gfeok-StyledText e13y3mga0"
-          for=":rd:"
-        />
-      </div>
-    </div>
     <div>
       <div
         class="cache-h4to4s-TagInputContainer ea7vc6o3"
@@ -2087,7 +1527,7 @@ exports[`TagInput should renders correctly with success 1`] = `
         >
           <input
             class="cache-45doph-StyledInput ea7vc6o0"
-            id=":rd:"
+            id=":r9:"
             type="text"
             value=""
           />

--- a/packages/ui/src/components/TagInput/index.tsx
+++ b/packages/ui/src/components/TagInput/index.tsx
@@ -300,20 +300,26 @@ export const TagInput = ({
 
   return (
     <Stack gap="0.5" className={className}>
-      <Stack direction="row" gap="1" alignItems="center">
-        <Stack direction="row" gap="0.5" alignItems="start">
-          <Text
-            as="label"
-            variant="bodyStrong"
-            sentiment="neutral"
-            htmlFor={localId}
-          >
-            {label}
-          </Text>
-          {required ? <Icon name="asterisk" color="danger" size={8} /> : null}
+      {label || labelDescription ? (
+        <Stack direction="row" gap="1" alignItems="center">
+          {label ? (
+            <Stack direction="row" gap="0.5" alignItems="start">
+              <Text
+                as="label"
+                variant="bodyStrong"
+                sentiment="neutral"
+                htmlFor={id ?? localId}
+              >
+                {label}
+              </Text>
+              {required ? (
+                <Icon name="asterisk" color="danger" size={8} />
+              ) : null}
+            </Stack>
+          ) : null}
+          {labelDescription ?? null}
         </Stack>
-        {labelDescription ?? null}
-      </Stack>
+      ) : null}
       <div>
         <Tooltip text={tooltip}>
           <TagInputContainer

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -178,20 +178,26 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     return (
       <Stack gap="0.5" className={className}>
-        <Stack direction="row" gap="1" alignItems="center">
-          <Stack direction="row" gap="0.5" alignItems="start">
-            <Text
-              as="label"
-              variant="bodyStrong"
-              sentiment="neutral"
-              htmlFor={id ?? localId}
-            >
-              {label}
-            </Text>
-            {required ? <Icon name="asterisk" color="danger" size={8} /> : null}
+        {label || labelDescription ? (
+          <Stack direction="row" gap="1" alignItems="center">
+            {label ? (
+              <Stack direction="row" gap="0.5" alignItems="start">
+                <Text
+                  as="label"
+                  variant="bodyStrong"
+                  sentiment="neutral"
+                  htmlFor={id ?? localId}
+                >
+                  {label}
+                </Text>
+                {required ? (
+                  <Icon name="asterisk" color="danger" size={8} />
+                ) : null}
+              </Stack>
+            ) : null}
+            {labelDescription ?? null}
           </Stack>
-          {labelDescription ?? null}
-        </Stack>
+        ) : null}
         <Tooltip text={tooltip}>
           <StyledTextAreaWrapper>
             <StyledTextArea

--- a/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
@@ -5,11 +5,10 @@ import { TextInputV2 } from '..'
 export const Template: StoryFn<typeof TextInputV2> = ({ ...args }) => {
   const [value, setValue] = useState<string | undefined>(args.value)
 
-  return <TextInputV2 {...args} value={value} onChange={setValue} success />
+  return <TextInputV2 {...args} value={value} onChange={setValue} />
 }
 
 Template.args = {
-  label: 'Label',
   placeholder: 'Placeholder',
   value: 'Text',
 }

--- a/packages/ui/src/components/TextInputV2/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextInputV2/__stories__/index.stories.tsx
@@ -10,7 +10,7 @@ export default {
 } as Meta<typeof TextInputV2>
 
 export { Playground } from './Playground.stories'
-export { Size } from './Size.stories'
+/* export { Size } from './Size.stories'
 export { Password } from './Password.stories'
 export { OnRandomize } from './OnRandomize.stories'
 export { Clearable } from './Clearable.stories'
@@ -19,4 +19,4 @@ export { ReadOnly } from './ReadOnly.stories'
 export { Loading } from './Loading.stories'
 export { Success } from './Success.stories'
 export { Error } from './Error.stories'
-export { Examples } from './Examples.stories'
+export { Examples } from './Examples.stories' */

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -216,20 +216,26 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
 
     return (
       <Stack gap={0.5} className={className}>
-        <Stack direction="row" gap="1" alignItems="center">
-          <Stack direction="row" gap="0.5" alignItems="start">
-            <Text
-              as="label"
-              variant="bodyStrong"
-              sentiment="neutral"
-              htmlFor={id ?? localId}
-            >
-              {label}
-            </Text>
-            {required ? <Icon name="asterisk" color="danger" size={8} /> : null}
+        {label || labelDescription ? (
+          <Stack direction="row" gap="1" alignItems="center">
+            {label ? (
+              <Stack direction="row" gap="0.5" alignItems="start">
+                <Text
+                  as="label"
+                  variant="bodyStrong"
+                  sentiment="neutral"
+                  htmlFor={id ?? localId}
+                >
+                  {label}
+                </Text>
+                {required ? (
+                  <Icon name="asterisk" color="danger" size={8} />
+                ) : null}
+              </Stack>
+            ) : null}
+            {labelDescription ?? null}
           </Stack>
-          {labelDescription ?? null}
-        </Stack>
+        ) : null}
         <div>
           <Tooltip text={tooltip}>
             <StyledInputWrapper


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The new inputs had an issue, when setting required and label it was leaving the required icon on to of it, I fixed it.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="962" alt="Screenshot 2024-02-21 at 15 06 35" src="https://github.com/scaleway/ultraviolet/assets/15812968/1d8b8ae2-0448-4144-a9b6-5cfc9b25296d"> | <img width="966" alt="Screenshot 2024-02-21 at 15 06 45" src="https://github.com/scaleway/ultraviolet/assets/15812968/18f5aa96-c5f3-4109-994c-e700e34b6d18"> |
| url  | <img width="960" alt="Screenshot 2024-02-21 at 15 07 23" src="https://github.com/scaleway/ultraviolet/assets/15812968/0b841b5a-e813-4f4c-85fd-e742b184b13c"> | <img width="968" alt="Screenshot 2024-02-21 at 15 07 33" src="https://github.com/scaleway/ultraviolet/assets/15812968/e12d8625-edc4-4ece-8fb7-4ba8cd165c3e"> |
| url  | <img width="962" alt="Screenshot 2024-02-21 at 15 09 48" src="https://github.com/scaleway/ultraviolet/assets/15812968/70698e8c-9aba-4d6a-a5e7-13da9ec85e8c"> | <img width="969" alt="Screenshot 2024-02-21 at 15 09 57" src="https://github.com/scaleway/ultraviolet/assets/15812968/e152e36b-609f-4743-bd60-e658063af936"> |
| url  | <img width="963" alt="Screenshot 2024-02-21 at 15 12 06" src="https://github.com/scaleway/ultraviolet/assets/15812968/d41b93fd-9fe3-425f-b698-47870bb01689"> |  <img width="976" alt="Screenshot 2024-02-21 at 15 12 17" src="https://github.com/scaleway/ultraviolet/assets/15812968/17164008-a025-4ae2-9757-3e1806434f80"> |
