### PR TITLE
fix(SelectInput): description and inline description spacing

### DIFF
--- a/.changeset/tender-walls-relate.md
+++ b/.changeset/tender-walls-relate.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInput />` description and inline description spacings

--- a/packages/ui/src/components/SelectInput/index.tsx
+++ b/packages/ui/src/components/SelectInput/index.tsx
@@ -393,15 +393,21 @@ const StyledPlaceholder = styled('label', {
   ${({ isDisabled, hasValue }) => hasValue && isDisabled && 'opacity: 0.5'}
 `
 
-const StyledText = styled(Text)<{ isSelectedAndNotFocused: boolean }>`
-  margin-left: ${({ theme }) => theme.space['1']};
+const StyledText = styled(Text, {
+  shouldForwardProp: prop =>
+    !['isSelectedAndNotFocused', 'isInline'].includes(prop),
+})<{
+  isSelectedAndNotFocused: boolean
+  isInline?: boolean
+}>`
+  margin-left: ${({ theme, isInline }) => (isInline ? theme.space['1'] : 0)};
   color: ${({ isSelectedAndNotFocused, theme }) =>
     isSelectedAndNotFocused ? theme.colors.primary.textStrong : undefined};
 `
 
 const MaxLineStyledText = styled(StyledText)`
   -webkit-line-clamp: 3;
-  margin-top: ${({ theme }) => theme.space['2']};
+  margin-top: ${({ theme }) => theme.space['1']};
 `
 
 const ValueContainer = ({
@@ -542,6 +548,7 @@ const Option = ({
             as="span"
             variant="bodySmall"
             isSelectedAndNotFocused={isSelected && !isFocused}
+            isInline={!!inlineDescription}
           >
             {inlineDescription}
           </StyledText>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<SelectInput />` description and inline description spacings

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="973" alt="Screenshot 2024-05-21 at 17 45 36" src="https://github.com/scaleway/ultraviolet/assets/15812968/965c3f00-0361-4def-845c-30e7eac4cc8c"> | <img width="979" alt="Screenshot 2024-05-21 at 17 49 22" src="https://github.com/scaleway/ultraviolet/assets/15812968/724888b3-80b7-4a97-bbed-329b51cf0794"> |
