### PR TITLE
refactor(KeyValueField): new spacing and text input v2 usage

### DIFF
--- a/.changeset/tiny-cows-smile.md
+++ b/.changeset/tiny-cows-smile.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": minor
+---
+
+Refactor `<KeyValueField />` component to have correct spacing and use `<TextInputFieldV2 />`

--- a/packages/form/src/components/KeyValueField/__stories__/Environnement.stories.tsx
+++ b/packages/form/src/components/KeyValueField/__stories__/Environnement.stories.tsx
@@ -25,7 +25,7 @@ Environnement.args = {
   },
   inputValue: {
     label: 'value',
-    type: 'toggleable-password',
+    type: 'password',
     placeholder: HIDDEN_SECRET_VALUE,
     regex: [alphanumDashUnderscoreDots],
     required: true,

--- a/packages/form/src/components/KeyValueField/__stories__/Playground.stories.tsx
+++ b/packages/form/src/components/KeyValueField/__stories__/Playground.stories.tsx
@@ -5,11 +5,11 @@ export const Playground = Template.bind({})
 Playground.args = {
   name: 'keyValues',
   inputKey: {
-    label: 'key',
+    label: 'Key',
     required: true,
   },
   inputValue: {
-    label: 'value',
+    label: 'Value',
     required: false,
   },
   addButton: {

--- a/packages/form/src/components/KeyValueField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/KeyValueField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -134,8 +134,8 @@ exports[`KeyValueField should render with default props & max size 1`] = `
         class="cache-1g4uved ehpbis70"
       >
         <div
-          aria-controls=":r2:"
-          aria-describedby=":r2:"
+          aria-controls=":r8:"
+          aria-describedby=":r8:"
           class="cache-jhu4ja e4h1g860"
           data-container-full-width="false"
           tabindex="0"
@@ -452,8 +452,8 @@ exports[`KeyValueField should render with default props in readonly mode 1`] = `
         class="cache-1g4uved ehpbis70"
       >
         <div
-          aria-controls=":r3:"
-          aria-describedby=":r3:"
+          aria-controls=":r9:"
+          aria-describedby=":r9:"
           class="cache-jhu4ja e4h1g860"
           data-container-full-width="false"
           tabindex="0"

--- a/packages/form/src/components/KeyValueField/index.tsx
+++ b/packages/form/src/components/KeyValueField/index.tsx
@@ -2,17 +2,17 @@ import { Button, Row, Stack } from '@ultraviolet/ui'
 import type { ComponentProps } from 'react'
 import { useFieldArray } from 'react-hook-form'
 import type { Control, FieldArrayPath, FieldValues } from 'react-hook-form'
-import { TextInputField } from '../TextInputField'
+import { TextInputField as TextInputFieldV2 } from '../TextInputFieldV2'
 
 type InputKeyProps = {
-  label: ComponentProps<typeof TextInputField>['label']
-  required?: ComponentProps<typeof TextInputField>['required']
-  regex?: ComponentProps<typeof TextInputField>['regex']
+  label: ComponentProps<typeof TextInputFieldV2>['label']
+  required?: ComponentProps<typeof TextInputFieldV2>['required']
+  regex?: ComponentProps<typeof TextInputFieldV2>['regex']
 }
 
 type InputValueProps = {
-  type?: ComponentProps<typeof TextInputField>['type']
-  placeholder?: ComponentProps<typeof TextInputField>['placeholder']
+  type?: ComponentProps<typeof TextInputFieldV2>['type']
+  placeholder?: ComponentProps<typeof TextInputFieldV2>['placeholder']
 } & InputKeyProps
 
 type AddButtonProps = {
@@ -64,17 +64,22 @@ export const KeyValueField = <
   return (
     <Stack gap={3}>
       {fields.length ? (
-        <Stack gap={2}>
+        <Stack gap={3}>
           {fields.map((field, index) => (
-            <Row key={field.id} templateColumns="1fr 1fr auto" gap={2}>
-              <TextInputField
+            <Row
+              key={field.id}
+              templateColumns="1fr 1fr auto"
+              gap={2}
+              alignItems="end"
+            >
+              <TextInputFieldV2
                 readOnly={readonly}
                 required={inputKey.required}
                 name={`${name}.${index}.key`}
                 label={inputKey.label}
                 regex={inputKey.regex}
               />
-              <TextInputField
+              <TextInputFieldV2
                 readOnly={readonly}
                 required={inputValue.required}
                 name={`${name}.${index}.value`}


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Refactor `<KeyValueField />` component to have correct spacing and use `<TextInputFieldV2 />`


## Relevant logs and/or screenshots

Before:
<img width="988" alt="Screenshot 2024-04-02 at 11 45 23" src="https://github.com/scaleway/ultraviolet/assets/15812968/f7bd8961-4cd2-437c-9c46-00ed36ac2a7a">

After:
<img width="968" alt="Screenshot 2024-04-02 at 11 45 31" src="https://github.com/scaleway/ultraviolet/assets/15812968/710414dc-2d77-47ab-af7b-8f44e2860775">
