### PR TITLE
fix: change navitem text color

### DIFF
--- a/.changeset/tall-seahorses-grow.md
+++ b/.changeset/tall-seahorses-grow.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+`<Navigation />`: Changed color of the text in `Navigation.Item` from textWeak to textDefault

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -473,7 +473,9 @@ export const Item = ({
                 variant="bodySmallStrong"
                 sentiment={active ? 'primary' : 'neutral'}
                 prominence={
-                  (categoryIcon || !hasParents) && !active ? 'strong' : 'weak'
+                  (categoryIcon || !hasParents) && !active
+                    ? 'strong'
+                    : 'default'
                 }
                 animation={animation}
                 disabled={disabled}

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -538,7 +538,7 @@ export const Item = ({
               <AnimatedIcon
                 name="open-in-new"
                 sentiment="neutral"
-                prominence="weak"
+                prominence="default"
                 disabled={disabled}
               />
             ) : null}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Text in `Navigation.Item` should be textDefault and not textWeak