### PR TITLE
fix(EstimateCost): forward hideFromOverlay in Region

### DIFF
--- a/.changeset/clean-guests-stare.md
+++ b/.changeset/clean-guests-stare.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": minor
+---
+
+`EstimateCost.Region`: forward `hideFromOverlay` prop

--- a/packages/plus/src/components/EstimateCost/Components/Region.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/Region.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import type { ReactNode } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import { useEstimateCost } from '../EstimateCostProvider'
 import type { BareEstimateProduct, EstimateProduct, Iteration } from '../types'
 import { Item } from './Item'
@@ -26,7 +26,7 @@ type RegionProps = {
   image: string
   noBorder?: boolean
   noPrice?: boolean
-}
+} & Pick<ComponentProps<typeof Item>, 'hideFromOverlay'>
 
 export const Region = ({
   label,
@@ -41,6 +41,7 @@ export const Region = ({
   discount,
   noBorder,
   noPrice,
+  hideFromOverlay,
 }: RegionProps) => {
   const { locales } = useEstimateCost()
 
@@ -57,6 +58,7 @@ export const Region = ({
       discount={discount}
       noBorder={noBorder}
       noPrice={noPrice}
+      hideFromOverlay={hideFromOverlay}
     >
       <Strong>
         <StyledImage alt={label} src={image} />


### PR DESCRIPTION
## Summary

`hideFromOverlay` is not forward from `EstimateCost.Region` to the `EstimateCost.Item` base component

## Type

- Enhancement