### PR TITLE
feat(SelectableCard): native indentation for children and spacing with label

### DIFF
--- a/.changeset/gorgeous-insects-build.md
+++ b/.changeset/gorgeous-insects-build.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": minor
+"@ultraviolet/ui": minor
+---
+
+`<SelectableCard />` component now implement natively indentation for childrens and spacing between label and childrens

--- a/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -247,9 +247,41 @@ exports[`SelectableCardField should render correctly 1`] = `
   fill: #ffffff;
 }
 
+.cache-1ualfon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1ualfon[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1ualfon[data-has-label='false'] {
+  display: contents;
+}
+
 <form>
     <div
-      class="cache-1wln6wd e1s5n3hj2"
+      class="cache-1wln6wd e1s5n3hj3"
       data-checked="false"
       data-disabled="false"
       data-error="false"
@@ -261,7 +293,7 @@ exports[`SelectableCardField should render correctly 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj4 cache-1rouikf-StyledRadio ehkrmld2"
           data-checked="false"
           data-error="false"
         >
@@ -301,7 +333,12 @@ exports[`SelectableCardField should render correctly 1`] = `
           </svg>
         </div>
       </div>
-      Radio field
+      <div
+        class="cache-1ualfon e1s5n3hj2"
+        data-has-label="false"
+      >
+        Radio field
+      </div>
     </div>
   </form>
 </DocumentFragment>
@@ -554,9 +591,41 @@ exports[`SelectableCardField should render correctly checked 1`] = `
   fill: #ffffff;
 }
 
