### PR TITLE
fix(Navigation): bad typing on locales

### DIFF
--- a/.changeset/forty-pumpkins-wink.md
+++ b/.changeset/forty-pumpkins-wink.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix typing on prop `locales` from `<Navigation />` and `<EstimateCost />` components.

--- a/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
+++ b/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
@@ -82,7 +82,7 @@ const DescriptionComponent = ({
   locales,
 }: {
   description: ReactNode
-  locales: typeof EstimateCostLocales
+  locales: Record<keyof typeof EstimateCostLocales, string>
 }) =>
   description === undefined || typeof description === 'string' ? (
     <Text as="span" variant="body">

--- a/packages/plus/src/components/EstimateCost/EstimateCostProvider.tsx
+++ b/packages/plus/src/components/EstimateCost/EstimateCostProvider.tsx
@@ -3,7 +3,7 @@ import { createContext, useCallback, useContext, useMemo } from 'react'
 import EstimateCostLocales from './locales/en'
 
 const EstimateCostContext = createContext<{
-  locales: typeof EstimateCostLocales
+  locales: Record<keyof typeof EstimateCostLocales, string>
   formatNumber: (number: number, options: FormatNumberOption) => string
 }>({ locales: EstimateCostLocales, formatNumber: () => '' })
 
@@ -11,7 +11,7 @@ export const useEstimateCost = () => useContext(EstimateCostContext)
 
 type EstimateCostProviderProps = {
   children: ReactNode
-  locales?: typeof EstimateCostLocales
+  locales?: Record<keyof typeof EstimateCostLocales, string>
   currency?: string
   numberLocales?: string
 }

--- a/packages/plus/src/components/EstimateCost/types.ts
+++ b/packages/plus/src/components/EstimateCost/types.ts
@@ -100,7 +100,7 @@ export type EstimateCostProps = {
   /**
    * Locales for the component. By default, it will use the english locales.
    */
-  locales?: typeof EstimateCostLocales
+  locales?: Record<keyof typeof EstimateCostLocales, string>
   /**
    * Defines the currency to be shown in the component.
    * To find out all currencies checkout https://en.wikipedia.org/wiki/ISO_4217#List_of_ISO_4217_currency_codes section "Code" of the table.

--- a/packages/plus/src/components/Navigation/NavigationProvider.tsx
+++ b/packages/plus/src/components/Navigation/NavigationProvider.tsx
@@ -32,7 +32,7 @@ type ContextProps = {
   pinnedItems: string[]
   pinLimit: number
   navigationRef: RefObject<HTMLDivElement>
-  locales: typeof NavigationLocales
+  locales: Record<keyof typeof NavigationLocales, string>
   width: number
   setWidth: (width: number) => void
   /**
@@ -105,7 +105,7 @@ type NavigationProviderProps = {
    * navigation will be expanded by default otherwise it will be collapsed
    */
   initialExpanded?: boolean
-  locales?: typeof NavigationLocales
+  locales?: Record<keyof typeof NavigationLocales, string>
   /**
    * You can get the expanded state of the navigation with this function
    */


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix typing on prop `locales` from `<Navigation />` component

