### PR TITLE
fix: add container id to toaster and notification

### DIFF
--- a/.changeset/tender-cats-mix.md
+++ b/.changeset/tender-cats-mix.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Toaster` and `Notification` : new prop `containerId`

--- a/packages/ui/src/components/Notification/__stories__/ContainerId.tsx
+++ b/packages/ui/src/components/Notification/__stories__/ContainerId.tsx
@@ -1,0 +1,54 @@
+import type { StoryFn } from '@storybook/react'
+import { ProductIcon } from '@ultraviolet/icons'
+import { NotificationContainer, notification } from '..'
+import { Button, Stack, Text } from '../../index'
+
+export const ContainerId: StoryFn<typeof NotificationContainer> = args => (
+  <Stack gap={2}>
+    <NotificationContainer {...args} containerId="notification1" />
+    <Button
+      onClick={() =>
+        notification(
+          <Text as="span" variant="bodySmall">
+            Default position (top-right)
+          </Text>,
+          'Notification 1',
+          <ProductIcon name="verifyCard" size="medium" variant="primary" />,
+          true,
+          'notification1',
+        )
+      }
+    >
+      ContainerId: &quot; notification1 &quot;
+    </Button>
+    <NotificationContainer
+      {...args}
+      containerId="notification2"
+      position="bottom-left"
+    />
+    <Button
+      onClick={() =>
+        notification(
+          <Text as="span" variant="bodySmall">
+            Notification at the bottom-left
+          </Text>,
+          'Notification 2',
+          <ProductIcon name="verifyCard" size="medium" variant="primary" />,
+          true,
+          'notification2',
+        )
+      }
+    >
+      ContainerId: &quot; notification2 &quot;
+    </Button>
+  </Stack>
+)
+
+ContainerId.parameters = {
+  docs: {
+    description: {
+      story:
+        'It is possible to use multiple containers and assign each notification to a specific container using prop `containerId`',
+    },
+  },
+}

--- a/packages/ui/src/components/Notification/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Notification/__stories__/index.stories.tsx
@@ -8,3 +8,4 @@ export default {
 
 export { Playground } from './Playground.stories'
 export { Children } from './Children'
+export { ContainerId } from './ContainerId'

--- a/packages/ui/src/components/Notification/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Notification/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,35 +2,46 @@
 
 exports[`Toaster renders correctly with close button 1`] = `
 [
-  <div
-    class="Toastify__toast-body"
-    role="alert"
+  .css-1oov0zf-StyledText {
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<h3
+    class="css-1oov0zf-StyledText e13y3mga0"
   >
-    <div />
-  </div>,
+    Title
+  </h3>,
 ]
 `;
 
 exports[`Toaster renders correctly with close button 2`] = `
 <DocumentFragment>
-  .css-ivzpm-toast {
+  .css-lkoz5w-toast {
   border-radius: 4px;
 }
 
-.css-ivzpm-toast.Toastify__toast {
+.css-lkoz5w-toast.Toastify__toast {
   background-color: #ffffff;
   color: #3f4250;
   padding: 16px;
   box-shadow: 0px 0px 8px 2px #d9dadd66;
 }
 
-.css-ivzpm-toast.Toastify__toast-container {
+.css-lkoz5w-toast.Toastify__toast-container {
   width: 312px;
 }
 
-.css-ivzpm-toast .Toastify__toast-body {
+.css-lkoz5w-toast .Toastify__toast-body {
   margin: 0;
   padding: 0;
+  display: none;
 }
 
 .css-4lkpn5-Stack {
@@ -155,12 +166,13 @@ exports[`Toaster renders correctly with close button 2`] = `
 
 <div
     class="Toastify"
+    id="notification"
   >
     <div
       class="Toastify__toast-container Toastify__toast-container--top-right"
     >
       <div
-        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--default css-ivzpm-toast Toastify--animate Toastify__slide-enter--top-right"
+        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--default css-lkoz5w-toast Toastify--animate Toastify__slide-enter--top-right"
         data-in="true"
         id="1"
       >
@@ -224,35 +236,35 @@ exports[`Toaster renders correctly with close button 2`] = `
 
 exports[`Toaster renders correctly with custom close button 1`] = `
 [
-  <div
-    class="Toastify__toast-body"
-    role="alert"
+  <button
+    type="button"
   >
-    <div />
-  </div>,
+    Decline
+  </button>,
 ]
 `;
 
 exports[`Toaster renders correctly with custom close button 2`] = `
 <DocumentFragment>
-  .css-ivzpm-toast {
+  .css-lkoz5w-toast {
   border-radius: 4px;
 }
 
-.css-ivzpm-toast.Toastify__toast {
+.css-lkoz5w-toast.Toastify__toast {
   background-color: #ffffff;
   color: #3f4250;
   padding: 16px;
   box-shadow: 0px 0px 8px 2px #d9dadd66;
 }
 
-.css-ivzpm-toast.Toastify__toast-container {
+.css-lkoz5w-toast.Toastify__toast-container {
   width: 312px;
 }
 
-.css-ivzpm-toast .Toastify__toast-body {
+.css-lkoz5w-toast .Toastify__toast-body {
   margin: 0;
   padding: 0;
+  display: none;
 }
 
 .css-4lkpn5-Stack {
@@ -314,12 +326,13 @@ exports[`Toaster renders correctly with custom close button 2`] = `
 
 <div
     class="Toastify"
+    id="notification"
   >
     <div
       class="Toastify__toast-container Toastify__toast-container--top-right"
     >
       <div
-        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--default css-ivzpm-toast Toastify--animate Toastify__slide-enter--top-right"
+        class="Toastify__toast Toastify__toast-theme--light Toastify__toast--default css-lkoz5w-toast Toastify--animate Toastify__slide-enter--top-right"
         data-in="true"
         id="2"
       >

--- a/packages/ui/src/components/Notification/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Notification/__tests__/index.test.tsx
@@ -26,7 +26,7 @@ describe('Toaster', () => {
 
         act(() => jest.runAllTimers())
 
-        expect(await screen.findAllByRole('alert')).toMatchSnapshot()
+        expect(await screen.findAllByText('Title')).toMatchSnapshot()
       },
     })
   })
@@ -47,7 +47,7 @@ describe('Toaster', () => {
 
         act(() => jest.runAllTimers())
 
-        expect(await screen.findAllByRole('alert')).toMatchSnapshot()
+        expect(await screen.findAllByText('Decline')).toMatchSnapshot()
       },
     })
   })

