### PR TITLE
fix(TextInputFieldV2): add shouldUnregister prop

### DIFF
--- a/.changeset/quick-masks-accept.md
+++ b/.changeset/quick-masks-accept.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+fix(TextInputFieldV2): add shouldUnregister prop

--- a/packages/form/src/components/TextInputFieldV2/index.tsx
+++ b/packages/form/src/components/TextInputFieldV2/index.tsx
@@ -55,6 +55,7 @@ export const TextInputField = <
   'aria-labelledby': ariaLabelledBy,
   'aria-label': ariaLabel,
   autoComplete,
+  shouldUnregister,
 }: TextInputFieldProps<TFieldValues, TName>) => {
   const { getError } = useErrors()
 
@@ -63,6 +64,7 @@ export const TextInputField = <
     fieldState: { error },
   } = useController<TFieldValues>({
     name,
+    shouldUnregister,
     rules: {
       required,
       validate: {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

`shouldUnregister` prop was not forwarded.
