### PR TITLE
fix(SelectableCardGroup): to hide required icon when there is no legend

### DIFF
--- a/.changeset/strange-cars-retire.md
+++ b/.changeset/strange-cars-retire.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectableCardGroup />` to hide required icon when there is no legend set

--- a/packages/ui/src/components/SelectableCardGroup/index.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/index.tsx
@@ -137,12 +137,14 @@ export const SelectableCardGroup = ({
       <Stack gap={1}>
         <FieldSet className={className}>
           <Stack gap={1.5}>
-            <Text as="legend" variant="bodyStrong">
-              {legend && <>{legend} &nbsp;</>}
-              {required ? (
-                <StyledRequiredIcon name="asterisk" color="danger" size={8} />
-              ) : null}
-            </Text>
+            {legend ? (
+              <Text as="legend" variant="bodyStrong">
+                {legend && <>{legend} &nbsp;</>}
+                {required ? (
+                  <StyledRequiredIcon name="asterisk" color="danger" size={8} />
+                ) : null}
+              </Text>
+            ) : null}
             <Row gap={2} templateColumns={`repeat(${columns}, auto)`}>
               {children}
             </Row>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<SelectableCardGroup />` to hide required icon when there is no legend set


## Relevant logs and/or screenshots

Before:
<img width="860" alt="Screenshot 2024-03-28 at 14 36 13" src="https://github.com/scaleway/ultraviolet/assets/15812968/9f640471-bf62-477b-aac3-3da0cee3f520">

After:
<img width="961" alt="Screenshot 2024-03-28 at 14 36 22" src="https://github.com/scaleway/ultraviolet/assets/15812968/962fe788-e900-4d2b-a73c-ecf877f4ac55">
