### PR TITLE
fix(SelectInputV2): use string or string[] as value prop instead of w…

### DIFF
--- a/.changeset/fluffy-windows-dance.md
+++ b/.changeset/fluffy-windows-dance.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+fix(SelectInputV2): pass string or string[] for values instead of an option (more compliant to native select tag). component is now controllable

--- a/.changeset/fluffy-windows-dance.md
+++ b/.changeset/fluffy-windows-dance.md
@@ -2,4 +2,4 @@
 "@ultraviolet/ui": minor
 ---
 
-fix(SelectInputV2): pass string or string[] for values instead of an option (more compliant to native select tag). component is now controllable
+Fix <SelectInputV2 /> component to pass string or string[] for values instead of an option (more compliant to native select tag). component is now controllable

--- a/.changeset/real-turtles-shop.md
+++ b/.changeset/real-turtles-shop.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": minor
+---
+
+fix(SelectInputV2Field): send good value to SelectInputV2

--- a/packages/form/src/components/SelectInputFieldV2/__stories__/Multiple.stories.tsx
+++ b/packages/form/src/components/SelectInputFieldV2/__stories__/Multiple.stories.tsx
@@ -5,4 +5,14 @@ import { planets } from './resources'
 
 export const Multiple: StoryFn<
   ComponentProps<typeof SelectInputFieldV2>
-> = () => <SelectInputFieldV2 name="options" multiselect options={planets} />
+> = () => (
+  <SelectInputFieldV2
+    selectAllGroup
+    selectAll={{
+      label: 'Select all',
+    }}
+    name="options"
+    multiselect
+    options={planets}
+  />
+)

--- a/packages/form/src/components/SelectInputFieldV2/index.tsx
+++ b/packages/form/src/components/SelectInputFieldV2/index.tsx
@@ -1,5 +1,5 @@
 import { SelectInputV2 } from '@ultraviolet/ui'
-import { type ComponentProps, useCallback } from 'react'
+import type { ComponentProps } from 'react'
 import type { FieldPath, FieldValues } from 'react-hook-form'
 import { useController } from 'react-hook-form'
 import { useErrors } from '../../providers'
@@ -94,25 +94,6 @@ export const SelectInputFieldV2 = <
   })
 
   const { getError } = useErrors()
-  const format = useCallback(
-    (val: unknown) => {
-      if (!Array.isArray(options)) {
-        let formattedValue
-        Object.keys(options).forEach(group =>
-          options[group].forEach(option => {
-            if (option.value === val) {
-              formattedValue = option
-            }
-          }),
-        )
-
-        return formattedValue
-      }
-
-      return options.find(option => option.value === val)
-    },
-    [options],
-  )
 
   return (
     <SelectInputV2
@@ -132,7 +113,7 @@ export const SelectInputFieldV2 = <
       }}
       placeholder={placeholder}
       readOnly={readOnly}
-      value={format(field.value)}
+      value={field.value}
       placeholderSearch={placeholderSearch}
       helper={helper}
       emptyState={emptyState}

