### PR TITLE
fix(Navigation): category icon variant on collasped version

### DIFF
--- a/.changeset/tricky-beans-compare.md
+++ b/.changeset/tricky-beans-compare.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<Navigation />` category icon variant on collapsed version

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -637,7 +637,10 @@ export const Item = ({
                 alignItems="center"
                 justifyContent="center"
               >
-                <CategoryIcon name={categoryIcon ?? 'console'} />
+                <CategoryIcon
+                  name={categoryIcon ?? 'console'}
+                  variant={categoryIconVariant}
+                />
               </Stack>
             </Button>
           </Tooltip>

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -121,10 +121,6 @@ const StyledContainer = styled(Stack)`
     padding: ${({ theme }) => `${theme.space['0.5']} ${theme.space['1']}`};
   }
 
-  transition:
-    background-color 0.2s ease-in-out,
-    color 0.2s ease-in-out;
-
   width: 100%;
 
   &:hover[data-has-no-expand='false']:not([disabled]):not(
@@ -155,9 +151,7 @@ const StyledContainer = styled(Stack)`
   &:hover[data-has-children='false'][data-is-active='false'] {
     ${WrapText} {
       color: ${({ theme }) => theme.colors.neutral.textWeakHover};
-      transition:
-        background-color 0.2s ease-in-out,
-        color 0.2s ease-in-out;
+      transition: background-color 0.2s ease-in-out;
     }
   }
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<Navigation />` category icon variant on collapsed version

## Relevant logs and/or screenshots

Before:
<img width="532" alt="Screenshot 2024-04-09 at 14 05 15" src="https://github.com/scaleway/ultraviolet/assets/15812968/ceb8af96-9cc8-4779-a944-56071e989be7">

After:
<img width="504" alt="Screenshot 2024-04-09 at 14 05 22" src="https://github.com/scaleway/ultraviolet/assets/15812968/8c271ab7-1f6b-4284-9689-097128467e45">



