### PR TITLE
fix(Navigation): correct color on hover for weak text

### DIFF
--- a/.changeset/short-toes-relax.md
+++ b/.changeset/short-toes-relax.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<Navigation />` to have correct text color on hover

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -137,6 +137,10 @@ const StyledContainer = styled(Stack)`
       [disabled][data-is-active='true']
     ) {
     background-color: ${({ theme }) => theme.colors.neutral.backgroundHover};
+    ${WrapText} {
+      color: ${({ theme }) => theme.colors.neutral.textWeakHover};
+    }
+
     ${ExpandedPinnedButton}, ${CollapsedPinnedButton} {
       opacity: 1;
     }

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -92,8 +92,12 @@ const PaddingStack = styled(Stack)`
 const AnimatedIcon = styled(Icon)``
 
 const WrapText = styled(Text, {
-  shouldForwardProp: prop => !['animation', 'subLabel'].includes(prop),
-})<{ animation?: 'collapse' | 'expand' | boolean; subLabel?: boolean }>`
+  shouldForwardProp: prop =>
+    !['animation', 'subLabel', 'textProminence'].includes(prop),
+})<{
+  animation?: 'collapse' | 'expand' | boolean
+  subLabel?: boolean
+}>`
   overflow-wrap: ${({ animation }) => (animation ? 'normal' : 'anywhere')};
   white-space: ${({ animation }) => (animation ? 'nowrap' : 'normal')};
 `
@@ -117,6 +121,10 @@ const StyledContainer = styled(Stack)`
     padding: ${({ theme }) => `${theme.space['0.5']} ${theme.space['1']}`};
   }
 
+  transition:
+    background-color 0.2s ease-in-out,
+    color 0.2s ease-in-out;
+
   width: 100%;
 
   &:hover[data-has-no-expand='false']:not([disabled]):not(
@@ -129,7 +137,6 @@ const StyledContainer = styled(Stack)`
       [disabled][data-is-active='true']
     ) {
     background-color: ${({ theme }) => theme.colors.neutral.backgroundHover};
-
     ${ExpandedPinnedButton}, ${CollapsedPinnedButton} {
       opacity: 1;
     }
@@ -138,6 +145,15 @@ const StyledContainer = styled(Stack)`
       ${StyledBadge} {
         opacity: 0;
       }
+    }
+  }
+
+  &:hover[data-has-children='false'][data-is-active='false'] {
+    ${WrapText} {
+      color: ${({ theme }) => theme.colors.neutral.textWeakHover};
+      transition:
+        background-color 0.2s ease-in-out,
+        color 0.2s ease-in-out;
     }
   }
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<Navigation />` to have correct text color on hover

## Relevant logs and/or screenshots

Before:
![Screenshot 2024-04-08 at 16 27 50](https://github.com/scaleway/ultraviolet/assets/15812968/b07428e4-c3c8-428e-a22e-750e726e2dd2)

After:
![Screenshot 2024-04-08 at 16 28 02](https://github.com/scaleway/ultraviolet/assets/15812968/efac863c-cc2c-4469-ad51-1de43bb2c09f)
