### PR TITLE
ci(chromatic): fix rebuild not providing storybook url by force rebuild everytime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: build:storybook:stats
           onlyChanged: true
+          forceRebuild: true
 
       - name: Update deployment
         uses: bobheadxi/deployments@v1.5.0


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Seems like there is an issue with chromatic on deploy. When no build is required as it was already done chromatic github action is skipping it and by doing so it doesn't provide the output `storybookUrl`. In order to fix this we force the build.

<img width="906" alt="Screenshot 2024-05-14 at 17 56 00" src="https://github.com/scaleway/ultraviolet/assets/15812968/db83bd1a-20a9-4d68-960e-fbecca53cec0">

