### PR TITLE
fix(List): update expandable behavior

### DIFF
--- a/.changeset/old-kangaroos-shake.md
+++ b/.changeset/old-kangaroos-shake.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+List: update expandable behavior

--- a/packages/ui/src/components/List/Row.tsx
+++ b/packages/ui/src/components/List/Row.tsx
@@ -15,6 +15,9 @@ const ExpandableWrapper = styled.div`
   margin: 0 -${({ theme }) => theme.space['2']};
   padding: ${({ theme }) => theme.space['2']};
   cursor: auto;
+  background: ${({ theme }) => theme.colors.neutral.backgroundWeak};
+  border-radius: 0 0 ${({ theme }) => theme.radii.default}
+    ${({ theme }) => theme.radii.default};
 `
 
 export const StyledRow = styled('div', {
@@ -71,13 +74,6 @@ export const StyledRow = styled('div', {
     color: ${({ theme }) => theme.colors.neutral.textDisabled};
     cursor: not-allowed;
   }
-
-  & [data-visibility='hover'] {
-    opacity: 0;
-  }
-  &:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-    opacity: 1;
-  }
 `
 
 const StyledCheckboxContainer = styled.div`
@@ -113,7 +109,6 @@ export const Row = forwardRef(
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     const {
-      allRowSelectValue,
       selectable,
       registerExpandableRow,
       expandedRowIds,
@@ -158,14 +153,16 @@ export const Row = forwardRef(
       }
     }
 
+    const canClickRowToExpand = !disabled && !!expandable && !expandButton
+
     return (
       <StyledRow
         className={className}
         ref={ref}
-        role={!disabled && expandable ? 'button row' : 'row'}
-        onClick={!disabled && expandable ? toggleRowExpand : undefined}
+        role={canClickRowToExpand ? 'button row' : 'row'}
+        onClick={canClickRowToExpand ? toggleRowExpand : undefined}
         onKeyDown={
-          !disabled && expandable
+          canClickRowToExpand
             ? event => {
                 if (event.key === ' ') {
                   toggleRowExpand()
@@ -174,7 +171,7 @@ export const Row = forwardRef(
               }
             : undefined
         }
-        tabIndex={!disabled && expandable ? 0 : -1}
+        tabIndex={canClickRowToExpand ? 0 : -1}
         sentiment={sentiment}
         aria-disabled={disabled}
         aria-expanded={expandable ? expandedRowIds[id] : undefined}
@@ -182,12 +179,8 @@ export const Row = forwardRef(
         data-testid={dataTestid}
       >
         {selectable ? (
-          <Cell preventClick>
-            <StyledCheckboxContainer
-              data-visibility={
-                allRowSelectValue === false ? 'hover' : undefined
-              }
-            >
+          <Cell preventClick={canClickRowToExpand}>
+            <StyledCheckboxContainer>
               <Tooltip
                 text={
                   typeof selectDisabled === 'string'
@@ -219,7 +212,7 @@ export const Row = forwardRef(
               disabled={disabled || !expandable}
               icon={expandedRowIds[id] ? 'arrow-up' : 'arrow-down'}
               onClick={toggleRowExpand}
-              size="xsmall"
+              size="small"
               sentiment="neutral"
               variant="ghost"
             />
@@ -229,12 +222,20 @@ export const Row = forwardRef(
         {expandable && expandedRowIds[id] ? (
           <ExpandableWrapper
             data-expandable-content
-            onClick={e => {
-              e.stopPropagation()
-            }}
-            onKeyDown={e => {
-              e.stopPropagation()
-            }}
+            onClick={
+              canClickRowToExpand
+                ? e => {
+                    e.stopPropagation()
+                  }
+                : undefined
+            }
+            onKeyDown={
+              canClickRowToExpand
+                ? e => {
+                    e.stopPropagation()
+                  }
+                : undefined
+            }
           >
             {expandable}
           </ExpandableWrapper>

--- a/packages/ui/src/components/List/__stories__/Example.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Example.stories.tsx
@@ -33,6 +33,7 @@ export const Example: StoryFn = args => {
     <List
       {...args}
       selectable
+      expandable
       columns={[
         {
           label: 'Solar system Planet',

--- a/packages/ui/src/components/List/__stories__/ExpandButton.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/ExpandButton.stories.tsx
@@ -10,7 +10,7 @@ export const ExpandButton = Template.bind({})
  */
 ExpandButton.args = {
   ...Template.args,
-  expandButton: true,
+  expandable: true,
   children: data.map(planet => (
     <List.Row
       key={planet.id}

--- a/packages/ui/src/components/List/__stories__/Expandable.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/Expandable.stories.tsx
@@ -6,6 +6,7 @@ export const Expandable = Template.bind({})
 
 Expandable.args = {
   ...Template.args,
+  expandable: true,
   children: data.map(planet => (
     <List.Row
       key={planet.id}

--- a/packages/ui/src/components/List/__stories__/ExpandableAutocollapse.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/ExpandableAutocollapse.stories.tsx
@@ -6,6 +6,7 @@ export const ExpandableAutocollapse = Template.bind({})
 
 ExpandableAutocollapse.args = {
   ...Template.args,
+  expandable: true,
   autoCollapse: true,
   children: data.map(planet => (
     <List.Row key={planet.id} id={planet.id} expandable="Planet description">

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -100,37 +100,29 @@ exports[`List Should expand a row by pressing Space 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -193,7 +185,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
     >
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -230,7 +222,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -267,7 +259,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -304,7 +296,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -341,7 +333,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -378,7 +370,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -415,7 +407,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -452,7 +444,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -489,7 +481,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -526,7 +518,7 @@ exports[`List Should expand a row by pressing Space 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -650,7 +642,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -667,37 +659,29 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -715,13 +699,15 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
   min-height: 60px;
 }
 
-.css-u2xaz3-ExpandableWrapper {
+.css-1d1xymw-ExpandableWrapper {
   grid-column: 1/-1;
   grid-column-start: 1;
   border-top: 1px solid #d9dadd;
   margin: 0 -16px;
   padding: 16px;
   cursor: auto;
+  background: #f9f9fa;
+  border-radius: 0 0 4px 4px;
 }
 
 <div
@@ -769,7 +755,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
     >
       <div
         aria-expanded="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -805,14 +791,14 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
           Row 1 Column 5
         </div>
         <div
-          class="css-u2xaz3-ExpandableWrapper ei4uyz12"
+          class="css-1d1xymw-ExpandableWrapper ei4uyz12"
           data-expandable-content="true"
         >
           Row 1 expandable content
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -849,7 +835,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -886,7 +872,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -923,7 +909,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -960,7 +946,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -997,7 +983,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -1034,7 +1020,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -1071,7 +1057,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -1108,7 +1094,7 @@ exports[`List Should not collapse a row by clicking on expandable content 1`] = 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -1232,7 +1218,7 @@ exports[`List Should render correctly 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -1249,37 +1235,29 @@ exports[`List Should render correctly 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -1341,7 +1319,7 @@ exports[`List Should render correctly 1`] = `
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1378,7 +1356,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1415,7 +1393,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1452,7 +1430,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1489,7 +1467,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1526,7 +1504,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1563,7 +1541,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1600,7 +1578,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1637,7 +1615,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1674,7 +1652,7 @@ exports[`List Should render correctly 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1798,7 +1776,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -1815,37 +1793,29 @@ exports[`List Should render correctly with bad sort value 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -1907,7 +1877,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1944,7 +1914,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -1981,7 +1951,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2018,7 +1988,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2055,7 +2025,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2092,7 +2062,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2129,7 +2099,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2166,7 +2136,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2203,7 +2173,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2240,7 +2210,7 @@ exports[`List Should render correctly with bad sort value 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2364,7 +2334,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -2381,37 +2351,29 @@ exports[`List Should render correctly with disabled rows 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -2474,7 +2436,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
     >
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2512,7 +2474,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2550,7 +2512,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2588,7 +2550,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2626,7 +2588,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2664,7 +2626,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2702,7 +2664,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2740,7 +2702,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2778,7 +2740,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2816,7 +2778,7 @@ exports[`List Should render correctly with disabled rows 1`] = `
       </div>
       <div
         aria-disabled="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -2940,7 +2902,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -2957,37 +2919,29 @@ exports[`List Should render correctly with expandable rows 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -3050,7 +3004,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
     >
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3088,7 +3042,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3126,7 +3080,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3164,7 +3118,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3202,7 +3156,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3240,7 +3194,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3278,7 +3232,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3316,7 +3270,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3354,7 +3308,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3392,7 +3346,7 @@ exports[`List Should render correctly with expandable rows 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -3533,7 +3487,7 @@ exports[`List Should render correctly with info 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -3550,37 +3504,29 @@ exports[`List Should render correctly with info 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -3717,7 +3663,7 @@ exports[`List Should render correctly with info 1`] = `
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -3754,7 +3700,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -3791,7 +3737,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -3828,7 +3774,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -3865,7 +3811,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -3902,7 +3848,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -3939,7 +3885,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -3976,7 +3922,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -4013,7 +3959,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -4050,7 +3996,7 @@ exports[`List Should render correctly with info 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -4174,7 +4120,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -4191,37 +4137,29 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -4239,13 +4177,15 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
   min-height: 60px;
 }
 
-.css-u2xaz3-ExpandableWrapper {
+.css-1d1xymw-ExpandableWrapper {
   grid-column: 1/-1;
   grid-column-start: 1;
   border-top: 1px solid #d9dadd;
   margin: 0 -16px;
   padding: 16px;
   cursor: auto;
+  background: #f9f9fa;
+  border-radius: 0 0 4px 4px;
 }
 
 <div
@@ -4292,7 +4232,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4330,7 +4270,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
       </div>
       <div
         aria-expanded="true"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4366,14 +4306,14 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
           Row 2 Column 5
         </div>
         <div
-          class="css-u2xaz3-ExpandableWrapper ei4uyz12"
+          class="css-1d1xymw-ExpandableWrapper ei4uyz12"
           data-expandable-content="true"
         >
           Row 2 expandable content
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4410,7 +4350,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4447,7 +4387,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4484,7 +4424,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4521,7 +4461,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4558,7 +4498,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4595,7 +4535,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4632,7 +4572,7 @@ exports[`List Should render correctly with isExpandable and autoClose rows then 
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4756,7 +4696,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -4773,37 +4713,29 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -4866,7 +4798,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
     >
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4904,7 +4836,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4942,7 +4874,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -4980,7 +4912,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -5018,7 +4950,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -5056,7 +4988,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -5094,7 +5026,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -5132,7 +5064,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -5170,7 +5102,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -5208,7 +5140,7 @@ exports[`List Should render correctly with isExpandable rows then click 1`] = `
       </div>
       <div
         aria-expanded="false"
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="button row"
         tabindex="0"
@@ -5342,7 +5274,7 @@ exports[`List Should render correctly with loading 1`] = `
   gap: 16px;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow {
+.css-p5zl6c-StyledRow-StyledLoadingRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -5360,37 +5292,29 @@ exports[`List Should render correctly with loading 1`] = `
   cursor: progress;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow[role='button row'] {
+.css-p5zl6c-StyledRow-StyledLoadingRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow [data-expandable-content] {
+.css-p5zl6c-StyledRow-StyledLoadingRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow:hover {
+.css-p5zl6c-StyledRow-StyledLoadingRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow[data-highlight='true'] {
+.css-p5zl6c-StyledRow-StyledLoadingRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow[aria-disabled='true'] {
+.css-p5zl6c-StyledRow-StyledLoadingRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-1kskmqo-StyledRow-StyledLoadingRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-1kskmqo-StyledRow-StyledLoadingRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -5505,7 +5429,7 @@ exports[`List Should render correctly with loading 1`] = `
       role="rowgroup"
     >
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-0"
         role="row"
       >
@@ -5596,7 +5520,7 @@ exports[`List Should render correctly with loading 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-1"
         role="row"
       >
@@ -5687,7 +5611,7 @@ exports[`List Should render correctly with loading 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-2"
         role="row"
       >
@@ -5778,7 +5702,7 @@ exports[`List Should render correctly with loading 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-3"
         role="row"
       >
@@ -5869,7 +5793,7 @@ exports[`List Should render correctly with loading 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-4"
         role="row"
       >
@@ -6331,7 +6255,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
   gap: 16px;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow {
+.css-p5zl6c-StyledRow-StyledLoadingRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -6349,37 +6273,29 @@ exports[`List Should render correctly with loading with selectable 1`] = `
   cursor: progress;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow[role='button row'] {
+.css-p5zl6c-StyledRow-StyledLoadingRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow [data-expandable-content] {
+.css-p5zl6c-StyledRow-StyledLoadingRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow:hover {
+.css-p5zl6c-StyledRow-StyledLoadingRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow[data-highlight='true'] {
+.css-p5zl6c-StyledRow-StyledLoadingRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-1kskmqo-StyledRow-StyledLoadingRow[aria-disabled='true'] {
+.css-p5zl6c-StyledRow-StyledLoadingRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-1kskmqo-StyledRow-StyledLoadingRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-1kskmqo-StyledRow-StyledLoadingRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -6552,7 +6468,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
       role="rowgroup"
     >
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-0"
         role="row"
       >
@@ -6644,7 +6560,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-1"
         role="row"
       >
@@ -6736,7 +6652,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-2"
         role="row"
       >
@@ -6828,7 +6744,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-3"
         role="row"
       >
@@ -6920,7 +6836,7 @@ exports[`List Should render correctly with loading with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-1kskmqo-StyledRow-StyledLoadingRow efawmbb1"
+        class="css-p5zl6c-StyledRow-StyledLoadingRow efawmbb1"
         id="skeleton-4"
         role="row"
       >
@@ -7099,7 +7015,7 @@ exports[`List Should render correctly with preventClick cell then click but even
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -7116,37 +7032,29 @@ exports[`List Should render correctly with preventClick cell then click but even
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -7208,7 +7116,7 @@ exports[`List Should render correctly with preventClick cell then click but even
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7245,7 +7153,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7282,7 +7190,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7319,7 +7227,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7356,7 +7264,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7393,7 +7301,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7430,7 +7338,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7467,7 +7375,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7504,7 +7412,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7541,7 +7449,7 @@ exports[`List Should render correctly with preventClick cell then click but even
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -7939,7 +7847,7 @@ exports[`List Should render correctly with selectable 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -7956,37 +7864,29 @@ exports[`List Should render correctly with selectable 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -8112,7 +8012,7 @@ exports[`List Should render correctly with selectable 1`] = `
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8123,7 +8023,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8211,7 +8110,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8222,7 +8121,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8310,7 +8208,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8321,7 +8219,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8409,7 +8306,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8420,7 +8317,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8508,7 +8404,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8519,7 +8415,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8607,7 +8502,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8618,7 +8513,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8706,7 +8600,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8717,7 +8611,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8805,7 +8698,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8816,7 +8709,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -8904,7 +8796,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -8915,7 +8807,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -9003,7 +8894,7 @@ exports[`List Should render correctly with selectable 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -9014,7 +8905,6 @@ exports[`List Should render correctly with selectable 1`] = `
         >
           <div
             class="css-atewdf-StyledCheckboxContainer ei4uyz10"
-            data-visibility="hover"
           >
             <div
               aria-disabled="false"
@@ -9463,7 +9353,7 @@ exports[`List Should render correctly with selectable then click on first row th
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -9480,37 +9370,29 @@ exports[`List Should render correctly with selectable then click on first row th
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -9636,7 +9518,7 @@ exports[`List Should render correctly with selectable then click on first row th
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -9734,7 +9616,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -9832,7 +9714,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -9930,7 +9812,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -10028,7 +9910,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -10126,7 +10008,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -10224,7 +10106,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -10322,7 +10204,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -10420,7 +10302,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -10518,7 +10400,7 @@ exports[`List Should render correctly with selectable then click on first row th
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="true"
         role="row"
         tabindex="-1"
@@ -10703,7 +10585,7 @@ exports[`List Should render correctly with sort 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -10720,37 +10602,29 @@ exports[`List Should render correctly with sort 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -10812,7 +10686,7 @@ exports[`List Should render correctly with sort 1`] = `
       role="rowgroup"
     >
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -10849,7 +10723,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -10886,7 +10760,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -10923,7 +10797,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -10960,7 +10834,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -10997,7 +10871,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -11034,7 +10908,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -11071,7 +10945,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -11108,7 +10982,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -11145,7 +11019,7 @@ exports[`List Should render correctly with sort 1`] = `
         </div>
       </div>
       <div
-        class="css-8s924x-StyledRow ei4uyz11"
+        class="css-2npocl-StyledRow ei4uyz11"
         data-highlight="false"
         role="row"
         tabindex="-1"
@@ -11315,7 +11189,7 @@ exports[`List Should render correctly with sort then click 1`] = `
   gap: 16px;
 }
 
-.css-8s924x-StyledRow {
+.css-2npocl-StyledRow {
   position: relative;
   border: 1px solid #d9dadd;
   border-radius: 4px;
@@ -11332,37 +11206,29 @@ exports[`List Should render correctly with sort then click 1`] = `
   background-color: #ffffff;
 }
 
-.css-8s924x-StyledRow[role='button row'] {
+.css-2npocl-StyledRow[role='button row'] {
   cursor: pointer;
 }
 
-.css-8s924x-StyledRow [data-expandable-content] {
+.css-2npocl-StyledRow [data-expandable-content] {
   border-color: #d9dadd;
 }
 
-.css-8s924x-StyledRow:hover {
+.css-2npocl-StyledRow:hover {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[data-highlight='true'] {
+.css-2npocl-StyledRow[data-highlight='true'] {
   border-color: #8c40ef;
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.css-8s924x-StyledRow[aria-disabled='true'] {
+.css-2npocl-StyledRow[aria-disabled='true'] {
   border: 1px solid #e9eaeb;
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
-}
-
-.css-8s924x-StyledRow [data-visibility='hover'] {
-  opacity: 0;
-}
-
-.css-8s924x-StyledRow:hover:not([aria-disabled='true']) [data-visibility='hover'] {
-  opacity: 1;
 }
 
 .css-1bcbf7v-StyledCell {
@@ -11531,7 +11397,7 @@ exports[`List Should render correctly with sort then click 1`] = `
         role="rowgroup"
       >
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11568,7 +11434,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11605,7 +11471,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11642,7 +11508,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11679,7 +11545,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11716,7 +11582,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11753,7 +11619,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11790,7 +11656,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11827,7 +11693,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"
@@ -11864,7 +11730,7 @@ exports[`List Should render correctly with sort then click 1`] = `
           </div>
         </div>
         <div
-          class="css-8s924x-StyledRow ei4uyz11"
+          class="css-2npocl-StyledRow ei4uyz11"
           data-highlight="false"
           role="row"
           tabindex="-1"

--- a/packages/ui/src/components/List/constants.tsx
+++ b/packages/ui/src/components/List/constants.tsx
@@ -1,2 +1,2 @@
 export const SELECTABLE_CHECKBOX_SIZE = 24
-export const EXPAND_BUTTON_SIZE = 24
+export const EXPANDABLE_COLUMN_SIZE = 24

--- a/packages/ui/src/components/List/index.tsx
+++ b/packages/ui/src/components/List/index.tsx
@@ -9,7 +9,7 @@ import { ListProvider, useListContext } from './ListContext'
 import { Row } from './Row'
 import { SelectBar } from './SelectBar'
 import { SkeletonRows } from './SkeletonRows'
-import { EXPAND_BUTTON_SIZE, SELECTABLE_CHECKBOX_SIZE } from './constants'
+import { EXPANDABLE_COLUMN_SIZE, SELECTABLE_CHECKBOX_SIZE } from './constants'
 
 const StyledList = styled('div', {
   shouldForwardProp: prop => !['template'].includes(prop),
@@ -38,7 +38,7 @@ type ColumnProps = Pick<
 }
 
 type ListProps = {
-  expandButton?: boolean
+  expandable?: boolean
   selectable?: boolean
   columns: ColumnProps[]
   children: ReactNode
@@ -55,7 +55,7 @@ type ListProps = {
 const BaseList = forwardRef(
   (
     {
-      expandButton = false,
+      expandable = false,
       selectable = false,
       columns,
       children,
@@ -67,13 +67,13 @@ const BaseList = forwardRef(
     const computeTemplate = `${
       selectable ? `${SELECTABLE_CHECKBOX_SIZE}px ` : ''
     }${
-      expandButton ? `${EXPAND_BUTTON_SIZE}px ` : ''
+      expandable ? `${EXPANDABLE_COLUMN_SIZE}px ` : ''
     }${columns.map(({ width }) => width ?? 'minmax(0, 1fr)').join(' ')}`
 
     return (
       <ListProvider
         selectable={selectable}
-        expandButton={expandButton}
+        expandButton={expandable}
         autoCollapse={autoCollapse}
       >
         <StyledList ref={ref} role="grid" template={computeTemplate}>

--- a/packages/ui/src/components/Table/Row.tsx
+++ b/packages/ui/src/components/Table/Row.tsx
@@ -52,7 +52,6 @@ export const Row = ({
   'data-testid': dataTestid,
 }: RowProps) => {
   const {
-    allRowSelectValue,
     selectable,
     registerSelectableRow,
     selectedRowIds,
@@ -78,9 +77,7 @@ export const Row = ({
     >
       {selectable ? (
         <Cell>
-          <StyledCheckboxContainer
-            data-visibility={allRowSelectValue === false ? 'hover' : undefined}
-          >
+          <StyledCheckboxContainer>
             <Tooltip
               text={
                 typeof selectDisabled === 'string' ? selectDisabled : undefined


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

- Row expandable content has a background
- props `expandButton` has been renamed `expandable`
- Adding a dedicated column (and CTA) to expand/collapse a row with expandable content now replace row click behavior (it's not an addition anymore)
- Select checkbox is now always visible, even if none is selected