### PR TITLE
fix(TextInputV2): add auto complete and missing props

### DIFF
--- a/.changeset/seven-mangos-end.md
+++ b/.changeset/seven-mangos-end.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Add prop `autoComplete` on `<TextInputV2 />` component

--- a/.changeset/seven-mangos-end.md
+++ b/.changeset/seven-mangos-end.md
@@ -2,4 +2,5 @@
 "@ultraviolet/ui": patch
 ---
 
-Add prop `autoComplete` on `<TextInputV2 />` component
+- Add prop `autoComplete` on `<TextInputV2 />` component
+- Fix spread prop `required` on input in `<TextInputV2 />` component

--- a/.changeset/tiny-geckos-happen.md
+++ b/.changeset/tiny-geckos-happen.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Fix `<TextInputV2Field />` to add missing props : `prefix`, `suffix`, `size`, `onRandomize`, `aria-label`, `aria-labelledby`, `autoComplete`.

--- a/packages/form/src/components/TextInputFieldV2/index.tsx
+++ b/packages/form/src/components/TextInputFieldV2/index.tsx
@@ -23,30 +23,38 @@ export const TextInputField = <
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
-  autoFocus,
-  clearable,
+  validate,
+  regex: regexes,
+  id,
   className,
   tabIndex,
-  'data-testid': dataTestId,
-  disabled,
-  helper,
-  label,
-  labelDescription,
-  loading,
   onChange,
-  minLength,
-  maxLength,
+  placeholder,
+  disabled = false,
+  readOnly = false,
+  success,
+  helper,
+  tooltip,
+  label,
+  autoFocus,
+  required = false,
+  'data-testid': dataTestId,
   name,
   onFocus,
   onBlur,
-  placeholder,
-  readOnly,
-  required,
-  success,
-  tooltip,
-  type,
-  validate,
-  regex: regexes,
+  clearable = false,
+  labelDescription,
+  type = 'text',
+  prefix,
+  suffix,
+  size = 'large',
+  loading,
+  onRandomize,
+  minLength,
+  maxLength,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-label': ariaLabel,
+  autoComplete,
 }: TextInputFieldProps<TFieldValues, TName>) => {
   const { getError } = useErrors()
 
@@ -121,6 +129,14 @@ export const TextInputField = <
       tooltip={tooltip}
       type={type}
       value={field.value}
+      id={id}
+      prefix={prefix}
+      suffix={suffix}
+      size={size}
+      onRandomize={onRandomize}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      autoComplete={autoComplete}
     />
   )
 }

--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -2685,6 +2685,7 @@ exports[`DateInput renders correctly error disabled required 1`] = `
                 class="cache-137prd4-StyledInput e7tir8v1"
                 disabled=""
                 id=":rn:"
+                required=""
                 type="text"
                 value=""
               />
@@ -3559,6 +3560,7 @@ exports[`DateInput renders correctly required 1`] = `
                 aria-invalid="false"
                 class="cache-137prd4-StyledInput e7tir8v1"
                 id=":r9:"
+                required=""
                 type="text"
                 value=""
               />

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -151,6 +151,7 @@ type TextInputProps = {
   | 'required'
   | 'autoFocus'
   | 'tabIndex'
+  | 'autoComplete'
 >
 
 /**
@@ -190,6 +191,7 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
       maxLength,
       'aria-labelledby': ariaLabelledBy,
       'aria-label': ariaLabel,
+      autoComplete,
     },
     ref,
   ) => {
@@ -293,6 +295,7 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
                 maxLength={maxLength}
                 aria-labelledby={ariaLabelledBy}
                 aria-label={ariaLabel}
+                autoComplete={autoComplete}
               />
               {success || error || loading || computedClearable ? (
                 <StateStack direction="row" gap={1} alignItems="center">

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -296,6 +296,7 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
                 aria-labelledby={ariaLabelledBy}
                 aria-label={ariaLabel}
                 autoComplete={autoComplete}
+                required={required}
               />
               {success || error || loading || computedClearable ? (
                 <StateStack direction="row" gap={1} alignItems="center">


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

- Add prop `autoComplete` on `<TextInputV2 />` component
- Fix `<TextInputV2Field />` to add missing props : `prefix`, `suffix`, `size`, `onRandomize`, `aria-label`, `aria-labelledby`, `autoComplete`.