### PR TITLE
fix(NumberInputV2): empty value behavior

### DIFF
--- a/.changeset/brave-bats-join.md
+++ b/.changeset/brave-bats-join.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/plus": patch
+"@ultraviolet/ui": patch
+---
+
+NumberInputV2: fix empty value behavior

--- a/packages/form/src/components/NumberInputFieldV2/__stories__/Required.stories.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/__stories__/Required.stories.tsx
@@ -16,4 +16,5 @@ export const Required: StoryFn<
 Required.args = {
   name: 'value',
   required: true,
+  label: 'This field is required',
 }

--- a/packages/form/src/components/NumberInputFieldV2/index.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/index.tsx
@@ -97,7 +97,7 @@ export const NumberInputFieldV2 = <
       }}
       onChange={newValue => {
         // React hook form doesnt allow undefined values after definition https://react-hook-form.com/docs/usecontroller/controller (that make sense)
-        field.onChange(newValue ?? null)
+        field.onChange(newValue)
         onChange?.(newValue as PathValue<TFieldValues, Path<TFieldValues>>)
       }}
       max={max}
@@ -118,6 +118,7 @@ export const NumberInputFieldV2 = <
       aria-label={ariaLabel}
       autoFocus={autoFocus}
       readOnly={readOnly}
+      required={required}
     />
   )
 }

--- a/packages/plus/src/components/EstimateCost/Components/NumberInput.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/NumberInput.tsx
@@ -6,8 +6,8 @@ import { Regular } from './Regular'
 
 type NumberInputProps = {
   amount?: number
-  itemCallback?: (amount?: number, isVariant?: boolean) => void
-  getAmountValue?: (amount?: number) => void
+  itemCallback?: (amount?: number | null, isVariant?: boolean) => void
+  getAmountValue?: (amount?: number | null) => void
   minValue?: number
   maxValue?: number
 }
@@ -20,7 +20,7 @@ export const NumberInput = ({
   itemCallback,
 }: NumberInputProps) => {
   const { isOverlay } = useOverlay()
-  const [value, setValue] = useState<number | undefined>(amount)
+  const [value, setValue] = useState<number | undefined | null>(amount)
 
   useEffect(() => {
     getAmountValue?.(amount)

--- a/packages/ui/src/components/NumberInputV2/__stories__/MinMax.stories.tsx
+++ b/packages/ui/src/components/NumberInputV2/__stories__/MinMax.stories.tsx
@@ -4,7 +4,7 @@ import type { NumberInputV2 } from '../index'
 import { Template } from './Template.stories'
 
 export const MinMax: StoryFn<typeof NumberInputV2> = args => {
-  const [value, setValue] = useState(10)
+  const [value, setValue] = useState<number | null>(10)
 
   return <Template {...args} value={value} onChange={setValue} />
 }

--- a/packages/ui/src/components/NumberInputV2/index.tsx
+++ b/packages/ui/src/components/NumberInputV2/index.tsx
@@ -184,8 +184,8 @@ type NumberInputProps = {
   error?: string
   success?: string | boolean
   helper?: ReactNode
-  value?: number
-  onChange?: (newValue: number) => void
+  value?: number | null
+  onChange?: (newValue: number | null) => void
   min?: number
   max?: number
 } & Pick<
@@ -385,12 +385,17 @@ export const NumberInputV2 = forwardRef(
                   placeholder={placeholder}
                   onKeyDown={event => {
                     if (event.key === 'Enter') {
-                      onChangeValue(localRef.current?.value ?? '')
+                      if (!localRef.current?.value) {
+                        onChange?.(null)
+                      } else if (onChange) {
+                        onChangeValue(localRef.current?.value ?? '')
+                      }
                     }
                   }}
                   onBlur={event => {
                     if (event.target.value === '') {
                       onBlur?.(event)
+                      onChange?.(null)
 
                       return
                     }
@@ -398,10 +403,9 @@ export const NumberInputV2 = forwardRef(
                     if (onChange) {
                       onChangeValue(event.target.value)
                     }
-
                     onBlur?.(event)
                   }}
-                  defaultValue={value}
+                  defaultValue={value?.toString()}
                   onFocus={onFocus}
                   data-size={size}
                   step={step}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

- **NumberInputV2/NumberInputV2Field** : Allow empty value (will return null as value)
- **NumberInputV2Field** : forward `required` prop to `NumberInputV2`