### PR TITLE
docs(storybook): fix broken stories on form

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -165,6 +165,9 @@ const withThemeProvider = (Story: StoryFn, context: { globals: any }) => {
 }
 
 const decorators = [
+  (Story: StoryFn) => {
+    return <>{<Story />}</> // Storybook is broken without this please refer to this issue: https://github.com/storybookjs/storybook/issues/24625
+  },
   withThemeFromJSXProvider({
     themes: {
       light: lightTheme,

--- a/packages/form/src/components/CheckboxField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/CheckboxField/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/CheckboxGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/CheckboxGroupField/__stories__/index.stories.tsx
@@ -37,7 +37,7 @@ export default {
           methods={methods}
         >
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/DateField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/DateField/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/KeyValueField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/KeyValueField/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
@@ -30,7 +30,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/NumberInputFieldV2/__stories__/index.stories.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/__stories__/index.stories.tsx
@@ -31,7 +31,7 @@ export default {
                 width: '250px',
               }}
             >
-              {ChildStory()}
+              <ChildStory />
             </div>
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">

--- a/packages/form/src/components/RadioField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/RadioField/__stories__/index.stories.tsx
@@ -30,7 +30,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/RadioGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/RadioGroupField/__stories__/index.stories.tsx
@@ -27,7 +27,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/SelectInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectInputField/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/SelectableCardField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectableCardField/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/SelectableCardGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectableCardGroupField/__stories__/index.stories.tsx
@@ -29,7 +29,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/TagInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TagInputField/__stories__/index.stories.tsx
@@ -29,7 +29,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/TextAreaField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextAreaField/__stories__/index.stories.tsx
@@ -14,7 +14,7 @@ export default {
           textarea: 'A long time ago in a galaxy far, far away',
         }}
       >
-        {ChildStory()}
+        <ChildStory />
       </Form>
     ),
   ],

--- a/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/TextInputFieldV2/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextInputFieldV2/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/TimeField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TimeField/__stories__/index.stories.tsx
@@ -26,7 +26,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/ToggleField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/ToggleField/__stories__/index.stories.tsx
@@ -36,7 +36,7 @@ export default {
           }}
         >
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/form/src/components/ToggleGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/ToggleGroupField/__stories__/index.stories.tsx
@@ -31,7 +31,7 @@ export default {
       return (
         <Form onRawSubmit={() => {}} errors={mockErrors} methods={methods}>
           <Stack gap={2}>
-            {ChildStory()}
+            <ChildStory />
             <Stack gap={1}>
               <Text variant="bodyStrong" as="p">
                 Form input values:

--- a/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
@@ -3,7 +3,6 @@ import { PieChart } from '..'
 
 export default {
   component: PieChart,
-  decorators: [StoryComponent => <StoryComponent />],
   title: 'Components/Data Display/Chart/PieChart',
   parameters: {
     experimental: true,

--- a/packages/ui/src/components/Popover/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Popover/__stories__/index.stories.tsx
@@ -3,7 +3,6 @@ import { Popover } from '..'
 
 export default {
   component: Popover,
-  decorators: [StoryComponent => <StoryComponent />],
   title: 'Components/Overlay/Popover',
 } as Meta<typeof Popover>
 

--- a/packages/ui/src/components/Skeleton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Skeleton/__stories__/index.stories.tsx
@@ -3,7 +3,6 @@ import { Skeleton } from '..'
 
 export default {
   component: Skeleton,
-  decorators: [StoryComponent => <StoryComponent />],
   title: 'Components/Feedback/Skeleton',
 } as Meta<typeof Skeleton>
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There is an issue since storybook v8 with some stories (especially form ones) with the following error:
> [!CAUTION]
> Storybook preview hooks can only be called inside decorators and story functions.

It seems like this comes from `@storybook/addon-themes` plugins, an issue is open about it here: https://github.com/storybookjs/storybook/issues/24625

To fix this adding an empty tag around general decorator seems to work and remove the error. 
