### PR TITLE
fix(Navigation): add functionality to disable expand

### DIFF
--- a/.changeset/healthy-squids-sin.md
+++ b/.changeset/healthy-squids-sin.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": minor
+---
+
+New prop `initialAllowNavigationResize` on `<NavigationProvider />` and serving `allowNavigationResize` and `setAllowNavigationResize` through `useNavigation()`

--- a/packages/plus/src/components/Navigation/NavigationContent.tsx
+++ b/packages/plus/src/components/Navigation/NavigationContent.tsx
@@ -140,6 +140,7 @@ export const NavigationContent = ({
     animation,
     locales,
     navigationRef,
+    allowNavigationResize,
   } = context
 
   const sliderRef = useRef<HTMLDivElement>(null)
@@ -299,30 +300,32 @@ export const NavigationContent = ({
           >
             {children}
           </Content>
-          <StickyFooter data-has-overflow-style={footerHasOverflowStyle}>
-            <Tooltip
-              text={
-                expanded
-                  ? locales['navigation.collapse.button']
-                  : locales['navigation.expand.button']
-              }
-              placement="right"
-            >
-              <Button
-                variant="ghost"
-                sentiment="neutral"
-                size="small"
-                icon={expanded ? 'arrow-left-double' : 'arrow-right-double'}
-                onClick={() => {
-                  toggleExpand()
-                  onToggleExpand?.(!expanded)
-                }}
-              />
-            </Tooltip>
-          </StickyFooter>
+          {allowNavigationResize ? (
+            <StickyFooter data-has-overflow-style={footerHasOverflowStyle}>
+              <Tooltip
+                text={
+                  expanded
+                    ? locales['navigation.collapse.button']
+                    : locales['navigation.expand.button']
+                }
+                placement="right"
+              >
+                <Button
+                  variant="ghost"
+                  sentiment="neutral"
+                  size="small"
+                  icon={expanded ? 'arrow-left-double' : 'arrow-right-double'}
+                  onClick={() => {
+                    toggleExpand()
+                    onToggleExpand?.(!expanded)
+                  }}
+                />
+              </Tooltip>
+            </StickyFooter>
+          ) : null}
         </ContentContainer>
       </Container>
-      <Slider ref={sliderRef} />
+      {allowNavigationResize ? <Slider ref={sliderRef} /> : null}
     </StyledNav>
   )
 }

--- a/packages/plus/src/components/Navigation/NavigationProvider.tsx
+++ b/packages/plus/src/components/Navigation/NavigationProvider.tsx
@@ -52,6 +52,8 @@ type ContextProps = {
   items: Items
   registerItem: Dispatch<Items>
   setPinnedItems: (value: string[]) => void
+  allowNavigationResize: boolean
+  setAllowNavigationResize: (value: boolean) => void
 }
 
 export const NavigationContext = createContext<ContextProps>({
@@ -74,6 +76,8 @@ export const NavigationContext = createContext<ContextProps>({
   items: {},
   registerItem: () => {},
   setPinnedItems: () => {},
+  allowNavigationResize: true,
+  setAllowNavigationResize: () => {},
 })
 
 export const useNavigation = () => useContext(NavigationContext)
@@ -106,6 +110,10 @@ type NavigationProviderProps = {
    * You can get the expanded state of the navigation with this function
    */
   onExpandChange?: (expanded: boolean) => void
+  /**
+   * This boolean will define if the navigation can be resized or not.
+   */
+  initialAllowNavigationResize?: boolean
 }
 
 export const NavigationProvider = ({
@@ -117,6 +125,7 @@ export const NavigationProvider = ({
   pinLimit = 7,
   onExpandChange,
   initialWidth = NAVIGATION_WIDTH,
+  initialAllowNavigationResize = true,
 }: NavigationProviderProps) => {
   const [expanded, setExpanded] = useState(initialExpanded)
   const [pinnedItems, setPinnedItems] = useState<string[]>(initialPinned ?? [])
@@ -124,6 +133,9 @@ export const NavigationProvider = ({
     false,
   )
   const [width, setWidth] = useState<number>(initialWidth)
+  const [allowNavigationResize, setAllowNavigationResize] = useState(
+    initialAllowNavigationResize,
+  )
 
   // This is used to store the items that are registered in the navigation
   // This way we can retrieve items with their active state in pinned feature
@@ -215,6 +227,8 @@ export const NavigationProvider = ({
       registerItem,
       items,
       setPinnedItems,
+      allowNavigationResize,
+      setAllowNavigationResize,
     }),
     [
       expanded,
@@ -229,7 +243,7 @@ export const NavigationProvider = ({
       width,
       reorderItems,
       items,
-      setPinnedItems,
+      allowNavigationResize,
     ],
   )
 

--- a/packages/plus/src/components/Navigation/components/PinnedItems.tsx
+++ b/packages/plus/src/components/Navigation/components/PinnedItems.tsx
@@ -36,8 +36,11 @@ const RelativeDiv = styled.div`
 
 const TextContainer = styled.div`
   padding: ${({ theme }) => theme.space['1']} 0;
-  padding-left: ${({ theme }) => theme.space['4']};
-  margin-left: ${({ theme }) => theme.space['0.5']};
+
+  &[data-expanded='true'] {
+    padding-left: ${({ theme }) => theme.space['4']};
+    margin-left: ${({ theme }) => theme.space['0.5']};
+  }
 `
 
 type PinnedItemsProps = {
@@ -147,7 +150,7 @@ export const PinnedItems = ({ toggle = true, onReorder }: PinnedItemsProps) => {
               ) : null,
             )
           ) : (
-            <TextContainer>
+            <TextContainer data-expanded={expanded}>
               <Text
                 as="p"
                 variant="caption"


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

New prop `initialAllowNavigationResize` on `<NavigationProvider />` and serving `allowNavigationResize` and `setAllowNavigationResize` through `useNavigation()`

#### Screenshots

without changing any props (can resize):
<img width="292" alt="Screenshot 2024-05-14 at 16 54 57" src="https://github.com/scaleway/ultraviolet/assets/15812968/76bc53a5-a525-41bd-a7e9-34452614a504">


using `initialAllowNavigationResize={false}` (cannot resize):
<img width="288" alt="Screenshot 2024-05-14 at 16 55 07" src="https://github.com/scaleway/ultraviolet/assets/15812968/4f120a93-4258-48b4-aea3-f3090fbfdcf5">


Also small fix, before:
<img width="251" alt="Screenshot 2024-05-14 at 16 57 19" src="https://github.com/scaleway/ultraviolet/assets/15812968/a0e7ed1a-014d-4ffd-8f32-fe8431b0d2ba">

After:
<img width="249" alt="Screenshot 2024-05-14 at 17 06 27" src="https://github.com/scaleway/ultraviolet/assets/15812968/161972bf-8af4-4dd3-8cd4-9c4def21b593">


