### PR TITLE
fix(Menu): to have smaller debounce delay

### DIFF
--- a/.changeset/dry-icons-punch.md
+++ b/.changeset/dry-icons-punch.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<MenuV2 />` to have a debounce delay of 250ms instead of 350ms - it will make the menu appear faster on hover

--- a/packages/ui/src/components/MenuV2/index.tsx
+++ b/packages/ui/src/components/MenuV2/index.tsx
@@ -163,7 +163,7 @@ const FwdMenu = forwardRef(
 
     return (
       <StyledPopup
-        debounceDelay={triggerMethod === 'hover' ? 350 : 0}
+        debounceDelay={triggerMethod === 'hover' ? 250 : 0}
         hideOnClickOutside
         aria-label={ariaLabel}
         className={className}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Current menuv2 has a debounce delay of 350ms, we changed it to be 250ms so the menu will appear faster on hover.
