### PR TITLE
feat(EstimateCost): add on total price change providing total and total max

### DIFF
--- a/.changeset/silly-chairs-do.md
+++ b/.changeset/silly-chairs-do.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": minor
+---
+
+Add `onTotalPriceChange` prop on `<EstimateCost />` this function will provide `total` and `totalMax when the total price is re-computed allowing users to get that value.`

--- a/packages/plus/src/components/EstimateCost/EstimateCost.tsx
+++ b/packages/plus/src/components/EstimateCost/EstimateCost.tsx
@@ -49,6 +49,7 @@ const EstimateCost = ({
   locales = EstimateCostLocales,
   numberLocales = 'en-EN',
   currency = 'EUR',
+  onTotalPriceChange,
 }: EstimateCostProps) => (
   <EstimateCostProvider
     locales={locales}
@@ -79,6 +80,7 @@ const EstimateCost = ({
       overlayUnit={overlayUnit}
       locales={locales}
       overlayMargin={overlayMargin}
+      onTotalPriceChange={onTotalPriceChange}
     >
       {children}
     </EstimateCostContent>

--- a/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
+++ b/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
@@ -118,6 +118,7 @@ export const EstimateCostContent = ({
   children = null,
   locales = EstimateCostLocales,
   overlayMargin,
+  onTotalPriceChange,
 }: EstimateCostProps) => {
   const { formatNumber } = useEstimateCost()
   const [ref, inView] = useInView()
@@ -137,6 +138,26 @@ export const EstimateCostContent = ({
 
   const [isLongFractionDigits, setIsLongFractionDigits] = useState(false)
   const providerValue = useMemo(() => ({ isOverlay: false }), [])
+
+  const totalValue = useMemo(
+    () =>
+      formatNumber(totalPrice.total, {
+        maximumFractionDigits: isLongFractionDigits
+          ? maximumFractionDigitsLong[iteration.unit]
+          : maximumFractionDigits[iteration.unit],
+      }),
+    [formatNumber, isLongFractionDigits, iteration.unit, totalPrice.total],
+  )
+
+  const totalMaxValue = useMemo(
+    () =>
+      formatNumber(totalPrice.maxTotal, {
+        maximumFractionDigits: isLongFractionDigits
+          ? maximumFractionDigitsLong[iteration.unit]
+          : maximumFractionDigits[iteration.unit],
+      }),
+    [formatNumber, isLongFractionDigits, iteration.unit, totalPrice.maxTotal],
+  )
 
   const productsCallback = useMemo(
     () => ({
@@ -238,7 +259,21 @@ export const EstimateCostContent = ({
           )
         : 0,
     })
-  }, [hideTotal, products, iteration, setTotalPrice])
+    onTotalPriceChange?.({
+      total: totalPrice.total,
+      totalMax: totalPrice.maxTotal > 0 ? totalPrice.maxTotal : undefined,
+    })
+  }, [
+    hideTotal,
+    products,
+    iteration,
+    setTotalPrice,
+    onTotalPriceChange,
+    totalPrice.total,
+    totalPrice.maxTotal,
+    totalValue,
+    totalMaxValue,
+  ])
 
   useEffect(() => {
     if (
@@ -390,18 +425,8 @@ export const EstimateCostContent = ({
                       <LineThrough
                         isActive={isBeta && (discount === 0 || discount >= 1)}
                       >
-                        {formatNumber(totalPrice.total, {
-                          maximumFractionDigits: isLongFractionDigits
-                            ? maximumFractionDigitsLong[iteration.unit]
-                            : maximumFractionDigits[iteration.unit],
-                        })}
-                        {totalPrice.maxTotal > 0
-                          ? ` - ${formatNumber(totalPrice.maxTotal, {
-                              maximumFractionDigits: isLongFractionDigits
-                                ? maximumFractionDigitsLong[iteration.unit]
-                                : maximumFractionDigits[iteration.unit],
-                            })}`
-                          : null}
+                        {totalValue}
+                        {totalPrice.maxTotal > 0 ? ` - ${totalMaxValue}` : null}
                       </LineThrough>
                     </StyledText>
                     {hideHourlyPriceOnTotal &&

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
@@ -2117,7 +2117,7 @@ exports[`EstimateCost - Regular Item render basic props with is not defined 1`] 
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r2s:"
+                          for=":r31:"
                         >
                           Select...
                         </label>
@@ -2139,7 +2139,7 @@ exports[`EstimateCost - Regular Item render basic props with is not defined 1`] 
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r2s:"
+                            id=":r31:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -3270,7 +3270,7 @@ exports[`EstimateCost - Regular Item render basic props with long fractions digi
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r1p:"
+                          for=":r1r:"
                         >
                           Select...
                         </label>
@@ -3292,7 +3292,7 @@ exports[`EstimateCost - Regular Item render basic props with long fractions digi
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r1p:"
+                            id=":r1r:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -4439,7 +4439,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r2g:"
+                          for=":r2k:"
                         >
                           Select...
                         </label>
@@ -4461,7 +4461,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r2g:"
+                            id=":r2k:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -5613,7 +5613,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice and longFr
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r24:"
+                          for=":r27:"
                         >
                           Select...
                         </label>
@@ -5635,7 +5635,7 @@ exports[`EstimateCost - Regular Item render basic props with maxPrice and longFr
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r24:"
+                            id=":r27:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -9489,7 +9489,7 @@ exports[`EstimateCost - Regular Item render basic props with sublabel 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r37:"
+                          for=":r3c:"
                         >
                           Select...
                         </label>
@@ -9511,7 +9511,7 @@ exports[`EstimateCost - Regular Item render basic props with sublabel 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r37:"
+                            id=":r3c:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -10651,7 +10651,7 @@ exports[`EstimateCost - Regular Item render basic props with textNotDefined 1`] 
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r3j:"
+                          for=":r3o:"
                         >
                           Select...
                         </label>
@@ -10673,7 +10673,7 @@ exports[`EstimateCost - Regular Item render basic props with textNotDefined 1`] 
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r3j:"
+                            id=":r3o:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -11844,7 +11844,7 @@ exports[`EstimateCost - Regular Item render basic with ellipsis 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r3v:"
+                          for=":r44:"
                         >
                           Select...
                         </label>
@@ -11866,7 +11866,7 @@ exports[`EstimateCost - Regular Item render basic with ellipsis 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r3v:"
+                            id=":r44:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -13178,7 +13178,7 @@ exports[`EstimateCost - Regular Item render with alert 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r4r:"
+                          for=":r50:"
                         >
                           Select...
                         </label>
@@ -13200,7 +13200,7 @@ exports[`EstimateCost - Regular Item render with alert 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r4r:"
+                            id=":r50:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -14314,7 +14314,7 @@ exports[`EstimateCost - Regular Item render with isDisabledOnOverlay 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r4e:"
+                          for=":r4j:"
                         >
                           Select...
                         </label>
@@ -14336,7 +14336,7 @@ exports[`EstimateCost - Regular Item render with isDisabledOnOverlay 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r4e:"
+                            id=":r4j:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -4177,7 +4177,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r1i:"
+                          for=":r1j:"
                         >
                           Select...
                         </label>
@@ -4199,7 +4199,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r1i:"
+                            id=":r1j:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -4320,7 +4320,7 @@ exports[`EstimateCost - NumberInput Item render with getAmountValue 1`] = `
                             class="cache-h5mwdc-Input e1b9qdjy1"
                             data-has-unit="false"
                             data-size="small"
-                            id=":r1l:"
+                            id=":r1m:"
                             max="100"
                             min="0"
                             placeholder=""

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.test.tsx.snap
@@ -1106,7 +1106,7 @@ exports[`EstimateCost - index render isBeta with discount 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":rh:"
+                          for=":ri:"
                         >
                           Select...
                         </label>
@@ -1128,7 +1128,7 @@ exports[`EstimateCost - index render isBeta with discount 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":rh:"
+                            id=":ri:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -2386,7 +2386,7 @@ exports[`EstimateCost - index render isBeta with discount equal to 100% 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r1b:"
+                          for=":r1d:"
                         >
                           Select...
                         </label>
@@ -2408,7 +2408,7 @@ exports[`EstimateCost - index render isBeta with discount equal to 100% 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r1b:"
+                            id=":r1d:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -3666,7 +3666,7 @@ exports[`EstimateCost - index render isBeta with discount more than 100% 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":ru:"
+                          for=":r10:"
                         >
                           Select...
                         </label>
@@ -3688,7 +3688,7 @@ exports[`EstimateCost - index render isBeta with discount more than 100% 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":ru:"
+                            id=":r10:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -6133,7 +6133,7 @@ exports[`EstimateCost - index render with all timeUnits values 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r42:"
+                          for=":r4a:"
                         >
                           Select...
                         </label>
@@ -6155,7 +6155,7 @@ exports[`EstimateCost - index render with all timeUnits values 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r42:"
+                            id=":r4a:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -7305,7 +7305,7 @@ exports[`EstimateCost - index render with commitmentFees 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r79:"
+                          for=":r7m:"
                         >
                           Select...
                         </label>
@@ -7327,7 +7327,7 @@ exports[`EstimateCost - index render with commitmentFees 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r79:"
+                            id=":r7m:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -8493,7 +8493,7 @@ exports[`EstimateCost - index render with commitmentFees and iscommitmentFeesCre
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r7n:"
+                          for=":r84:"
                         >
                           Select...
                         </label>
@@ -8515,7 +8515,7 @@ exports[`EstimateCost - index render with commitmentFees and iscommitmentFeesCre
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r7n:"
+                            id=":r84:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -9688,7 +9688,7 @@ exports[`EstimateCost - index render with description as node 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r84:"
+                          for=":r8h:"
                         >
                           Select...
                         </label>
@@ -9710,7 +9710,7 @@ exports[`EstimateCost - index render with description as node 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r84:"
+                            id=":r8h:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -10869,7 +10869,7 @@ exports[`EstimateCost - index render with discount 0 and defaultTimeUnit months 
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r55:"
+                          for=":r5d:"
                         >
                           Select...
                         </label>
@@ -10891,7 +10891,7 @@ exports[`EstimateCost - index render with discount 0 and defaultTimeUnit months 
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r55:"
+                            id=":r5d:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -12050,7 +12050,7 @@ exports[`EstimateCost - index render with discount 0.5 and defaultTimeUnit month
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r6a:"
+                          for=":r6l:"
                         >
                           Select...
                         </label>
@@ -12072,7 +12072,7 @@ exports[`EstimateCost - index render with discount 0.5 and defaultTimeUnit month
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r6a:"
+                            id=":r6l:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -13231,7 +13231,7 @@ exports[`EstimateCost - index render with discount 1 and defaultTimeUnit months 
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r4q:"
+                          for=":r52:"
                         >
                           Select...
                         </label>
@@ -13253,7 +13253,7 @@ exports[`EstimateCost - index render with discount 1 and defaultTimeUnit months 
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r4q:"
+                            id=":r52:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -14505,7 +14505,7 @@ exports[`EstimateCost - index render with discount 1, isBeta and defaultTimeUnit
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r4e:"
+                          for=":r4m:"
                         >
                           Select...
                         </label>
@@ -14527,7 +14527,7 @@ exports[`EstimateCost - index render with discount 1, isBeta and defaultTimeUnit
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r4e:"
+                            id=":r4m:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -15692,7 +15692,7 @@ exports[`EstimateCost - index render with discount 100% but no isBeta 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r1n:"
+                          for=":r1p:"
                         >
                           Select...
                         </label>
@@ -15714,7 +15714,7 @@ exports[`EstimateCost - index render with discount 100% but no isBeta 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r1n:"
+                            id=":r1p:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -17427,7 +17427,7 @@ exports[`EstimateCost - index render with hideTotal 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r6v:"
+                          for=":r7c:"
                         >
                           Select...
                         </label>
@@ -17449,7 +17449,7 @@ exports[`EstimateCost - index render with hideTotal 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r6v:"
+                            id=":r7c:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -18668,7 +18668,7 @@ exports[`EstimateCost - index render with isBeta but undefined discount 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r23:"
+                          for=":r25:"
                         >
                           Select...
                         </label>
@@ -18690,7 +18690,7 @@ exports[`EstimateCost - index render with isBeta but undefined discount 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r23:"
+                            id=":r25:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -19948,7 +19948,7 @@ exports[`EstimateCost - index render with isBeta, discount 0 and defaultTimeUnit
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r5h:"
+                          for=":r5q:"
                         >
                           Select...
                         </label>
@@ -19970,7 +19970,7 @@ exports[`EstimateCost - index render with isBeta, discount 0 and defaultTimeUnit
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r5h:"
+                            id=":r5q:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -21223,7 +21223,7 @@ exports[`EstimateCost - index render with isBeta, discount 0.5 and defaultTimeUn
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r5u:"
+                          for=":r68:"
                         >
                           Select...
                         </label>
@@ -21245,7 +21245,7 @@ exports[`EstimateCost - index render with isBeta, discount 0.5 and defaultTimeUn
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r5u:"
+                            id=":r68:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -22498,7 +22498,7 @@ exports[`EstimateCost - index render with isBeta, price, discount 50% 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r2g:"
+                          for=":r2j:"
                         >
                           Select...
                         </label>
@@ -22520,7 +22520,7 @@ exports[`EstimateCost - index render with isBeta, price, discount 50% 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r2g:"
+                            id=":r2j:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -23685,7 +23685,7 @@ exports[`EstimateCost - index render with item discount 50% 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r2s:"
+                          for=":r30:"
                         >
                           Select...
                         </label>
@@ -23707,7 +23707,7 @@ exports[`EstimateCost - index render with item discount 50% 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r2s:"
+                            id=":r30:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -24866,7 +24866,7 @@ exports[`EstimateCost - index render with item discount 50% and defaultTimeUnit 
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r3n:"
+                          for=":r3u:"
                         >
                           Select...
                         </label>
@@ -24888,7 +24888,7 @@ exports[`EstimateCost - index render with item discount 50% and defaultTimeUnit 
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r3n:"
+                            id=":r3u:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -26093,7 +26093,7 @@ exports[`EstimateCost - index render with item discount 50% and text 1`] = `
                           aria-live="assertive"
                           as="label"
                           class="cache-1bxh4i1-StyledPlaceholder e11gt5pw2"
-                          for=":r38:"
+                          for=":r3d:"
                         >
                           Select...
                         </label>
@@ -26115,7 +26115,7 @@ exports[`EstimateCost - index render with item discount 50% and text 1`] = `
                             autocomplete="off"
                             autocorrect="off"
                             class=""
-                            id=":r38:"
+                            id=":r3d:"
                             role="combobox"
                             spellcheck="false"
                             style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"

--- a/packages/plus/src/components/EstimateCost/types.ts
+++ b/packages/plus/src/components/EstimateCost/types.ts
@@ -112,6 +112,19 @@ export type EstimateCostProps = {
    */
   numberLocales?: string
   overlayMargin?: string
+  onTotalPriceChange?: ({
+    total,
+    totalMax,
+  }: {
+    /**
+     * The total price of the estimate cost.
+     */
+    total: number
+    /**
+     * If the price has a range (ex: 10-20), this is the maximum value.
+     */
+    totalMax?: number
+  }) => void
 }
 
 export type Units = 'seconds' | 'minutes' | 'hours' | 'days' | 'months'


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Add `onTotalPriceChange` prop on `<EstimateCost />` this function will provide `total` and `totalMax when the total price is re-computed allowing users to get that value.`

### How to use it?

```tsx
<EstimateCost {...} onTotalPriceChange={({ total, totalMax}) => {
  console.log(total, totalMax)
}}>
   ...
</EstimateCost>
```

You will notice that `total` defines the total price and `totalMax` defines the maximum price when there is a range. 

For example if estimate cost shows a total of 100€-200€
- `total = 100` where `100` is a type `number`
- `totalMax = 200` where `200` is a type `number`