--- a/packages/ui/src/components/SelectInputV2/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/Dropdown.tsx
@@ -112,7 +112,7 @@ const DropdownItem = styled.button<{
   padding: ${({ theme }) => theme.space['1.5']} ${({ theme }) => theme.space['2']} ${({ theme }) => theme.space['1.5']} ${({ theme }) => theme.space['2']};
   margin-left: ${({ theme }) => theme.space['0.5']};
   margin-right: ${({ theme }) => theme.space['0.5']};
-  
+
   color:  ${({ theme }) => theme.colors.neutral.text};
   border-radius: ${({ theme }) => theme.radii.default};
 
@@ -120,7 +120,7 @@ const DropdownItem = styled.button<{
     background-color: ${({ theme }) => theme.colors.primary.background};
     color: ${({ theme }) => theme.colors.primary.text};
     cursor: pointer;
-    outline: none; 
+    outline: none;
   }
 
   &[data-selected='true'] {
@@ -139,7 +139,7 @@ const DropdownItem = styled.button<{
     cursor: not-allowed;
     outline: none;
   }
-  
+
   }
 `
 const PopupFooter = styled.div`
@@ -310,18 +310,14 @@ const CreateDropdown = ({
   const handleClick = (clickedOption: OptionType, group?: string) => {
     setSelectedData({ type: 'selectOption', clickedOption, group })
     if (multiselect) {
-      if (selectedData.selectedValues.includes(clickedOption)) {
+      if (selectedData.selectedValues.includes(clickedOption.value)) {
         onChange?.(
-          selectedData.selectedValues
-            .filter(val => val !== clickedOption)
-            .map(val => val?.value),
-        )
-      } else {
-        onChange?.(
-          [...selectedData.selectedValues, clickedOption].map(
-            val => val?.value,
+          selectedData.selectedValues.filter(
+            val => val !== clickedOption.value,
           ),
         )
+      } else {
+        onChange?.([...selectedData.selectedValues, clickedOption.value])
       }
     } else {
       onChange?.([clickedOption.value])
@@ -358,18 +354,19 @@ const CreateDropdown = ({
     if (!Array.isArray(options)) {
       if (selectedData.selectedGroups.includes(group)) {
         const newSelectedValues = [...selectedData.selectedValues].filter(
-          selectedValue => !options[group].includes(selectedValue),
+          selectedValue =>
+            !options[group].find(option => option.value === selectedValue),
         )
-        onChange?.(newSelectedValues.map(value => value.value))
+        onChange?.(newSelectedValues)
       } else {
         const newSelectedValues = [...selectedData.selectedValues]
 
         options[group].map(option =>
-          newSelectedValues.includes(option) || option.disabled
+          newSelectedValues.includes(option.value) || option.disabled
             ? null
-            : newSelectedValues.push(option),
+            : newSelectedValues.push(option.value),
         )
-        onChange?.(newSelectedValues.map(value => value.value))
+        onChange?.(newSelectedValues)
       }
     }
   }
@@ -473,7 +470,7 @@ const CreateDropdown = ({
                     key={option.value}
                     disabled={option.disabled}
                     data-selected={
-                      selectedData.selectedValues.includes(option) &&
+                      selectedData.selectedValues.includes(option.value) &&
                       !option.disabled
                     }
                     aria-label={option.value}
@@ -500,7 +497,7 @@ const CreateDropdown = ({
                     {multiselect ? (
                       <StyledCheckbox
                         checked={
-                          selectedData.selectedValues.includes(option) &&
+                          selectedData.selectedValues.includes(option.value) &&
                           !option.disabled
                         }
                         disabled={option.disabled}
@@ -587,7 +584,8 @@ const CreateDropdown = ({
               key={option.value}
               disabled={option.disabled}
               data-selected={
-                selectedData.selectedValues.includes(option) && !option.disabled
+                selectedData.selectedValues.includes(option.value) &&
+                !option.disabled
               }
               onClick={() => {
                 if (!option.disabled) {
@@ -611,7 +609,7 @@ const CreateDropdown = ({
               {multiselect ? (
                 <StyledCheckbox
                   checked={
-                    selectedData.selectedValues.includes(option) &&
+                    selectedData.selectedValues.includes(option.value) &&
                     !option.disabled
                   }
                   disabled={option.disabled}

--- a/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
@@ -115,11 +115,9 @@ export const SearchBarDropdown = ({
               : undefined,
           })
           onChange?.(
-            selectedData.selectedValues.includes(closestOption)
-              ? selectedData.selectedValues.map(val => val?.value)
-              : [...selectedData.selectedValues, closestOption].map(
-                  val => val?.value,
-                ),
+            selectedData.selectedValues.includes(closestOption.value)
+              ? selectedData.selectedValues
+              : [...selectedData.selectedValues, closestOption.value],
           )
           setSearchInput(closestOption.searchText ?? closestOption.value)
         } else {
@@ -127,7 +125,7 @@ export const SearchBarDropdown = ({
             type: 'selectOption',
             clickedOption: closestOption,
           })
-          onChange?.(selectedData.selectedValues.map(val => val?.value))
+          onChange?.(selectedData.selectedValues)
         }
       }
     }

--- a/packages/ui/src/components/SelectInputV2/__stories__/Multiselect.stories.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/Multiselect.stories.tsx
@@ -7,7 +7,7 @@ Multiselect.args = {
   ...Template.args,
   options: dataGrouped,
   multiselect: true,
-  value: dataGrouped['terrestrial planets'][4],
+  value: dataGrouped['terrestrial planets'][4].value,
 }
 Multiselect.decorators = [
   StoryComponent => (

--- a/packages/ui/src/components/SelectInputV2/__stories__/Multiselect.stories.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/Multiselect.stories.tsx
@@ -7,7 +7,7 @@ Multiselect.args = {
   ...Template.args,
   options: dataGrouped,
   multiselect: true,
-  value: dataGrouped['terrestrial planets'][4].value,
+  value: [dataGrouped['terrestrial planets'][4].value],
 }
 Multiselect.decorators = [
   StoryComponent => (

--- a/packages/ui/src/components/SelectInputV2/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectInputV2/__tests__/index.test.tsx
@@ -132,7 +132,7 @@ describe('SelectInputV2', () => {
         options={dataGrouped}
         placeholder="placeholder"
         placeholderSearch="placeholdersearch"
-        value={dataGrouped['terrestrial planets'][4].value}
+        value={[dataGrouped['terrestrial planets'][4].value]}
         multiselect
       />,
       {

--- a/packages/ui/src/components/SelectInputV2/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectInputV2/__tests__/index.test.tsx
@@ -59,7 +59,7 @@ describe('SelectInputV2', () => {
         placeholderSearch="placeholdersearch"
         clearable={false}
         searchable={false}
-        value={dataUnGrouped[4]}
+        value={dataUnGrouped[4].value}
       />,
     ))
   test('renders correctly ungrouped', () =>
@@ -99,7 +99,7 @@ describe('SelectInputV2', () => {
         options={dataGrouped}
         placeholder="placeholder"
         placeholderSearch="placeholdersearch"
-        value={dataGrouped['terrestrial planets'][4]}
+        value={dataGrouped['terrestrial planets'][4].value}
       />,
       {
         transform: async () => {
@@ -115,7 +115,7 @@ describe('SelectInputV2', () => {
         options={dataGrouped}
         placeholder="placeholder"
         placeholderSearch="placeholdersearch"
-        value={dataGrouped['terrestrial planets'][4]}
+        value={dataGrouped['terrestrial planets'][4].value}
         footer="this is a footer"
       />,
       {
@@ -132,7 +132,7 @@ describe('SelectInputV2', () => {
         options={dataGrouped}
         placeholder="placeholder"
         placeholderSearch="placeholdersearch"
-        value={dataGrouped['terrestrial planets'][4]}
+        value={dataGrouped['terrestrial planets'][4].value}
         multiselect
       />,
       {
@@ -390,7 +390,7 @@ describe('SelectInputV2', () => {
         placeholderSearch="placeholdersearch"
         searchable={false}
         multiselect
-        value={dataUnGrouped[1]}
+        value={[dataUnGrouped[1].value]}
         onChange={() => {}}
       />,
     )
@@ -409,7 +409,7 @@ describe('SelectInputV2', () => {
         placeholderSearch="placeholdersearch"
         searchable={false}
         multiselect
-        value={dataUnGrouped[1]}
+        value={[dataUnGrouped[1].value]}
         onChange={() => {}}
       />,
     ))
@@ -493,7 +493,7 @@ describe('SelectInputV2', () => {
         placeholder="placeholder"
         placeholderSearch="placeholdersearch"
         searchable={false}
-        value={dataUnGrouped[4]}
+        value={dataUnGrouped[4].value}
       />,
     )
     const clearAll = screen.getByTestId('clear-all')
@@ -789,7 +789,7 @@ describe('SelectInputV2', () => {
         options={dataGrouped}
         multiselect
         placeholder="placeholder"
-        value={dataGrouped['jovian planets'][1]}
+        value={[dataGrouped['jovian planets'][1].value]}
         onChange={(values: (string | undefined)[]) => values}
         optionalInfoPlacement="left"
         descriptionDirection="column"

--- a/packages/ui/src/components/SelectInputV2/findOptionInOptions.ts
+++ b/packages/ui/src/components/SelectInputV2/findOptionInOptions.ts
@@ -1,0 +1,14 @@
+import type { DataType, OptionType } from './types'
+
+export const findOptionInOptions = (options: DataType, optionValue: string) => {
+  let flatOptions: OptionType[] = []
+  if (!Array.isArray(options)) {
+    flatOptions = Object.keys(options)
+      .map(group => options[group])
+      .flat()
+  } else {
+    flatOptions = options
+  }
+
+  return flatOptions.find(option => option.value === optionValue)
+}

--- a/packages/ui/src/components/SelectInputV2/index.tsx
+++ b/packages/ui/src/components/SelectInputV2/index.tsx
@@ -7,7 +7,7 @@ import { Text } from '../Text'
 import { Dropdown } from './Dropdown'
 import { SelectBar } from './SelectBar'
 import { SelectInputProvider } from './SelectInputProvider'
-import type { DataType, OptionType } from './types'
+import type { DataType } from './types'
 
 type SelectInputV2Props = {
   /**
@@ -17,7 +17,7 @@ type SelectInputV2Props = {
   /**
    * Default value, must be one of the options
    */
-  value?: OptionType
+  value?: string | string[]
   /**
    * Place holder when no value defined
    */

--- a/packages/ui/src/components/SelectInputV2/index.tsx
+++ b/packages/ui/src/components/SelectInputV2/index.tsx
@@ -15,10 +15,6 @@ type SelectInputV2Props = {
    */
   name: string
   /**
-   * Default value, must be one of the options
-   */
-  value?: string | string[]
-  /**
    * Place holder when no value defined
    */
   placeholder?: string
@@ -62,10 +58,6 @@ type SelectInputV2Props = {
    * Size of the input
    */
   size?: 'small' | 'medium' | 'large'
-  /**
-   * Whether it is possible to select multiple options
-   */
-  multiselect?: boolean
   /**
    * Whether field is required
    */
@@ -116,7 +108,29 @@ type SelectInputV2Props = {
 } & Pick<
   HTMLAttributes<HTMLDivElement>,
   'id' | 'onBlur' | 'onFocus' | 'aria-label' | 'className'
->
+> &
+  (
+    | {
+        /**
+         * Whether it is possible to select multiple options
+         */
+        multiselect: true
+        /**
+         * Default value, must be one of the options
+         */
+        value?: string[]
+      }
+    | {
+        /**
+         * Whether it is possible to select multiple options
+         */
+        multiselect?: false | undefined
+        /**
+         * Default value, must be one of the options
+         */
+        value?: string
+      }
+  )
 
 const SelectInputContainer = styled.div`
   width: 100%;

--- a/packages/ui/src/components/SelectInputV2/types.ts
+++ b/packages/ui/src/components/SelectInputV2/types.ts
@@ -12,7 +12,7 @@ export type OptionType = {
 export type DataType = Record<string, OptionType[]> | OptionType[]
 
 export type ReducerState = {
-  selectedValues: OptionType[]
+  selectedValues: string[]
   allSelected: boolean
   selectedGroups: string[]
 }


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Instead of passing a whole option as value prop we can pass string or string[] and it affect the SelectInput component. It makes the component more easy to use and compliant with basic select tags.

#### The following changes where made:

1. Change all checking type, includes, ... by OptionType to string

2. Add some props on SelectInputFieldV2 story to test it 

3. Remove format function in SelectInputFieldV2 because we dont need it
