### PR TITLE
fix: menu alignment

### DIFF
--- a/.changeset/soft-bats-train.md
+++ b/.changeset/soft-bats-train.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`MenuV2`: fix menu text alignment

--- a/packages/ui/src/components/MenuV2/Item.tsx
+++ b/packages/ui/src/components/MenuV2/Item.tsx
@@ -20,6 +20,7 @@ const itemCoreStyle = ({
 }) => `
   display: flex;
   justify-content: start;
+  text-align: left;
   align-items: center;
   min-height: 32px;
   max-height: 44px;

--- a/packages/ui/src/components/MenuV2/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/components/MenuV2/__stories__/Playground.stories.tsx
@@ -5,7 +5,7 @@ export const Playground = Template.bind({})
 
 Playground.args = {
   children: [
-    <MenuV2.Item borderless>Information</MenuV2.Item>,
+    <MenuV2.Item borderless>Information with a long name</MenuV2.Item>,
     <MenuV2.Item borderless>Power on</MenuV2.Item>,
   ],
 }

--- a/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/MenuV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`Menu > Menu.Item > render with active props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -85,6 +86,7 @@ exports[`Menu > Menu.Item > render with active props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -132,6 +134,7 @@ exports[`Menu > Menu.Item > render with active props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -208,6 +211,7 @@ exports[`Menu > Menu.Item > render with borderless props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -255,6 +259,7 @@ exports[`Menu > Menu.Item > render with borderless props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -302,6 +307,7 @@ exports[`Menu > Menu.Item > render with borderless props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -396,6 +402,7 @@ exports[`Menu > Menu.Item > render with default props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -443,6 +450,7 @@ exports[`Menu > Menu.Item > render with default props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -490,6 +498,7 @@ exports[`Menu > Menu.Item > render with default props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -584,6 +593,7 @@ exports[`Menu > Menu.Item > render with disabled props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -619,6 +629,7 @@ exports[`Menu > Menu.Item > render with disabled props 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -702,6 +713,7 @@ exports[`Menu > Menu.Item > render with sentiment danger 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1192,6 +1204,7 @@ exports[`Menu > placement > renders bottom 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1239,6 +1252,7 @@ exports[`Menu > placement > renders bottom 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1286,6 +1300,7 @@ exports[`Menu > placement > renders bottom 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1652,6 +1667,7 @@ exports[`Menu > placement > renders left 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1699,6 +1715,7 @@ exports[`Menu > placement > renders left 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1746,6 +1763,7 @@ exports[`Menu > placement > renders left 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2112,6 +2130,7 @@ exports[`Menu > placement > renders right 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2159,6 +2178,7 @@ exports[`Menu > placement > renders right 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2206,6 +2226,7 @@ exports[`Menu > placement > renders right 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2572,6 +2593,7 @@ exports[`Menu > placement > renders top 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2619,6 +2641,7 @@ exports[`Menu > placement > renders top 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2666,6 +2689,7 @@ exports[`Menu > placement > renders top 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2919,6 +2943,7 @@ exports[`Menu > renders with Menu.Group 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3164,6 +3189,7 @@ exports[`Menu > renders with Menu.Item 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3400,6 +3426,7 @@ exports[`Menu > renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3637,6 +3664,7 @@ exports[`Menu > renders with Menu.ItemLink 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4143,6 +4171,7 @@ exports[`Menu > sizes > renders large 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4190,6 +4219,7 @@ exports[`Menu > sizes > renders large 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4237,6 +4267,7 @@ exports[`Menu > sizes > renders large 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4657,6 +4688,7 @@ exports[`Menu > sizes > renders medium 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4704,6 +4736,7 @@ exports[`Menu > sizes > renders medium 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4751,6 +4784,7 @@ exports[`Menu > sizes > renders medium 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5269,6 +5303,7 @@ exports[`Menu > sizes > renders small 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5316,6 +5351,7 @@ exports[`Menu > sizes > renders small 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5363,6 +5399,7 @@ exports[`Menu > sizes > renders small 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -2384,6 +2384,7 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3526,6 +3527,7 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   -ms-flex-pack: start;
   -webkit-justify-content: start;
   justify-content: start;
+  text-align: left;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

MenuV2 : the text was centered instead of being on the left


## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | :--------: |
| url  | <img width="199" alt="Capture d’écran 2024-06-12 à 14 56 22" src="https://github.com/scaleway/ultraviolet/assets/106706307/9f59f1fd-9683-4f51-a017-cd32557bea9d"> | <img width="199" alt="Capture d’écran 2024-06-12 à 14 56 04" src="https://github.com/scaleway/ultraviolet/assets/106706307/77cb4681-b0b5-4c76-a571-a0c343626f08"> |