### PR TITLE
fix(SelectInputV2): auto focus on search bar

### DIFF
--- a/.changeset/thin-maps-drum.md
+++ b/.changeset/thin-maps-drum.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInputV2 />` autoFocus issue on search bar

--- a/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { Icon } from '@ultraviolet/icons'
 import type { Dispatch, SetStateAction } from 'react'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { TextInputV2 } from '../TextInputV2'
 import { useSelectInput } from './SelectInputProvider'
 import type { DataType } from './types'
@@ -132,6 +132,14 @@ export const SearchBarDropdown = ({
     }
   }
 
+  useEffect(() => {
+    // TODO: Remove me and use autoFocus when popup is fixed
+    // Autofocus on the search bar create some scroll issues
+    setTimeout(() => {
+      searchInputRef.current?.focus()
+    }, 50)
+  }, [])
+
   return (
     <StyledInput
       value={searchInput}
@@ -143,7 +151,6 @@ export const SearchBarDropdown = ({
       prefix={<Icon name="search" size="small" sentiment="neutral" />}
       onKeyDown={event => handleKeyDown(event.key, searchInput)}
       size="medium"
-      autoFocus
       aria-label="search-bar"
       ref={searchInputRef}
     />

--- a/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -829,8 +829,6 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -3400,8 +3398,6 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-37>.emotion-44 {
@@ -6098,8 +6094,6 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -7708,8 +7702,6 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -8722,8 +8714,6 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-26>.emotion-33 {
@@ -9803,8 +9793,6 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -10376,8 +10364,6 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-24>.emotion-31 {
@@ -11419,8 +11405,6 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-26>.emotion-33 {
@@ -12511,8 +12495,6 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -13625,8 +13607,6 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -14738,8 +14718,6 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -15874,8 +15852,6 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -17784,8 +17760,6 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-24>.emotion-31 {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There is still some issues with `SelectInputV2` and the searchbar having `autoFocus` onto it. When opening the select input it scroll on top of the page. To fix that we temporarily added a `setTimeout` that will focus when search bar appear, replacing `autoFocus` behavior.