+.cache-1ualfon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1ualfon[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1ualfon[data-has-label='false'] {
+  display: contents;
+}
+
 <form>
     <div
-      class="cache-1wln6wd e1s5n3hj2"
+      class="cache-1wln6wd e1s5n3hj3"
       data-checked="true"
       data-disabled="false"
       data-error="false"
@@ -568,7 +637,7 @@ exports[`SelectableCardField should render correctly checked 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj4 cache-1rouikf-StyledRadio ehkrmld2"
           data-checked="true"
           data-error="false"
         >
@@ -609,7 +678,12 @@ exports[`SelectableCardField should render correctly checked 1`] = `
           </svg>
         </div>
       </div>
-      Radio field checked
+      <div
+        class="cache-1ualfon e1s5n3hj2"
+        data-has-label="false"
+      >
+        Radio field checked
+      </div>
     </div>
   </form>
 </DocumentFragment>
@@ -862,9 +936,41 @@ exports[`SelectableCardField should render correctly disabled 1`] = `
   fill: #ffffff;
 }
 
+.cache-1ualfon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1ualfon[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1ualfon[data-has-label='false'] {
+  display: contents;
+}
+
 <form>
     <div
-      class="cache-1wln6wd e1s5n3hj2"
+      class="cache-1wln6wd e1s5n3hj3"
       data-checked="false"
       data-disabled="true"
       data-error="false"
@@ -876,7 +982,7 @@ exports[`SelectableCardField should render correctly disabled 1`] = `
       >
         <div
           aria-disabled="true"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj4 cache-1rouikf-StyledRadio ehkrmld2"
           data-checked="false"
           data-error="false"
         >
@@ -917,7 +1023,12 @@ exports[`SelectableCardField should render correctly disabled 1`] = `
           </svg>
         </div>
       </div>
-      Radio field disabled
+      <div
+        class="cache-1ualfon e1s5n3hj2"
+        data-has-label="false"
+      >
+        Radio field disabled
+      </div>
     </div>
   </form>
 </DocumentFragment>
@@ -1170,9 +1281,41 @@ exports[`SelectableCardField should render correctly with errors 1`] = `
   fill: #ffffff;
 }
 
+.cache-1ualfon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1ualfon[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1ualfon[data-has-label='false'] {
+  display: contents;
+}
+
 <form>
     <div
-      class="cache-1wln6wd e1s5n3hj2"
+      class="cache-1wln6wd e1s5n3hj3"
       data-checked="false"
       data-disabled="false"
       data-error="true"
@@ -1184,7 +1327,7 @@ exports[`SelectableCardField should render correctly with errors 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj4 cache-1rouikf-StyledRadio ehkrmld2"
           data-checked="false"
           data-error="true"
         >
@@ -1224,7 +1367,12 @@ exports[`SelectableCardField should render correctly with errors 1`] = `
           </svg>
         </div>
       </div>
-      Radio field error
+      <div
+        class="cache-1ualfon e1s5n3hj2"
+        data-has-label="false"
+      >
+        Radio field error
+      </div>
     </div>
     <button
       type="submit"
@@ -1482,9 +1630,41 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
   fill: #ffffff;
 }
 
+.cache-1ualfon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1ualfon[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1ualfon[data-has-label='false'] {
+  display: contents;
+}
+
 <form>
     <div
-      class="cache-1wln6wd e1s5n3hj2"
+      class="cache-1wln6wd e1s5n3hj3"
       data-checked="true"
       data-disabled="false"
       data-error="false"
@@ -1496,7 +1676,7 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
       >
         <div
           aria-disabled="false"
-          class="e1s5n3hj3 cache-1rouikf-StyledRadio ehkrmld2"
+          class="e1s5n3hj4 cache-1rouikf-StyledRadio ehkrmld2"
           data-checked="true"
           data-error="false"
         >
@@ -1536,7 +1716,12 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
           </svg>
         </div>
       </div>
-      Radio field events
+      <div
+        class="cache-1ualfon e1s5n3hj2"
+        data-has-label="false"
+      >
+        Radio field events
+      </div>
     </div>
   </form>
 </DocumentFragment>

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -374,8 +374,40 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   flex: 1;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-has-label="false"
@@ -432,7 +464,12 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
         />
       </div>
     </div>
-    Checkbox card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Checkbox card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -811,8 +848,40 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   flex: 1;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="true"
     data-disabled="false"
     data-has-label="false"
@@ -870,7 +939,12 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
         />
       </div>
     </div>
-    Radio card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Radio card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -1249,8 +1323,40 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   flex: 1;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="true"
     data-has-label="false"
@@ -1308,7 +1414,12 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
         />
       </div>
     </div>
-    Radio card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Radio card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -1700,8 +1811,40 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   padding-top: 4px;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-error="true"
@@ -1763,7 +1906,12 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
         />
       </div>
     </div>
-    Radio card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Radio card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -2176,6 +2324,38 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   flex: 1;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
     class="cache-10fpg8v-Stack ehpbis70"
   >
@@ -2186,7 +2366,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
       tabindex="0"
     >
       <div
-        class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+        class="cache-1ls95ey-Stack-Container e1s5n3hj3"
         data-checked="false"
         data-disabled="false"
         data-has-label="false"
@@ -2243,7 +2423,12 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
             />
           </div>
         </div>
-        Checkbox card
+        <div
+          class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+          data-has-label="false"
+        >
+          Checkbox card
+        </div>
       </div>
     </div>
   </div>
@@ -2624,8 +2809,40 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   flex: 1;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="true"
     data-has-label="false"
@@ -2684,9 +2901,14 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
       </div>
     </div>
     <div
-      style="background: gray; color: gray;"
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
     >
-      Complex radio card
+      <div
+        style="background: gray; color: gray;"
+      >
+        Complex radio card
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -2939,8 +3161,40 @@ exports[`SelectableCard renders correctly with default props 1`] = `
   fill: #ffffff;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-has-label="false"
@@ -2951,7 +3205,7 @@ exports[`SelectableCard renders correctly with default props 1`] = `
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj4 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
         data-checked="false"
       >
         <input
@@ -2990,7 +3244,12 @@ exports[`SelectableCard renders correctly with default props 1`] = `
         </svg>
       </div>
     </div>
-    Radio card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Radio card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -3242,8 +3501,40 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
   fill: #ffffff;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="true"
     data-disabled="false"
     data-has-label="false"
@@ -3254,7 +3545,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj4 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
         data-checked="true"
       >
         <input
@@ -3294,7 +3585,12 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
         </svg>
       </div>
     </div>
-    Radio card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Radio card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -3546,8 +3842,40 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
   fill: #ffffff;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="true"
     data-has-label="false"
@@ -3558,7 +3886,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
     >
       <div
         aria-disabled="true"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj4 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
         data-checked="false"
       >
         <input
@@ -3598,7 +3926,12 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
         </svg>
       </div>
     </div>
-    Radio card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Radio card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -3850,8 +4183,40 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
   fill: #ffffff;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-error="true"
@@ -3863,7 +4228,7 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj4 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
         data-checked="false"
         data-error="true"
       >
@@ -3903,7 +4268,12 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
         </svg>
       </div>
     </div>
-    Radio card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Radio card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -4189,6 +4559,38 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
   fill: #ffffff;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
     class="cache-10fpg8v-Stack ehpbis70"
   >
@@ -4199,7 +4601,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
       tabindex="0"
     >
       <div
-        class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+        class="cache-1ls95ey-Stack-Container e1s5n3hj3"
         data-checked="false"
         data-disabled="false"
         data-has-label="false"
@@ -4210,7 +4612,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj4 cache-1nauh8c-RadioContainer-StyledRadio-StyledElement ehkrmld2"
             data-checked="false"
           >
             <input
@@ -4249,7 +4651,12 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
             </svg>
           </div>
         </div>
-        Radio card
+        <div
+          class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+          data-has-label="false"
+        >
+          Radio card
+        </div>
       </div>
     </div>
   </div>
@@ -4622,8 +5029,40 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   flex: 1;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-has-label="false"
@@ -4680,7 +5119,12 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
         />
       </div>
     </div>
-    Checkbox card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Checkbox card
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -4924,8 +5368,40 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
   fill: #ffffff;
 }
 
+.cache-1g3aymm-Stack-StyledStack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.cache-1g3aymm-Stack-StyledStack[data-has-label='false'] {
+  display: contents;
+}
+
 <div
-    class="cache-1ls95ey-Stack-Container e1s5n3hj2"
+    class="cache-1ls95ey-Stack-Container e1s5n3hj3"
     data-checked="false"
     data-disabled="false"
     data-has-label="false"
@@ -4936,7 +5412,7 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
     >
       <div
         aria-disabled="false"
-        class="e1s5n3hj3 cache-15ags5z-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+        class="e1s5n3hj4 cache-15ags5z-RadioContainer-StyledRadio-StyledElement ehkrmld2"
         data-checked="false"
       >
         <input
@@ -4975,7 +5451,12 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
         </svg>
       </div>
     </div>
-    Checkbox card
+    <div
+      class="cache-1g3aymm-Stack-StyledStack e1s5n3hj2"
+      data-has-label="false"
+    >
+      Checkbox card
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/SelectableCard/index.tsx
+++ b/packages/ui/src/components/SelectableCard/index.tsx
@@ -58,6 +58,16 @@ const Container = styled(Stack)`
   }
 `
 
+const StyledStack = styled(Stack)`
+  &[data-has-label='true'] {
+    padding-left: ${({ theme }) => theme.space['4']};
+  }
+
+  &[data-has-label='false'] {
+    display: contents;
+  }
+`
+
 const StyledElement = styled('div', {
   shouldForwardProp: prop => !['showTick', 'hasLabel'].includes(prop),
 })<{ showTick?: boolean; hasLabel?: boolean }>`
@@ -220,9 +230,13 @@ export const SelectableCard = forwardRef(
               {label}
             </StyledCheckbox>
           )}
-          {typeof children === 'function'
-            ? children({ checked, disabled })
-            : children}
+          {children ? (
+            <StyledStack data-has-label={!!label && showTick} width="100%">
+              {typeof children === 'function'
+                ? children({ checked, disabled })
+                : children}
+            </StyledStack>
+          ) : null}
         </Container>
       </ParentContainer>
     )

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -403,7 +403,7 @@ exports[`SwitchButton renders correctly 1`] = `
       class="cache-tib6m2-StyledBorderedBox e4ryteh1"
     >
       <div
-        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="false"
         data-disabled="false"
         data-has-label="true"
@@ -414,7 +414,7 @@ exports[`SwitchButton renders correctly 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj4 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
             data-checked="false"
           >
             <input