--- a/packages/ui/src/components/Notification/index.tsx
+++ b/packages/ui/src/components/Notification/index.tsx
@@ -47,6 +47,7 @@ const styles = {
     ${PREFIX}__toast-body {
       margin: 0;
       padding: 0;
+      display: none;
     }
   `,
 }
@@ -67,6 +68,7 @@ export const notification = (
   title: string,
   icon?: ReactNode,
   isClosable?: boolean,
+  containerId?: string,
   options?: ToastOptions,
 ) =>
   baseToast('', {
@@ -83,6 +85,7 @@ export const notification = (
         {isClosable ? closeButton(props) : null}
       </Stack>
     ),
+    containerId: containerId ?? 'notification',
   })
 
 type NotificationContainerProps = {
@@ -105,6 +108,10 @@ type NotificationContainerProps = {
   position?: ToastOptions['position']
   'data-testid'?: string
   className?: string
+  /**
+   * Give a personalized containerId in case there are multiple notifications with different styled to display
+   */
+  containerId?: string
 }
 
 export const NotificationContainer = ({
@@ -114,6 +121,7 @@ export const NotificationContainer = ({
   position = 'top-right',
   'data-testid': dataTestId,
   className,
+  containerId = 'notification',
 }: NotificationContainerProps) => {
   const theme = useTheme()
 
@@ -134,6 +142,7 @@ export const NotificationContainer = ({
             draggable={false}
             transition={Slide}
             className={className}
+            containerId={containerId}
           />
         )}
       </ClassNames>

--- a/packages/ui/src/components/Toaster/__stories__/ContainerId.tsx
+++ b/packages/ui/src/components/Toaster/__stories__/ContainerId.tsx
@@ -1,0 +1,35 @@
+import type { StoryFn } from '@storybook/react'
+import { ToastContainer, toast } from '..'
+import { Button, Stack } from '../../index'
+
+export const ContainerId: StoryFn<typeof ToastContainer> = args => (
+  <Stack direction="row" gap={2}>
+    <ToastContainer {...args} containerId="toaster1" position="bottom-left" />
+    <Button
+      sentiment="neutral"
+      onClick={() =>
+        toast.success('Toaster from container 1', undefined, 'toaster1')
+      }
+    >
+      Container 1
+    </Button>
+    <ToastContainer {...args} containerId="toaster2" position="top-right" />
+    <Button
+      sentiment="neutral"
+      onClick={() =>
+        toast.success('Toaster from container 2', undefined, 'toaster2')
+      }
+    >
+      Container 2
+    </Button>
+  </Stack>
+)
+
+ContainerId.parameters = {
+  docs: {
+    description: {
+      story:
+        'It is possible to use multiple containers and assign each toaster to a specific container using prop `containerId`',
+    },
+  },
+}

--- a/packages/ui/src/components/Toaster/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Toaster/__stories__/index.stories.tsx
@@ -8,3 +8,4 @@ export default {
 
 export { Playground } from './Playground.stories'
 export { Sentiments } from './Sentiments.stories'
+export { ContainerId } from './ContainerId'

--- a/packages/ui/src/components/Toaster/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Toaster/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,30 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toaster renders correctly with all kind of toast 1`] = `
-[
-  .css-4lkpn5-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 16px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
 .css-10an7cj-StyledText {
   font-size: 14px;
   font-family: Inter,Asap;
@@ -36,176 +12,71 @@ exports[`Toaster renders correctly with all kind of toast 1`] = `
   text-decoration: none;
 }
 
