### PR TITLE
fix(Popup): to correctly set portal taget prop

### DIFF
--- a/.changeset/lazy-squids-press.md
+++ b/.changeset/lazy-squids-press.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Popup />` component to correctly set `portalTarget` prop

--- a/packages/ui/src/components/Popup/index.tsx
+++ b/packages/ui/src/components/Popup/index.tsx
@@ -203,8 +203,9 @@ export const Popup = forwardRef(
 
     const timer = useRef<ReturnType<typeof setTimeout> | undefined>()
     const popupPortalTarget = useMemo(() => {
+      if (portalTarget) return portalTarget
+
       if (role === 'dialog') {
-        if (portalTarget) return portalTarget
         if (childrenRef.current) return childrenRef.current
         if (typeof window !== 'undefined') return document.body
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix Popup to correctly set portalTarget, if the role is something else than dialog.