### PR TITLE
fix(Stepper): clean null or undefined children before render

### DIFF
--- a/.changeset/honest-moles-notice.md
+++ b/.changeset/honest-moles-notice.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Stepper />` component to clean null or undefined children before rendering

--- a/packages/ui/src/components/Stepper/index.tsx
+++ b/packages/ui/src/components/Stepper/index.tsx
@@ -153,7 +153,8 @@ export const Stepper = ({
   size = 'medium',
   'data-testid': dataTestId,
 }: StepperProps) => {
-  const lastStep = Children.count(children) - 1
+  const cleanChildren = Children.toArray(children)
+  const lastStep = Children.count(cleanChildren) - 1
 
   return (
     <StyledContainer
@@ -162,7 +163,7 @@ export const Stepper = ({
       labelPosition={labelPosition}
       size={size}
     >
-      {Children.map(children, (child, index) => {
+      {Children.map(cleanChildren, (child, index) => {
         const getTemporal = () => {
           if (selected > index) return 'previous'
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<Stepper />` component to clean null or undefined children before rendering

Not working example that now works:

```ts
  <Stepper selected={0} labelPosition="right" size="small">
    {null}
    <Text as="span" variant="bodySmall">
      test2
    </Text>
    <Text as="span" variant="bodySmall">
      test3
    </Text>
  </Stepper>
```

## Relevant logs and/or screenshots

Before:
![Screenshot 2024-04-08 at 17 42 54](https://github.com/scaleway/ultraviolet/assets/15812968/1a9d0320-b58e-4416-b15d-00705a919759)


After:
![Screenshot 2024-04-08 at 17 43 16](https://github.com/scaleway/ultraviolet/assets/15812968/f691e908-734f-494c-b3b0-2cde6cda7d46)