-<div
-    class="Toastify__toast-body"
-    role="alert"
-  >
-    <div>
-      <div
-        class="css-4lkpn5-Stack ehpbis70"
-      >
-        <span
-          class="css-10an7cj-StyledText e13y3mga0"
-        >
-          This is an info
-        </span>
-      </div>
-    </div>
-  </div>,
-  .css-4lkpn5-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 16px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.css-10an7cj-StyledText {
-  font-size: 14px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 20px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-<div
-    class="Toastify__toast-body"
-    role="alert"
-  >
-    <div>
-      <div
-        class="css-4lkpn5-Stack ehpbis70"
-      >
-        <span
-          class="css-10an7cj-StyledText e13y3mga0"
-        >
-          This is a success
-        </span>
-      </div>
-    </div>
-  </div>,
-  .css-4lkpn5-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 16px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.css-10an7cj-StyledText {
-  font-size: 14px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 20px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-<div
-    class="Toastify__toast-body"
-    role="alert"
-  >
-    <div>
-      <div
-        class="css-4lkpn5-Stack ehpbis70"
-      >
-        <span
-          class="css-10an7cj-StyledText e13y3mga0"
-        >
-          This is an error
-        </span>
-      </div>
-    </div>
-  </div>,
-  .css-4lkpn5-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 16px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.css-10an7cj-StyledText {
-  font-size: 14px;
-  font-family: Inter,Asap;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 20px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-<div
-    class="Toastify__toast-body"
-    role="alert"
-  >
-    <div>
-      <div
-        class="css-4lkpn5-Stack ehpbis70"
-      >
-        <span
-          class="css-10an7cj-StyledText e13y3mga0"
-        >
-          This is a warning
-        </span>
-      </div>
-    </div>
-  </div>,
-]
+<span
+  class="css-10an7cj-StyledText e13y3mga0"
+>
+  This is an info
+</span>
 `;
 
 exports[`Toaster renders correctly with all kind of toast 2`] = `
+.css-10an7cj-StyledText {
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<span
+  class="css-10an7cj-StyledText e13y3mga0"
+>
+  This is a success
+</span>
+`;
+
+exports[`Toaster renders correctly with all kind of toast 3`] = `
+.css-10an7cj-StyledText {
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<span
+  class="css-10an7cj-StyledText e13y3mga0"
+>
+  This is an error
+</span>
+`;
+
+exports[`Toaster renders correctly with all kind of toast 4`] = `
+.css-10an7cj-StyledText {
+  font-size: 14px;
+  font-family: Inter,Asap;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<span
+  class="css-10an7cj-StyledText e13y3mga0"
+>
+  This is a warning
+</span>
+`;
+
+exports[`Toaster renders correctly with all kind of toast 5`] = `
 <DocumentFragment>
   .css-tb58o0-toast {
   border-radius: 4px;
@@ -534,6 +405,7 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
 
 <div
     class="Toastify"
+    id="toaster"
   >
     <div
       class="Toastify__toast-container Toastify__toast-container--top-right"

--- a/packages/ui/src/components/Toaster/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Toaster/__tests__/index.test.tsx
@@ -37,7 +37,10 @@ describe('Toaster', () => {
 
         act(() => jest.runAllTimers())
 
-        expect(await screen.findAllByRole('alert')).toMatchSnapshot()
+        expect(await screen.findByText('This is an info')).toMatchSnapshot()
+        expect(await screen.findByText('This is a success')).toMatchSnapshot()
+        expect(await screen.findByText('This is an error')).toMatchSnapshot()
+        expect(await screen.findByText('This is a warning')).toMatchSnapshot()
       },
     })
   })

--- a/packages/ui/src/components/Toaster/index.tsx
+++ b/packages/ui/src/components/Toaster/index.tsx
@@ -98,31 +98,51 @@ const Content = ({ children }: ContentProps) => (
 )
 
 export const toast = {
-  error: (children: ReactNode, options?: ToastOptions): number | string =>
+  error: (
+    children: ReactNode,
+    options?: ToastOptions,
+    containerId?: string,
+  ): number | string =>
     baseToast.error(<Content>{children}</Content>, {
       ...options,
       closeButton: <CloseButton sentiment="danger" />,
+      containerId: containerId ?? 'toaster',
     }),
   /**
    * @deprecated "Deprecated, please use another variant instead"
    */
   // eslint-disable-next-line deprecation/deprecation
-  info: (children: ReactNode, options?: ToastOptions): number | string =>
+  info: (
+    children: ReactNode,
+    options?: ToastOptions,
+    containerId?: string,
+  ): number | string =>
     baseToast.info(<Content>{children}</Content>, {
       ...options,
       closeButton: <CloseButton sentiment="info" />,
+      containerId: containerId ?? 'toaster',
     }),
 
-  success: (children: ReactNode, options?: ToastOptions): number | string =>
+  success: (
+    children: ReactNode,
+    options?: ToastOptions,
+    containerId?: string,
+  ): number | string =>
     baseToast.success(<Content>{children}</Content>, {
       ...options,
       closeButton: <CloseButton sentiment="success" />,
+      containerId: containerId ?? 'toaster',
     }),
 
-  warning: (children: ReactNode, options?: ToastOptions): number | string =>
+  warning: (
+    children: ReactNode,
+    options?: ToastOptions,
+    containerId?: string,
+  ): number | string =>
     baseToast.warn(<Content>{children}</Content>, {
       ...options,
       closeButton: <CloseButton sentiment="warning" />,
+      containerId: containerId ?? 'toaster',
     }),
 }
 
@@ -146,6 +166,11 @@ type ToastContainerProps = {
    * Delay before the toast is automatically closed, if not set the default value is 6000ms
    */
   autoClose?: number
+
+  /**
+   * Set a custom containerId to be able to define multiple ToastContainers
+   */
+  containerId?: string
 }
 
 /**
@@ -163,6 +188,7 @@ export const ToastContainer = ({
   'data-testid': dataTestId,
   className,
   autoClose,
+  containerId = 'toaster',
 }: ToastContainerProps) => {
   const theme = useTheme()
 
@@ -183,6 +209,7 @@ export const ToastContainer = ({
             hideProgressBar
             className={className}
             transition={Slide}
+            containerId={containerId}
           />
         )}
       </ClassNames>


### PR DESCRIPTION
## Summary

## Type


- Enhancement

### Summarise concisely:

#### What is expected?

Added a prop `containerId` to toaster and notification components to be able to use multiple Containers simultaneously. 
#### The following changes were made:


1. new prop to `NotificationContainer`, `notification`, `ToastContainer`and `toast` 

2. Stories to showcase the prop
