### PR TITLE
fix(MenuV2.Item): item full width

### DIFF
--- a/.changeset/olive-readers-chew.md
+++ b/.changeset/olive-readers-chew.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `MenuV2.Item` border to be fullwidth

--- a/packages/ui/src/components/MenuV2/Item.tsx
+++ b/packages/ui/src/components/MenuV2/Item.tsx
@@ -28,6 +28,7 @@ const itemCoreStyle = ({
   }
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
 
   color: ${theme.colors[sentiment][disabled ? 'textDisabled' : 'text']};
   svg {

--- a/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Menu Menu.Item render with borderless props 1`] = `
 <DocumentFragment>
-  .css-1dn316x-StyledItem {
+  .css-wjkgdk-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -11,27 +11,28 @@ exports[`Menu Menu.Item render with borderless props 1`] = `
   border: none;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1dn316x-StyledItem svg {
+.css-wjkgdk-StyledItem svg {
   fill: #3f4250;
 }
 
-.css-1dn316x-StyledItem:hover,
-.css-1dn316x-StyledItem:focus {
+.css-wjkgdk-StyledItem:hover,
+.css-wjkgdk-StyledItem:focus {
   color: #222638;
 }
 
-.css-1dn316x-StyledItem:hover svg,
-.css-1dn316x-StyledItem:focus svg {
+.css-wjkgdk-StyledItem:hover svg,
+.css-wjkgdk-StyledItem:focus svg {
   fill: #222638;
 }
 
 <div>
     <button
-      class="css-1dn316x-StyledItem ei26g5y1"
+      class="css-wjkgdk-StyledItem ei26g5y1"
       role="menuitem"
       type="button"
     >
@@ -43,7 +44,7 @@ exports[`Menu Menu.Item render with borderless props 1`] = `
 
 exports[`Menu Menu.Item render with default props 1`] = `
 <DocumentFragment>
-  .css-1g2q9ft-StyledItem {
+  .css-1rj7mbu-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -53,27 +54,28 @@ exports[`Menu Menu.Item render with default props 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1g2q9ft-StyledItem svg {
+.css-1rj7mbu-StyledItem svg {
   fill: #3f4250;
 }
 
-.css-1g2q9ft-StyledItem:hover,
-.css-1g2q9ft-StyledItem:focus {
+.css-1rj7mbu-StyledItem:hover,
+.css-1rj7mbu-StyledItem:focus {
   color: #222638;
 }
 
-.css-1g2q9ft-StyledItem:hover svg,
-.css-1g2q9ft-StyledItem:focus svg {
+.css-1rj7mbu-StyledItem:hover svg,
+.css-1rj7mbu-StyledItem:focus svg {
   fill: #222638;
 }
 
 <div>
     <button
-      class="css-1g2q9ft-StyledItem ei26g5y1"
+      class="css-1rj7mbu-StyledItem ei26g5y1"
       role="menuitem"
       type="button"
     >
@@ -85,7 +87,7 @@ exports[`Menu Menu.Item render with default props 1`] = `
 
 exports[`Menu Menu.Item render with disabled props 1`] = `
 <DocumentFragment>
-  .css-mgnrz8-StyledItem {
+  .css-vzca0s-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -95,18 +97,19 @@ exports[`Menu Menu.Item render with disabled props 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #b5b7bd;
   cursor: not-allowed;
   background: none;
 }
 
-.css-mgnrz8-StyledItem svg {
+.css-vzca0s-StyledItem svg {
   fill: #b5b7bd;
 }
 
 <div>
     <button
-      class="css-mgnrz8-StyledItem ei26g5y1"
+      class="css-vzca0s-StyledItem ei26g5y1"
       disabled=""
       role="menuitem"
       type="button"
@@ -119,7 +122,7 @@ exports[`Menu Menu.Item render with disabled props 1`] = `
 
 exports[`Menu Menu.Item render with sentiment danger 1`] = `
 <DocumentFragment>
-  .css-1goa4p3-StyledItem {
+  .css-l87rea-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -129,27 +132,28 @@ exports[`Menu Menu.Item render with sentiment danger 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #b3144d;
   background: none;
 }
 
-.css-1goa4p3-StyledItem svg {
+.css-l87rea-StyledItem svg {
   fill: #b3144d;
 }
 
-.css-1goa4p3-StyledItem:hover,
-.css-1goa4p3-StyledItem:focus {
+.css-l87rea-StyledItem:hover,
+.css-l87rea-StyledItem:focus {
   color: #92103f;
 }
 
-.css-1goa4p3-StyledItem:hover svg,
-.css-1goa4p3-StyledItem:focus svg {
+.css-l87rea-StyledItem:hover svg,
+.css-l87rea-StyledItem:focus svg {
   fill: #92103f;
 }
 
 <div>
     <button
-      class="css-1goa4p3-StyledItem ei26g5y1"
+      class="css-l87rea-StyledItem ei26g5y1"
       role="menuitem"
       type="button"
     >
@@ -278,7 +282,7 @@ exports[`Menu placement renders bottom 1`] = `
   border-color: transparent;
 }
 
-.css-1g2q9ft-StyledItem {
+.css-1rj7mbu-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -288,21 +292,22 @@ exports[`Menu placement renders bottom 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1g2q9ft-StyledItem svg {
+.css-1rj7mbu-StyledItem svg {
   fill: #3f4250;
 }
 
-.css-1g2q9ft-StyledItem:hover,
-.css-1g2q9ft-StyledItem:focus {
+.css-1rj7mbu-StyledItem:hover,
+.css-1rj7mbu-StyledItem:focus {
   color: #222638;
 }
 
-.css-1g2q9ft-StyledItem:hover svg,
-.css-1g2q9ft-StyledItem:focus svg {
+.css-1rj7mbu-StyledItem:hover svg,
+.css-1rj7mbu-StyledItem:focus svg {
   fill: #222638;
 }
 
@@ -331,7 +336,7 @@ exports[`Menu placement renders bottom 1`] = `
       >
         <div>
           <button
-            class="css-1g2q9ft-StyledItem ei26g5y1"
+            class="css-1rj7mbu-StyledItem ei26g5y1"
             role="menuitem"
             type="button"
           >
@@ -463,7 +468,7 @@ exports[`Menu placement renders left 1`] = `
   border-color: transparent;
 }
 
-.css-1g2q9ft-StyledItem {
+.css-1rj7mbu-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -473,21 +478,22 @@ exports[`Menu placement renders left 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1g2q9ft-StyledItem svg {
+.css-1rj7mbu-StyledItem svg {
   fill: #3f4250;
 }
 
-.css-1g2q9ft-StyledItem:hover,
-.css-1g2q9ft-StyledItem:focus {
+.css-1rj7mbu-StyledItem:hover,
+.css-1rj7mbu-StyledItem:focus {
   color: #222638;
 }
 
-.css-1g2q9ft-StyledItem:hover svg,
-.css-1g2q9ft-StyledItem:focus svg {
+.css-1rj7mbu-StyledItem:hover svg,
+.css-1rj7mbu-StyledItem:focus svg {
   fill: #222638;
 }
 
@@ -516,7 +522,7 @@ exports[`Menu placement renders left 1`] = `
       >
         <div>
           <button
-            class="css-1g2q9ft-StyledItem ei26g5y1"
+            class="css-1rj7mbu-StyledItem ei26g5y1"
             role="menuitem"
             type="button"
           >
@@ -648,7 +654,7 @@ exports[`Menu placement renders right 1`] = `
   border-color: transparent;
 }
 
-.css-1g2q9ft-StyledItem {
+.css-1rj7mbu-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -658,21 +664,22 @@ exports[`Menu placement renders right 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1g2q9ft-StyledItem svg {
+.css-1rj7mbu-StyledItem svg {
   fill: #3f4250;
 }
 
-.css-1g2q9ft-StyledItem:hover,
-.css-1g2q9ft-StyledItem:focus {
+.css-1rj7mbu-StyledItem:hover,
+.css-1rj7mbu-StyledItem:focus {
   color: #222638;
 }
 
-.css-1g2q9ft-StyledItem:hover svg,
-.css-1g2q9ft-StyledItem:focus svg {
+.css-1rj7mbu-StyledItem:hover svg,
+.css-1rj7mbu-StyledItem:focus svg {
   fill: #222638;
 }
 
@@ -701,7 +708,7 @@ exports[`Menu placement renders right 1`] = `
       >
         <div>
           <button
-            class="css-1g2q9ft-StyledItem ei26g5y1"
+            class="css-1rj7mbu-StyledItem ei26g5y1"
             role="menuitem"
             type="button"
           >
@@ -833,7 +840,7 @@ exports[`Menu placement renders top 1`] = `
   border-color: transparent;
 }
 
-.css-1g2q9ft-StyledItem {
+.css-1rj7mbu-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -843,21 +850,22 @@ exports[`Menu placement renders top 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1g2q9ft-StyledItem svg {
+.css-1rj7mbu-StyledItem svg {
   fill: #3f4250;
 }
 
-.css-1g2q9ft-StyledItem:hover,
-.css-1g2q9ft-StyledItem:focus {
+.css-1rj7mbu-StyledItem:hover,
+.css-1rj7mbu-StyledItem:focus {
   color: #222638;
 }
 
-.css-1g2q9ft-StyledItem:hover svg,
-.css-1g2q9ft-StyledItem:focus svg {
+.css-1rj7mbu-StyledItem:hover svg,
+.css-1rj7mbu-StyledItem:focus svg {
   fill: #222638;
 }
 
@@ -886,7 +894,7 @@ exports[`Menu placement renders top 1`] = `
       >
         <div>
           <button
-            class="css-1g2q9ft-StyledItem ei26g5y1"
+            class="css-1rj7mbu-StyledItem ei26g5y1"
             role="menuitem"
             type="button"
           >
@@ -1018,7 +1026,7 @@ exports[`Menu renders with Menu.Item 1`] = `
   border-color: transparent;
 }
 
-.css-1g2q9ft-StyledItem {
+.css-1rj7mbu-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -1028,21 +1036,22 @@ exports[`Menu renders with Menu.Item 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1g2q9ft-StyledItem svg {
+.css-1rj7mbu-StyledItem svg {
   fill: #3f4250;
 }
 
-.css-1g2q9ft-StyledItem:hover,
-.css-1g2q9ft-StyledItem:focus {
+.css-1rj7mbu-StyledItem:hover,
+.css-1rj7mbu-StyledItem:focus {
   color: #222638;
 }
 
-.css-1g2q9ft-StyledItem:hover svg,
-.css-1g2q9ft-StyledItem:focus svg {
+.css-1rj7mbu-StyledItem:hover svg,
+.css-1rj7mbu-StyledItem:focus svg {
   fill: #222638;
 }
 
@@ -1071,7 +1080,7 @@ exports[`Menu renders with Menu.Item 1`] = `
       >
         <div>
           <button
-            class="css-1g2q9ft-StyledItem ei26g5y1"
+            class="css-1rj7mbu-StyledItem ei26g5y1"
             role="menuitem"
             type="button"
           >
@@ -1203,7 +1212,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   border-color: transparent;
 }
 
-.css-mgnrz8-StyledItem {
+.css-vzca0s-StyledItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -1213,12 +1222,13 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #b5b7bd;
   cursor: not-allowed;
   background: none;
 }
 
-.css-mgnrz8-StyledItem svg {
+.css-vzca0s-StyledItem svg {
   fill: #b5b7bd;
 }
 
@@ -1247,7 +1257,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
       >
         <div>
           <button
-            class="css-mgnrz8-StyledItem ei26g5y1"
+            class="css-vzca0s-StyledItem ei26g5y1"
             disabled=""
             role="menuitem"
             type="button"
@@ -1257,7 +1267,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         </div>
         <div>
           <button
-            class="css-mgnrz8-StyledItem ei26g5y1"
+            class="css-vzca0s-StyledItem ei26g5y1"
             disabled=""
             role="menuitem"
             type="button"
@@ -1390,7 +1400,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   border-color: transparent;
 }
 
-.css-s7n5ht-StyledLinkItem {
+.css-h77bml-StyledLinkItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -1399,26 +1409,27 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   border: none;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.css-s7n5ht-StyledLinkItem svg {
+.css-h77bml-StyledLinkItem svg {
   fill: #3f4250;
 }
 
-.css-s7n5ht-StyledLinkItem:hover,
-.css-s7n5ht-StyledLinkItem:focus {
+.css-h77bml-StyledLinkItem:hover,
+.css-h77bml-StyledLinkItem:focus {
   color: #222638;
 }
 
-.css-s7n5ht-StyledLinkItem:hover svg,
-.css-s7n5ht-StyledLinkItem:focus svg {
+.css-h77bml-StyledLinkItem:hover svg,
+.css-h77bml-StyledLinkItem:focus svg {
   fill: #222638;
 }
 
-.css-s7n5ht-StyledLinkItem:focus {
+.css-h77bml-StyledLinkItem:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -1448,7 +1459,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
       >
         <div>
           <a
-            class="css-s7n5ht-StyledLinkItem ei26g5y0"
+            class="css-h77bml-StyledLinkItem ei26g5y0"
             href="/link"
             role="menuitem"
           >

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -809,7 +809,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
   border-color: transparent;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem {
+.css-1tgj35f-StyledItem-StyledMenuItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -819,29 +819,30 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem svg {
+.css-1tgj35f-StyledItem-StyledMenuItem svg {
   fill: #3f4250;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem:hover,
-.css-1xezjbx-StyledItem-StyledMenuItem:focus {
+.css-1tgj35f-StyledItem-StyledMenuItem:hover,
+.css-1tgj35f-StyledItem-StyledMenuItem:focus {
   color: #222638;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem:hover svg,
-.css-1xezjbx-StyledItem-StyledMenuItem:focus svg {
+.css-1tgj35f-StyledItem-StyledMenuItem:hover svg,
+.css-1tgj35f-StyledItem-StyledMenuItem:focus svg {
   fill: #222638;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem[aria-selected='true'] {
+.css-1tgj35f-StyledItem-StyledMenuItem[aria-selected='true'] {
   color: #641cb3;
 }
 
-.css-1m6x1vf-StyledItem-StyledMenuItem {
+.css-1n17sfh-StyledItem-StyledMenuItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -851,16 +852,17 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #b5b7bd;
   cursor: not-allowed;
   background: none;
 }
 
-.css-1m6x1vf-StyledItem-StyledMenuItem svg {
+.css-1n17sfh-StyledItem-StyledMenuItem svg {
   fill: #b5b7bd;
 }
 
-.css-1m6x1vf-StyledItem-StyledMenuItem[aria-selected='true'] {
+.css-1n17sfh-StyledItem-StyledMenuItem[aria-selected='true'] {
   color: #641cb3;
 }
 
@@ -876,7 +878,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
     >
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >
@@ -885,7 +887,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       </div>
       <div>
         <button
-          class="eeet93f0 css-1m6x1vf-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1n17sfh-StyledItem-StyledMenuItem ei26g5y1"
           disabled=""
           role="menuitem"
           type="button"
@@ -895,7 +897,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       </div>
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >
@@ -904,7 +906,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       </div>
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >
@@ -913,7 +915,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       </div>
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >
@@ -2193,7 +2195,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   border-color: transparent;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem {
+.css-1tgj35f-StyledItem-StyledMenuItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -2203,25 +2205,26 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem svg {
+.css-1tgj35f-StyledItem-StyledMenuItem svg {
   fill: #3f4250;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem:hover,
-.css-1xezjbx-StyledItem-StyledMenuItem:focus {
+.css-1tgj35f-StyledItem-StyledMenuItem:hover,
+.css-1tgj35f-StyledItem-StyledMenuItem:focus {
   color: #222638;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem:hover svg,
-.css-1xezjbx-StyledItem-StyledMenuItem:focus svg {
+.css-1tgj35f-StyledItem-StyledMenuItem:hover svg,
+.css-1tgj35f-StyledItem-StyledMenuItem:focus svg {
   fill: #222638;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem[aria-selected='true'] {
+.css-1tgj35f-StyledItem-StyledMenuItem[aria-selected='true'] {
   color: #641cb3;
 }
 
@@ -2238,7 +2241,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >
@@ -2247,7 +2250,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       </div>
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >
@@ -3263,7 +3266,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   border-color: transparent;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem {
+.css-1tgj35f-StyledItem-StyledMenuItem {
   display: inline-block;
   font-size: 14px;
   line-height: 20px;
@@ -3273,25 +3276,26 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   border-bottom: 1px solid #d9dadd;
   cursor: pointer;
   min-width: 110px;
+  width: 100%;
   color: #3f4250;
   background: none;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem svg {
+.css-1tgj35f-StyledItem-StyledMenuItem svg {
   fill: #3f4250;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem:hover,
-.css-1xezjbx-StyledItem-StyledMenuItem:focus {
+.css-1tgj35f-StyledItem-StyledMenuItem:hover,
+.css-1tgj35f-StyledItem-StyledMenuItem:focus {
   color: #222638;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem:hover svg,
-.css-1xezjbx-StyledItem-StyledMenuItem:focus svg {
+.css-1tgj35f-StyledItem-StyledMenuItem:hover svg,
+.css-1tgj35f-StyledItem-StyledMenuItem:focus svg {
   fill: #222638;
 }
 
-.css-1xezjbx-StyledItem-StyledMenuItem[aria-selected='true'] {
+.css-1tgj35f-StyledItem-StyledMenuItem[aria-selected='true'] {
   color: #641cb3;
 }
 
@@ -3308,7 +3312,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >
@@ -3317,7 +3321,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       </div>
       <div>
         <button
-          class="eeet93f0 css-1xezjbx-StyledItem-StyledMenuItem ei26g5y1"
+          class="eeet93f0 css-1tgj35f-StyledItem-StyledMenuItem ei26g5y1"
           role="menuitem"
           type="button"
         >


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarise concisely:

#### What is expected?

Now the border of elements in MenuV2 will always be full width.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--: | :--------: | :--------: |
| example  | <img width="257" alt="Capture d’écran 2024-03-07 à 15 15 29" src="https://github.com/scaleway/ultraviolet/assets/106706307/b1eed8db-3de6-4a6e-97bb-668251c6d19c"> | <img width="243" alt="Capture d’écran 2024-03-07 à 15 15 15" src="https://github.com/scaleway/ultraviolet/assets/106706307/7efce094-589d-42e7-a46e-ffa17e626850">|
