### PR TITLE
feat(Navigation): new pinned feature and reorder

### DIFF
--- a/.changeset/neat-badgers-juggle.md
+++ b/.changeset/neat-badgers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": minor
+---
+
+New pinned feature on `<Navigation />` you can enable it using prop `pinnedFeature={true}` on `<NavigationProvider />`

--- a/packages/plus/src/components/Navigation/NavigationProvider.tsx
+++ b/packages/plus/src/components/Navigation/NavigationProvider.tsx
@@ -1,14 +1,23 @@
-import type { ReactNode, RefObject } from 'react'
+import type { Dispatch, ReactNode, Reducer, RefObject } from 'react'
 import {
   createContext,
   useCallback,
   useContext,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from 'react'
 import { ANIMATION_DURATION, NAVIGATION_WIDTH } from './constants'
 import NavigationLocales from './locales/en'
+
+type Item = {
+  label: string
+  active?: boolean
+  onClick?: (toggle?: true | false) => void
+}
+
+type Items = Record<string, Item>
 
 type ContextProps = {
   expanded: boolean
@@ -38,6 +47,8 @@ type ContextProps = {
      */
     endIndex: number,
   ) => void
+  items: Items
+  registerItem: Dispatch<Items>
 }
 
 export const NavigationContext = createContext<ContextProps>({
@@ -57,6 +68,8 @@ export const NavigationContext = createContext<ContextProps>({
   width: NAVIGATION_WIDTH,
   setWidth: () => {},
   reorderItems: () => {},
+  items: {},
+  registerItem: () => {},
 })
 
 export const useNavigation = () => useContext(NavigationContext)
@@ -121,7 +134,19 @@ export const NavigationProvider = ({
     false,
   )
   const [width, setWidth] = useState<number>(initialWidth)
+
+  // This is used to store the items that are registered in the navigation
+  // This way we can retrieve items with their active state in pinned feature
+  const [items, registerItem] = useReducer<Reducer<Items, Items>>(
+    (oldState: Items, newState: Items) => ({
+      ...oldState,
+      ...newState,
+    }),
+    {},
+  )
   const navigationRef = useRef<HTMLDivElement>(null)
+
+  // console.log('items', items)
 
   // This function will be triggered when expand/collapse button is clicked
   const toggleExpand = useCallback(
@@ -193,6 +218,8 @@ export const NavigationProvider = ({
       width,
       setWidth,
       reorderItems,
+      registerItem,
+      items,
     }),
     [
       expanded,
@@ -205,10 +232,8 @@ export const NavigationProvider = ({
       pinLimit,
       animation,
       width,
-      setWidth,
-      navigationRef,
-      setAnimation,
       reorderItems,
+      items,
     ],
   )
 

--- a/packages/plus/src/components/Navigation/NavigationProvider.tsx
+++ b/packages/plus/src/components/Navigation/NavigationProvider.tsx
@@ -111,6 +111,10 @@ type NavigationProviderProps = {
    */
   onClickPinUnpin?: (
     /**
+     * The state of the item after the click
+     */
+    state: 'pin' | 'unpin',
+    /**
      * The current items that has been pinned on click
      */
     pinned: string,
@@ -146,8 +150,6 @@ export const NavigationProvider = ({
   )
   const navigationRef = useRef<HTMLDivElement>(null)
 
-  // console.log('items', items)
-
   // This function will be triggered when expand/collapse button is clicked
   const toggleExpand = useCallback(
     (toggle?: boolean) => {
@@ -179,7 +181,7 @@ export const NavigationProvider = ({
   const pinItem = useCallback(
     (item: string) => {
       setPinnedItems([...pinnedItems, item])
-      onClickPinUnpin?.(item)
+      onClickPinUnpin?.('pin', item)
     },
     [onClickPinUnpin, pinnedItems],
   )
@@ -187,7 +189,7 @@ export const NavigationProvider = ({
   const unpinItem = useCallback(
     (item: string) => {
       setPinnedItems(pinnedItems.filter(localItem => localItem !== item))
-      onClickPinUnpin?.(item)
+      onClickPinUnpin?.('unpin', item)
     },
     [onClickPinUnpin, pinnedItems],
   )

--- a/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
+++ b/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
@@ -2,8 +2,8 @@ import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { StoryFn } from '@storybook/react'
 import { Stack } from '@ultraviolet/ui'
-import { type ComponentProps, useCallback, useState } from 'react'
-import { Navigation, NavigationProvider } from '..'
+import { type ComponentProps, useCallback, useEffect, useState } from 'react'
+import { Navigation, NavigationProvider, useNavigation } from '..'
 import logoSmall from './assets/logo-small.svg'
 import logo from './assets/logo.svg'
 
@@ -45,6 +45,12 @@ type PlaygroundContentProps = ComponentProps<typeof Navigation> & {
 
 const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
   const [active, setActive] = useState('Instance')
+  const { pinnedItems } = useNavigation()
+
+  useEffect(() => {
+    console.log('pinned items:', pinnedItems)
+    localStorage.setItem('pinnedItems', pinnedItems.toString())
+  }, [pinnedItems])
 
   const saveWidthInLocalStorage = useCallback((width: number) => {
     console.log(`width of ${width} saved in local storage`)
@@ -259,6 +265,7 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
 export const Playground: StoryFn<ComponentProps<typeof Navigation>> = props => {
   const navigationExpanded = localStorage.getItem('expanded') === 'true'
   const navigationWidth = Number(localStorage.getItem('width')) || undefined
+  const pinnedItems = localStorage.getItem('pinnedItems')?.split(',') || []
   const [expanded, setExpanded] = useState(navigationExpanded)
   const saveExpandedInLocalStorage = useCallback((localExpanded: boolean) => {
     setExpanded(localExpanded)
@@ -266,6 +273,10 @@ export const Playground: StoryFn<ComponentProps<typeof Navigation>> = props => {
       `expanded state with value ${localExpanded} saved in local storage`,
     )
     localStorage.setItem('expanded', localExpanded.toString())
+  }, [])
+
+  const onClickPinned = useCallback((pinned: string) => {
+    console.log(`You just pinned/unpin "${pinned}"`)
   }, [])
 
   return (
@@ -281,6 +292,8 @@ export const Playground: StoryFn<ComponentProps<typeof Navigation>> = props => {
         onClickExpand={saveExpandedInLocalStorage}
         initialExpanded={navigationExpanded}
         initialWidth={navigationWidth}
+        initialPinned={pinnedItems}
+        onClickPinUnpin={onClickPinned}
         pinnedFeature
       >
         <PlaygroundContent expanded={expanded} {...props} />

--- a/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
+++ b/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
@@ -303,7 +303,8 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
 export const Playground: StoryFn<ComponentProps<typeof Navigation>> = props => {
   const navigationExpanded = localStorage.getItem('expanded') === 'true'
   const navigationWidth = Number(localStorage.getItem('width')) || undefined
-  const pinnedItems = localStorage.getItem('pinnedItems')?.split(',') || []
+  const storageItems = localStorage.getItem('pinnedItems')
+  const pinnedItems = storageItems ? storageItems.split(',') : []
   const [expanded, setExpanded] = useState(navigationExpanded)
   const saveExpandedInLocalStorage = useCallback((localExpanded: boolean) => {
     setExpanded(localExpanded)

--- a/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
+++ b/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
@@ -47,6 +47,8 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
   const [active, setActive] = useState('Instance')
   const { pinnedItems } = useNavigation()
 
+  console.log('active', active)
+
   useEffect(() => {
     console.log('pinned items:', pinnedItems)
     localStorage.setItem('pinnedItems', pinnedItems.toString())
@@ -77,6 +79,7 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
     >
       <Navigation.Item
         label="Organization Dashboard"
+        id="organization-dashboard"
         categoryIcon="console"
         categoryIconVariant="neutral"
         noPinButton
@@ -85,6 +88,7 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
       />
       <Navigation.Item
         label="Project Dashboard"
+        id="project-dashboard"
         categoryIcon="useCase"
         categoryIconVariant="neutral"
         noPinButton
@@ -96,12 +100,14 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
       <Navigation.Group label="Products">
         <Navigation.Item
           label="Compute"
+          id="compute"
           subLabel="All compute ressources"
           categoryIcon="baremetal"
           toggle={false}
         >
           <Navigation.Item
             label="Instance"
+            id="instance"
             badgeText="new"
             badgeSentiment="success"
             active={active === 'Instance'}
@@ -109,18 +115,21 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
           />
           <Navigation.Item
             label="Elastic Metal"
+            id="elastic-metal"
             disabled
             active={active === 'Elastic Metal'}
             onClick={() => setActive('Elastic Metal')}
           />
           <Navigation.Item
             label="Dedibox"
+            id="dedibox"
             href="https://scaleway.com"
             active={active === 'Dedibox'}
             onClick={() => setActive('Dedibox')}
           />
           <Navigation.Item
             label="Very long product name with spaces"
+            id="very-long-product-name-with-spaces"
             badgeText="internal"
             badgeSentiment="danger"
             active={active === 'Very long product name with spaces'}
@@ -128,123 +137,151 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
           />
           <Navigation.Item
             label="Verylongproductnamewithoutspace"
+            id="verylongproductnamewithoutspace"
             badgeText="internal"
             badgeSentiment="danger"
             active={active === 'Verylongproductnamewithoutspace'}
             onClick={() => setActive('Verylongproductnamewithoutspace')}
           />
-          <Navigation.Item label="Advanced">
+          <Navigation.Item id="advanced" label="Advanced">
             <Navigation.Item
               label="Kubernetes"
+              id="kubernetes"
               active={active === 'Kubernetes'}
               onClick={() => setActive('Kubernetes')}
             />
             <Navigation.Item
               label="OpenStack"
+              id="openstack"
               active={active === 'OpenStack'}
               onClick={() => setActive('OpenStack')}
             />
           </Navigation.Item>
         </Navigation.Item>
-        <Navigation.Item label="Storage" categoryIcon="managedServices">
+        <Navigation.Item
+          label="Storage"
+          id="storage"
+          categoryIcon="managedServices"
+        >
           <Navigation.Item
             label="Block Storage"
+            id="block-storage"
             active={active === 'Block Storage'}
             onClick={() => setActive('Block Storage')}
           />
           <Navigation.Item
             label="Object Storage"
+            id="object-storage"
             badgeText="beta"
             badgeSentiment="warning"
             active={active === 'Object Storage'}
             onClick={() => setActive('Object Storage')}
           />
         </Navigation.Item>
-        <Navigation.Item label="Network" categoryIcon="network">
+        <Navigation.Item label="Network" id="network" categoryIcon="network">
           <Navigation.Item
             label="Load Balancer"
+            id="load-balancer"
             active={active === 'Load Balancer'}
             onClick={() => setActive('Load Balancer')}
           />
           <Navigation.Item
             label="IP"
+            id="ip"
             active={active === 'IP'}
             onClick={() => setActive('IP')}
           />
           <Navigation.Item
             label="VPC"
+            id="vpc"
             active={active === 'VPC'}
             onClick={() => setActive('VPC')}
           />
         </Navigation.Item>
-        <Navigation.Item label="Database" categoryIcon="database">
+        <Navigation.Item id="database" label="Database" categoryIcon="database">
           <Navigation.Item
             label="Managed Database"
+            id="managed-database"
             active={active === 'Managed Database'}
             onClick={() => setActive('Managed Database')}
           />
           <Navigation.Item
             label="Redis"
+            id="redis"
             active={active === 'Redis'}
             onClick={() => setActive('Redis')}
           />
           <Navigation.Item
             label="Elasticsearch"
+            id="elasticsearch"
             active={active === 'Elasticsearch'}
             onClick={() => setActive('Elasticsearch')}
           />
         </Navigation.Item>
-        <Navigation.Item label="Monitoring" categoryIcon="observability">
+        <Navigation.Item
+          label="Monitoring"
+          id="monitoring"
+          categoryIcon="observability"
+        >
           <Navigation.Item
             label="Logs"
+            id="logs"
             active={active === 'Logs'}
             onClick={() => setActive('Logs')}
           />
           <Navigation.Item
             label="Metrics"
+            id="metrics"
             active={active === 'Metrics'}
             onClick={() => setActive('Metrics')}
           />
           <Navigation.Item
             label="Alerts"
+            id="alerts"
             active={active === 'Alerts'}
             onClick={() => setActive('Alerts')}
           />
         </Navigation.Item>
-        <Navigation.Item label="Security" categoryIcon="security">
+        <Navigation.Item label="Security" id="security" categoryIcon="security">
           <Navigation.Item
             label="Firewall"
+            id="firewall"
             active={active === 'Firewall'}
             onClick={() => setActive('Firewall')}
           />
           <Navigation.Item
             label="Certificate"
+            id="certificate"
             active={active === 'Certificate'}
             onClick={() => setActive('Certificate')}
           />
           <Navigation.Item
             label="VPN"
+            id="vpn"
             active={active === 'VPN'}
             onClick={() => setActive('VPN')}
           />
         </Navigation.Item>
       </Navigation.Group>
       <Navigation.Separator />
-      <Navigation.Item label="Quick Links" noExpand>
+      <Navigation.Item label="Quick Links" id="quick-links" noExpand>
         <Navigation.Item
           label="Support"
+          id="support"
           noPinButton
           active={active === 'Support'}
           onClick={() => setActive('Support')}
         />
         <Navigation.Item
           label="Abuse"
+          id="abuse"
           noPinButton
           active={active === 'Abuse'}
           onClick={() => setActive('Abuse')}
         />
         <Navigation.Item
           label="Documentation"
+          id="documentation"
           badgeText="new"
           badgeSentiment="success"
           href="http://scaleway.com"
@@ -253,6 +290,7 @@ const PlaygroundContent = ({ expanded, ...props }: PlaygroundContentProps) => {
         />
         <Navigation.Item
           label="Feature Request"
+          id="feature-request"
           href="http://scaleway.com"
           active={active === 'Feature Request'}
           onClick={() => setActive('Feature Request')}

--- a/packages/plus/src/components/Navigation/components/Group.tsx
+++ b/packages/plus/src/components/Navigation/components/Group.tsx
@@ -12,6 +12,7 @@ type GroupProps = {
 
 const StyledText = styled(Text)`
   padding-bottom: ${({ theme }) => theme.space['1']};
+  padding-left: ${({ theme }) => theme.space['1']};
 
   transition:
     opacity ${ANIMATION_DURATION}ms ease-in-out,

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -58,6 +58,7 @@ const ExpandedPinnedButton = styled(Button)`
 const GrabIcon = styled(Icon)`
   opacity: 0;
   margin: 0 ${({ theme }) => theme.space['0.25']};
+  cursor: grab;
 `
 
 // Pin button when the navigation is collapsed
@@ -362,7 +363,9 @@ export const Item = ({
 
   useEffect(
     () => {
-      registerItem({ [id]: { label, active, onClick } })
+      if (type !== 'pinnedGroup') {
+        registerItem({ [id]: { label, active, onClick } })
+      }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [active, id, label, registerItem],
@@ -731,7 +734,6 @@ export const Item = ({
       <StyledMenuItem
         href={href}
         onClick={() => {
-          console.log('clicked', onClick)
           onClick?.()
         }}
         borderless

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -57,6 +57,7 @@ const ExpandedPinnedButton = styled(Button)`
 
 const GrabIcon = styled(Icon)`
   opacity: 0;
+  margin: 0 ${({ theme }) => theme.space['0.25']};
 `
 
 // Pin button when the navigation is collapsed

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -78,11 +78,7 @@ const CollapsedPinnedButton = styled(Button)`
 
 const StyledBadge = styled(Badge)``
 
-const StyledMenuItem = styled(MenuV2.Item, {
-  shouldForwardProp: prop => !['isPinnable'].includes(prop),
-})<{
-  isPinnable?: boolean
-}>`
+const StyledMenuItem = styled(MenuV2.Item)`
   text-align: left;
 
   &:hover {
@@ -91,7 +87,12 @@ const StyledMenuItem = styled(MenuV2.Item, {
     }
 
     ${StyledBadge} {
-      opacity: ${({ isPinnable }) => (isPinnable ? 0 : 1)};
+      &[data-is-pinnable='true'] {
+        opacity: 0;
+      }
+      &[data-is-pinnable='false'] {
+        opacity: 1;
+      }
     }
   }
 `
@@ -670,6 +671,7 @@ export const Item = ({
         {Children.count(children) > 0 ? (
           <StyledMenu
             triggerMethod="hover"
+            dynamicDomRendering={false} // As we parse the children we don't need dynamic rendering
             disclosure={
               <Button
                 sentiment="neutral"
@@ -740,7 +742,7 @@ export const Item = ({
         active={active}
         disabled={disabled}
         sentiment={active ? 'primary' : 'neutral'}
-        isPinnable={shouldShowPinnedButton}
+        data-is-pinnable={shouldShowPinnedButton}
       >
         <Stack
           gap={1}

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -70,29 +70,29 @@ const CollapsedPinnedButton = styled(Button)`
   top: 0;
   bottom: 0;
 
-  &:hover,
-  &:focus {
+  &:hover {
     opacity: 1;
   }
 `
 
 const StyledBadge = styled(Badge)``
 
-const StyledMenuItem = styled(MenuV2.Item)`
+const StyledMenuItem = styled(MenuV2.Item, {
+  shouldForwardProp: prop => !['isPinnable'].includes(prop),
+})<{
+  isPinnable?: boolean
+}>`
   text-align: left;
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &:active {
     ${CollapsedPinnedButton} {
       opacity: 1;
     }
 
     ${StyledBadge} {
-      &[data-is-pinnable='true'] {
-        opacity: 0;
-      }
-      &[data-is-pinnable='false'] {
-        opacity: 1;
-      }
+      opacity: ${({ isPinnable }) => (isPinnable ? 0 : 1)};
     }
   }
 `
@@ -670,7 +670,7 @@ export const Item = ({
       <MenuStack gap={1} alignItems="start" justifyContent="start">
         {Children.count(children) > 0 ? (
           <StyledMenu
-            triggerMethod="hover"
+            triggerMethod="click"
             dynamicDomRendering={false} // As we parse the children we don't need dynamic rendering
             disclosure={
               <Button
@@ -742,7 +742,7 @@ export const Item = ({
         active={active}
         disabled={disabled}
         sentiment={active ? 'primary' : 'neutral'}
-        data-is-pinnable={shouldShowPinnedButton}
+        isPinnable={shouldShowPinnedButton}
       >
         <Stack
           gap={1}
@@ -750,6 +750,7 @@ export const Item = ({
           alignItems="center"
           justifyContent="space-between"
           flex={1}
+          width="100%"
         >
           <WrapText as="span" variant="bodySmall">
             {label}

--- a/packages/plus/src/components/Navigation/components/PinnedItems.tsx
+++ b/packages/plus/src/components/Navigation/components/PinnedItems.tsx
@@ -14,7 +14,7 @@ const DropableArea = styled.div`
   height: 2px;
   border-top: 2px solid;
   border-color: transparent;
-  padding: 4px 0;
+  padding: ${({ theme }) => theme.space['0.5']} 0;
 
   &::before {
     content: '';
@@ -83,8 +83,6 @@ export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
     // eslint-disable-next-line no-param-reassign
     event.currentTarget.style.borderColor = 'transparent'
   }, [])
-
-  console.log('itemssss:', items)
 
   if (Object.keys(items).length === 0) {
     return null

--- a/packages/plus/src/components/Navigation/components/PinnedItems.tsx
+++ b/packages/plus/src/components/Navigation/components/PinnedItems.tsx
@@ -30,6 +30,10 @@ const DropableArea = styled.div`
   }
 `
 
+const RelativeDiv = styled.div`
+  position: relative;
+`
+
 const TextContainer = styled.div`
   padding: ${({ theme }) => theme.space['1']} 0;
   padding-left: ${({ theme }) => theme.space['4']};
@@ -144,13 +148,13 @@ export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
             </TextContainer>
           )}
           {expanded ? (
-            <div style={{ position: 'relative' }}>
+            <RelativeDiv style={{ position: 'relative' }}>
               <DropableArea
                 onDragOver={onDragOver}
                 onDragLeave={onDragLeave}
                 onDrop={event => onDrop(event, pinnedItems.length)}
               />
-            </div>
+            </RelativeDiv>
           ) : null}
         </Item>
       </div>

--- a/packages/plus/src/components/Navigation/components/PinnedItems.tsx
+++ b/packages/plus/src/components/Navigation/components/PinnedItems.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
+import { Text } from '@ultraviolet/ui'
 import type { DragEvent } from 'react'
 import { useCallback } from 'react'
 import { useNavigation } from '../NavigationProvider'
@@ -27,6 +28,12 @@ const DropableArea = styled.div`
     border-color: inherit;
     border-radius: ${({ theme }) => theme.radii.circle};
   }
+`
+
+const TextContainer = styled.div`
+  padding: ${({ theme }) => theme.space['1']} 0;
+  padding-left: ${({ theme }) => theme.space['4']};
+  margin-left: ${({ theme }) => theme.space['0.5']};
 `
 
 type PinnedItemsProps = {
@@ -88,7 +95,7 @@ export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
     return null
   }
 
-  if (pinnedItems.length > 0 && pinnedFeature) {
+  if (pinnedFeature) {
     return (
       <div>
         <Item
@@ -99,30 +106,43 @@ export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
           type="pinnedGroup"
           id="pinned-group"
         >
-          {pinnedItems.map((itemId, index) => (
-            <div
-              style={{ position: expanded ? 'relative' : undefined }}
-              key={itemId}
-            >
-              {expanded ? (
-                <DropableArea
-                  onDragOver={onDragOver}
-                  onDragLeave={onDragLeave}
-                  onDrop={event => onDrop(event, index)}
+          {pinnedItems.length > 0 ? (
+            pinnedItems.map((itemId, index) => (
+              <div
+                style={{ position: expanded ? 'relative' : undefined }}
+                key={itemId}
+              >
+                {expanded ? (
+                  <DropableArea
+                    onDragOver={onDragOver}
+                    onDragLeave={onDragLeave}
+                    onDrop={event => onDrop(event, index)}
+                  />
+                ) : null}
+                <Item
+                  label={items[itemId]?.label ?? 'Unknown navigation item'}
+                  type="pinned"
+                  index={index}
+                  toggle={toggle}
+                  id={itemId}
+                  active={items[itemId]?.active ?? false}
+                  onClick={items[itemId]?.onClick ?? undefined}
+                  hasParents
                 />
-              ) : null}
-              <Item
-                label={items[itemId]?.label ?? 'Unknown navigation item'}
-                type="pinned"
-                index={index}
-                toggle={toggle}
-                id={itemId}
-                active={items[itemId]?.active ?? false}
-                onClick={items[itemId]?.onClick ?? undefined}
-                hasParents
-              />
-            </div>
-          ))}
+              </div>
+            ))
+          ) : (
+            <TextContainer>
+              <Text
+                as="p"
+                variant="caption"
+                prominence="weak"
+                sentiment="neutral"
+              >
+                {locales['navigation.pinned.item.group.empty']}
+              </Text>
+            </TextContainer>
+          )}
           {expanded ? (
             <div style={{ position: 'relative' }}>
               <DropableArea

--- a/packages/plus/src/components/Navigation/components/PinnedItems.tsx
+++ b/packages/plus/src/components/Navigation/components/PinnedItems.tsx
@@ -45,7 +45,7 @@ export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
     )
   }
 
-  const { locales, pinnedItems, pinnedFeature, reorderItems, expanded } =
+  const { locales, pinnedItems, pinnedFeature, reorderItems, expanded, items } =
     context
   const theme = useTheme()
 
@@ -84,34 +84,48 @@ export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
     event.currentTarget.style.borderColor = 'transparent'
   }, [])
 
-  console.log(expanded)
+  console.log('itemssss:', items)
+
+  if (Object.keys(items).length === 0) {
+    return null
+  }
 
   if (pinnedItems.length > 0 && pinnedFeature) {
-    if (expanded) {
-      return (
-        <div>
-          <Item
-            label={locales['navigation.pinned.item.group.label']}
-            categoryIcon="pin"
-            categoryIconVariant="neutral"
-            toggle={toggle}
-            type="pinnedGroup"
-          >
-            {pinnedItems.map((item, index) => (
-              <div style={{ position: 'relative' }} key={item}>
+    return (
+      <div>
+        <Item
+          label={locales['navigation.pinned.item.group.label']}
+          categoryIcon="pin"
+          categoryIconVariant="neutral"
+          toggle={toggle}
+          type="pinnedGroup"
+          id="pinned-group"
+        >
+          {pinnedItems.map((itemId, index) => (
+            <div
+              style={{ position: expanded ? 'relative' : undefined }}
+              key={itemId}
+            >
+              {expanded ? (
                 <DropableArea
                   onDragOver={onDragOver}
                   onDragLeave={onDragLeave}
                   onDrop={event => onDrop(event, index)}
                 />
-                <Item
-                  label={item}
-                  type="pinned"
-                  index={index}
-                  toggle={toggle}
-                />
-              </div>
-            ))}
+              ) : null}
+              <Item
+                label={items[itemId]?.label ?? 'Unknown navigation item'}
+                type="pinned"
+                index={index}
+                toggle={toggle}
+                id={itemId}
+                active={items[itemId]?.active ?? false}
+                onClick={items[itemId]?.onClick ?? undefined}
+                hasParents
+              />
+            </div>
+          ))}
+          {expanded ? (
             <div style={{ position: 'relative' }}>
               <DropableArea
                 onDragOver={onDragOver}
@@ -119,24 +133,7 @@ export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
                 onDrop={event => onDrop(event, pinnedItems.length)}
               />
             </div>
-          </Item>
-        </div>
-      )
-    }
-
-    return (
-      <div>
-        <Item
-          label={locales['navigation.pinned.item.group.label']}
-          categoryIcon="pin"
-          categoryIconVariant="neutral"
-          type="pinnedGroup"
-        >
-          {pinnedItems.map((item, index) => (
-            <div style={{ position: 'relative' }} key={item}>
-              <Item label={item} type="pinned" index={index} hasParents />
-            </div>
-          ))}
+          ) : null}
         </Item>
       </div>
     )

--- a/packages/plus/src/components/Navigation/components/PinnedItems.tsx
+++ b/packages/plus/src/components/Navigation/components/PinnedItems.tsx
@@ -1,7 +1,42 @@
+import { useTheme } from '@emotion/react'
+import styled from '@emotion/styled'
+import type { DragEvent } from 'react'
+import { useCallback } from 'react'
 import { useNavigation } from '../NavigationProvider'
+import type { DragNDropData } from '../constants'
 import { Item } from './Item'
 
-export const PinnedItems = () => {
+const DropableArea = styled.div`
+  position: absolute;
+  right: 0;
+  left: 0;
+  top: 0;
+  height: 2px;
+  border-top: 2px solid;
+  border-color: transparent;
+  padding: 4px 0;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: -4px;
+    height: 0px;
+    width: 0px;
+    border: 3px solid;
+    border-color: inherit;
+    border-radius: ${({ theme }) => theme.radii.circle};
+  }
+`
+
+type PinnedItemsProps = {
+  /**
+   * This prop is used to control if the item is expanded or collapsed
+   */
+  toggle?: boolean
+}
+
+export const PinnedItems = ({ toggle = true }: PinnedItemsProps) => {
   const context = useNavigation()
 
   if (!context) {
@@ -10,20 +45,100 @@ export const PinnedItems = () => {
     )
   }
 
-  const { locales, pinnedItems, pinnedFeature } = context
+  const { locales, pinnedItems, pinnedFeature, reorderItems, expanded } =
+    context
+  const theme = useTheme()
+
+  const onDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>, index: number) => {
+      event.preventDefault()
+      if (event?.dataTransfer) {
+        // eslint-disable-next-line no-param-reassign
+        event.currentTarget.style.borderColor = 'transparent'
+        const data = JSON.parse(
+          event.dataTransfer.getData('text'),
+        ) as DragNDropData
+        if (data.index === index - 1 || index > data.index) {
+          reorderItems(data.index, index - 1)
+
+          return
+        }
+        reorderItems(data.index, index)
+      }
+    },
+    [reorderItems],
+  )
+
+  const onDragOver = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      // eslint-disable-next-line no-param-reassign
+      event.currentTarget.style.borderColor = theme.colors.primary.border
+    },
+    [theme.colors.primary.border],
+  )
+
+  const onDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    // eslint-disable-next-line no-param-reassign
+    event.currentTarget.style.borderColor = 'transparent'
+  }, [])
+
+  console.log(expanded)
 
   if (pinnedItems.length > 0 && pinnedFeature) {
+    if (expanded) {
+      return (
+        <div>
+          <Item
+            label={locales['navigation.pinned.item.group.label']}
+            categoryIcon="pin"
+            categoryIconVariant="neutral"
+            toggle={toggle}
+            type="pinnedGroup"
+          >
+            {pinnedItems.map((item, index) => (
+              <div style={{ position: 'relative' }} key={item}>
+                <DropableArea
+                  onDragOver={onDragOver}
+                  onDragLeave={onDragLeave}
+                  onDrop={event => onDrop(event, index)}
+                />
+                <Item
+                  label={item}
+                  type="pinned"
+                  index={index}
+                  toggle={toggle}
+                />
+              </div>
+            ))}
+            <div style={{ position: 'relative' }}>
+              <DropableArea
+                onDragOver={onDragOver}
+                onDragLeave={onDragLeave}
+                onDrop={event => onDrop(event, pinnedItems.length)}
+              />
+            </div>
+          </Item>
+        </div>
+      )
+    }
+
     return (
-      <Item
-        label={locales['navigation.pinned.item.group.label']}
-        categoryIcon="pin"
-        toggle={false}
-        type="pinnedGroup"
-      >
-        {pinnedItems.map(item => (
-          <Item key={item} label={item} type="pinned" />
-        ))}
-      </Item>
+      <div>
+        <Item
+          label={locales['navigation.pinned.item.group.label']}
+          categoryIcon="pin"
+          categoryIconVariant="neutral"
+          type="pinnedGroup"
+        >
+          {pinnedItems.map((item, index) => (
+            <div style={{ position: 'relative' }} key={item}>
+              <Item label={item} type="pinned" index={index} hasParents />
+            </div>
+          ))}
+        </Item>
+      </div>
     )
   }
 

--- a/packages/plus/src/components/Navigation/constants.ts
+++ b/packages/plus/src/components/Navigation/constants.ts
@@ -8,7 +8,6 @@ export const NAVIGATION_MAX_WIDTH = 320 // in px
 /**
  * ANIMATIONS
  */
-export const PIN_BUTTON_OPACITY_TRANSITION = 'opacity 250ms ease-in-out' // this is the transition animation when hovering pin button
 export const ANIMATION_DURATION = 700 // collapse and expand animation duration of the whole nav in ms
 
 export const shrinkHeight = keyframes`
@@ -34,3 +33,8 @@ export const groupAnimation = keyframes`
     margin-bottom: 0;
   }
 `
+
+export type DragNDropData = {
+  index: number
+  item: string
+}

--- a/packages/plus/src/components/Navigation/locales/en.ts
+++ b/packages/plus/src/components/Navigation/locales/en.ts
@@ -5,4 +5,5 @@ export default {
   'navigation.pinned.item.group.label': 'Pinned items',
   'navigation.expand.button': 'Expand sidebar',
   'navigation.collapse.button': 'Collapse sidebar',
+  'navigation.pinned.item.group.empty': 'You have no pinned items.',
 } as const

--- a/packages/plus/src/components/Navigation/locales/en.ts
+++ b/packages/plus/src/components/Navigation/locales/en.ts
@@ -1,6 +1,7 @@
 export default {
   'navigation.pin.tooltip': 'Pin product',
   'navigation.unpin.tooltip': 'Unpin product',
+  'navigation.pin.limit': 'You cannot pin more products',
   'navigation.pinned.item.group.label': 'Pinned items',
   'navigation.expand.button': 'Expand sidebar',
   'navigation.collapse.button': 'Collapse sidebar',


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Introducing pin feature on Navigation ✨

Navigation is nice for traveling around in your website but it lacked some customization. Pinned feature is here to overcome this issue and provide a new way to customize your navigation. This feature can be enabled adding `pinnedFeature` on your `<NavigationProvider />`

![Screen Recording 2024-04-26 at 17 55 32](https://github.com/scaleway/ultraviolet/assets/15812968/46b54572-d82a-48cb-9f53-fa31f896407e)

Pinned feature allows you to pin / unpin your favorite items until it reach the limit you've set using `pinLimit` on your `<NavigationProvider />`.
It also allows you to re-order your pinned items by using drag n drop and placing it in the order you like.

All your pinned items can be accessed with the hook `useNavigation()`:

```tsx
// pinnedItems = ['myitem1', 'myitem2']
const { pinnedItems } = useNavigation()

// Save in local storage to keep the pinned items on refresh
useEffect(() => {
   localStorage.setItem('pinnedItems', pinnedItems.toString())
}, [pinnedItems])
```

You can of course provide your initially pinned items to the `<NavigationProvider />` by using the prop `initialPinned`.
