### PR TITLE
fix(SelectInputV2): label to have correct color

### DIFF
--- a/.changeset/funny-sloths-divide.md
+++ b/.changeset/funny-sloths-divide.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInputV2 />` label color

--- a/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`SelectInputV2 > renders correctly 1`] = `
 }
 
 .emotion-8 {
+  color: #3f4250;
   font-size: 16px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -5541,6 +5542,7 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
 }
 
 .emotion-8 {
+  color: #3f4250;
   font-size: 16px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -6791,6 +6793,7 @@ exports[`SelectInputV2 > renders correctly small 1`] = `
 }
 
 .emotion-8 {
+  color: #3f4250;
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;

--- a/packages/ui/src/components/SelectInputV2/index.tsx
+++ b/packages/ui/src/components/SelectInputV2/index.tsx
@@ -211,6 +211,7 @@ export const SelectInputV2 = <IsMulti extends undefined | boolean>({
                 <Text
                   as="label"
                   variant={size === 'large' ? 'bodyStrong' : 'bodySmallStrong'}
+                  sentiment="neutral"
                   htmlFor={finalId}
                 >
                   {label}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

`SelectInputV2` was missing `sentiment` on it's label. By default text inherit the color from a parent.