@@ -461,7 +461,7 @@ exports[`SwitchButton renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="true"
         data-disabled="false"
         data-has-label="true"
@@ -472,7 +472,7 @@ exports[`SwitchButton renders correctly 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj4 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
             data-checked="true"
           >
             <input
@@ -831,7 +831,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
       class="cache-tib6m2-StyledBorderedBox e4ryteh1"
     >
       <div
-        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="false"
         data-disabled="false"
         data-has-label="true"
@@ -842,7 +842,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj4 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
             data-checked="false"
           >
             <input
@@ -889,7 +889,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
         </div>
       </div>
       <div
-        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj2"
+        class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj3"
         data-checked="true"
         data-disabled="false"
         data-has-label="true"
@@ -900,7 +900,7 @@ exports[`SwitchButton renders correctly with right value 1`] = `
         >
           <div
             aria-disabled="false"
-            class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+            class="e1s5n3hj4 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
             data-checked="true"
           >
             <input
@@ -1273,7 +1273,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
         class="cache-tib6m2-StyledBorderedBox e4ryteh1"
       >
         <div
-          class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj2"
+          class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj3"
           data-checked="false"
           data-disabled="false"
           data-has-label="true"
@@ -1284,7 +1284,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
           >
             <div
               aria-disabled="false"
-              class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+              class="e1s5n3hj4 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
               data-checked="false"
             >
               <input
@@ -1331,7 +1331,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
           </div>
         </div>
         <div
-          class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj2"
+          class="e4ryteh0 cache-fo7o17-Stack-Container-StyledSelectableCard e1s5n3hj3"
           data-checked="true"
           data-disabled="false"
           data-has-label="true"
@@ -1342,7 +1342,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
           >
             <div
               aria-disabled="false"
-              class="e1s5n3hj3 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
+              class="e1s5n3hj4 cache-14syb4e-RadioContainer-StyledRadio-StyledElement ehkrmld2"
               data-checked="true"
             >
               <input


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

#### What is expected?

Selectable card now include indentation on children and a spacing between label and children to give clarity. This is a common pattern we were already using but that wasn't implemented natively in the component.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="964" alt="Screenshot 2024-02-26 at 11 07 43" src="https://github.com/scaleway/ultraviolet/assets/15812968/b1d49874-2d92-4e74-82bd-04ae339be6df"> | <img width="962" alt="Screenshot 2024-02-26 at 11 07 49" src="https://github.com/scaleway/ultraviolet/assets/15812968/8eed56d4-076e-40e8-9dc7-6e9d53afec72"> |
