### PR TITLE
ci: fix ci not running on release pr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           git config --global user.email 'github@scaleway.com'
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
       - uses: pnpm/action-setup@v4.0.0
       - name: Use Node.js
         uses: actions/setup-node@v4.0.2
@@ -35,6 +35,6 @@ jobs:
           title: 'chore: release'
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

This PR should fix CI not running on release PR. By using PAT tokens instead of github tokens.
