### PR TITLE
fix(SelectableCardGroup): force item to follow grid

### DIFF
--- a/.changeset/nice-rules-collect.md
+++ b/.changeset/nice-rules-collect.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+SelectableCardGroup: force item to follow grid

--- a/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -65,9 +65,9 @@ exports[`SelectableCardField should render correctly 1`] = `
   text-decoration: none;
 }
 
-.cache-1bc2sza {
+.cache-q335xz {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -344,7 +344,7 @@ exports[`SelectableCardField should render correctly 1`] = `
             test  
           </legend>
           <div
-            class="cache-1bc2sza e3f5lzv0"
+            class="cache-q335xz e3f5lzv0"
           >
             <div
               class="cache-1wln6wd e1s5n3hj3"
@@ -535,9 +535,9 @@ exports[`SelectableCardField should render correctly checked as a checkbox 1`] =
   text-decoration: none;
 }
 
-.cache-1bc2sza {
+.cache-q335xz {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -939,7 +939,7 @@ exports[`SelectableCardField should render correctly checked as a checkbox 1`] =
             test  
           </legend>
           <div
-            class="cache-1bc2sza e3f5lzv0"
+            class="cache-q335xz e3f5lzv0"
           >
             <div
               class="cache-1wln6wd e1s5n3hj3"
@@ -1082,9 +1082,9 @@ exports[`SelectableCardField should render correctly checked as radiofield 1`] =
   text-decoration: none;
 }
 
-.cache-1bc2sza {
+.cache-q335xz {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -1361,7 +1361,7 @@ exports[`SelectableCardField should render correctly checked as radiofield 1`] =
             test  
           </legend>
           <div
-            class="cache-1bc2sza e3f5lzv0"
+            class="cache-q335xz e3f5lzv0"
           >
             <div
               class="cache-1wln6wd e1s5n3hj3"
@@ -1496,9 +1496,9 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
   text-decoration: none;
 }
 
-.cache-1bc2sza {
+.cache-q335xz {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -1900,7 +1900,7 @@ exports[`SelectableCardField should trigger events correctly 1`] = `
             test  
           </legend>
           <div
-            class="cache-1bc2sza e3f5lzv0"
+            class="cache-q335xz e3f5lzv0"
           >
             <div
               class="cache-1wln6wd e1s5n3hj3"

--- a/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -65,9 +65,9 @@ exports[`SelectableCardGroup renders correctly 1`] = `
   text-decoration: none;
 }
 
-.cache-t79hcp-StyledRow {
+.cache-15hrxne-StyledRow {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -466,7 +466,7 @@ exports[`SelectableCardGroup renders correctly 1`] = `
           Label  
         </legend>
         <div
-          class="cache-t79hcp-StyledRow e3f5lzv0"
+          class="cache-15hrxne-StyledRow e3f5lzv0"
         >
           <div
             class="cache-1ls95ey-Stack-Container e1s5n3hj3"
@@ -673,9 +673,9 @@ exports[`SelectableCardGroup renders correctly as a radio 1`] = `
   text-decoration: none;
 }
 
-.cache-t79hcp-StyledRow {
+.cache-15hrxne-StyledRow {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -961,7 +961,7 @@ exports[`SelectableCardGroup renders correctly as a radio 1`] = `
           Label  
         </legend>
         <div
-          class="cache-t79hcp-StyledRow e3f5lzv0"
+          class="cache-15hrxne-StyledRow e3f5lzv0"
         >
           <div
             class="cache-1ls95ey-Stack-Container e1s5n3hj3"
@@ -1172,9 +1172,9 @@ exports[`SelectableCardGroup renders correctly required and showTick 1`] = `
   fill: none;
 }
 
-.cache-t79hcp-StyledRow {
+.cache-15hrxne-StyledRow {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -1578,7 +1578,7 @@ exports[`SelectableCardGroup renders correctly required and showTick 1`] = `
           </svg>
         </legend>
         <div
-          class="cache-t79hcp-StyledRow e3f5lzv0"
+          class="cache-15hrxne-StyledRow e3f5lzv0"
         >
           <div
             class="cache-1ls95ey-Stack-Container e1s5n3hj3"
@@ -1785,9 +1785,9 @@ exports[`SelectableCardGroup renders correctly with direction multiple columns 1
   text-decoration: none;
 }
 
-.cache-evbsfc-StyledRow {
+.cache-1yxh7gy-StyledRow {
   display: grid;
-  grid-template-columns: repeat(2, auto);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -2186,7 +2186,7 @@ exports[`SelectableCardGroup renders correctly with direction multiple columns 1
           Label  
         </legend>
         <div
-          class="cache-evbsfc-StyledRow e3f5lzv0"
+          class="cache-1yxh7gy-StyledRow e3f5lzv0"
         >
           <div
             class="cache-1ls95ey-Stack-Container e1s5n3hj3"
@@ -2393,9 +2393,9 @@ exports[`SelectableCardGroup renders correctly with error content 1`] = `
   text-decoration: none;
 }
 
-.cache-t79hcp-StyledRow {
+.cache-15hrxne-StyledRow {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -2806,7 +2806,7 @@ exports[`SelectableCardGroup renders correctly with error content 1`] = `
           Label  
         </legend>
         <div
-          class="cache-t79hcp-StyledRow e3f5lzv0"
+          class="cache-15hrxne-StyledRow e3f5lzv0"
         >
           <div
             class="cache-1ls95ey-Stack-Container e1s5n3hj3"
@@ -3018,9 +3018,9 @@ exports[`SelectableCardGroup renders correctly with helper content 1`] = `
   text-decoration: none;
 }
 
-.cache-t79hcp-StyledRow {
+.cache-15hrxne-StyledRow {
   display: grid;
-  grid-template-columns: repeat(1, auto);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 16px;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
@@ -3431,7 +3431,7 @@ exports[`SelectableCardGroup renders correctly with helper content 1`] = `
           Label  
         </legend>
         <div
-          class="cache-t79hcp-StyledRow e3f5lzv0"
+          class="cache-15hrxne-StyledRow e3f5lzv0"
         >
           <div
             class="cache-1ls95ey-Stack-Container e1s5n3hj3"

--- a/packages/ui/src/components/SelectableCardGroup/index.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/index.tsx
@@ -145,7 +145,7 @@ export const SelectableCardGroup = ({
                 ) : null}
               </Text>
             ) : null}
-            <Row gap={2} templateColumns={`repeat(${columns}, auto)`}>
+            <Row gap={2} templateColumns={`repeat(${columns}, minmax(0, 1fr))`}>
               {children}
             </Row>
           </Stack>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Inside a `SelectableCardGroup` if a `SelectableCard` have a `label` or a `content`  (children),  it kind of overflows the space allocated by the `Row`

## Relevant logs and/or screenshots

| Component |   Before   |      After |
| :--- | :--------: | ---------: |
| SelectableCardGroup  | 
![Capture d’écran 2024-04-24 à 18 00 44](https://github.com/scaleway/ultraviolet/assets/8116991/4123e54c-e85d-4e3b-88e0-e3977892dfea) | ![Capture d’écran 2024-04-24 à 18 01 30](https://github.com/scaleway/ultraviolet/assets/8116991/21c4dadf-2f34-4b68-91d0-d6e2f1dcd1d1) |
