### PR TITLE
ci: add new action checking format using biome ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,23 @@ jobs:
       - run: pnpm run build
       - run: pnpm install
       - run: pnpm run lint
+  format:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4.0.0
+      - name: Use Node.js
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - run: pnpm install
+      - run: pnpm run build
+      - run: pnpm install
+      - run: pnpm run format:ci
   test:
     runs-on: ubuntu-22.04
-    needs: [lint, typecheck]
+    needs: [lint, typecheck, format]
     strategy:
       matrix:
         node: ["20"]
@@ -84,7 +98,7 @@ jobs:
       matrix:
         node: ["20"]
     runs-on: ubuntu-22.04
-    needs: [lint, typecheck]
+    needs: [lint, typecheck, format]
     steps:
       - uses: actions/checkout@v4 # v4.1.4
       - uses: pnpm/action-setup@v4.0.0
@@ -99,7 +113,7 @@ jobs:
       matrix:
         node: ["20"]
     runs-on: ubuntu-22.04
-    needs: [lint, test]
+    needs: [lint, test, format]
     steps:
       - uses: actions/checkout@v4 # v4.1.4
       - uses: pnpm/action-setup@v4.0.0

--- a/.storybook/components/DocsContainer.tsx
+++ b/.storybook/components/DocsContainer.tsx
@@ -46,12 +46,12 @@ const DocsContainer = ({ children, context }: DocsContainerProps) => {
       <BaseContainer context={context}>
         {isValidElement<ExtraProps>(children)
           ? cloneElement(children, {
-            deprecated: parameters?.deprecated,
-            deprecatedReason: parameters?.deprecatedReason,
-            migrationLink: parameters?.migrationLink,
-            hideArgsTable: parameters?.hideArgsTable,
-            experimental: isPlusLibrary ? true : parameters?.experimental,
-          })
+              deprecated: parameters?.deprecated,
+              deprecatedReason: parameters?.deprecatedReason,
+              migrationLink: parameters?.migrationLink,
+              hideArgsTable: parameters?.hideArgsTable,
+              experimental: isPlusLibrary ? true : parameters?.experimental,
+            })
           : children}
       </BaseContainer>
     </ThemeProvider>

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
       "coverage/",
       "**/node_modules/",
       "**/storybook-static",
-      "**/dist/",
+      "dist",
       "**/pnpm-lock.yaml",
       "**/package.json",
       "**/CHANGELOG.md",

--- a/biome.json
+++ b/biome.json
@@ -1,19 +1,16 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "organizeImports": { "enabled": false },
-  "linter": { "enabled": false },
+  "organizeImports": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": false
+  },
   "vcs": {
     "clientKind": "git",
     "useIgnoreFile": true
   },
-  "formatter": {
-    "enabled": true,
-    "formatWithErrors": false,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineEnding": "lf",
-    "lineWidth": 80,
-    "attributePosition": "auto",
+  "files": {
     "ignore": [
       ".next/",
       "coverage/",
@@ -26,6 +23,15 @@
       "*.snap",
       "**/__snapshots__/"
     ]
+  },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto"
   },
   "javascript": {
     "formatter": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start": "STORYBOOK_ENVIRONMENT=development storybook dev -p 6006",
     "start:production": "STORYBOOK_ENVIRONMENT=production storybook dev -p 6006",
     "format": "biome format --write .",
+    "format:ci": "biome ci .",
     "lint:fix": "pnpm run lint --fix",
     "lint": "eslint --report-unused-disable-directives --cache .",
     "prebuild": "pnpm --filter '@ultraviolet/*' recursive run prebuild",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,7 @@
     "target": "esnext",
     "module": "esnext",
     "jsxImportSource": "@emotion/react",
-    "types": [
-      "vite/client",
-      "@testing-library/jest-dom"
-    ],
+    "types": ["vite/client", "@testing-library/jest-dom"],
     "noEmit": true,
     "skipLibCheck": true,
     // Should be removed once we clear all errors
@@ -25,10 +22,5 @@
     "expect.d.ts",
     "jest-axe.d.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "coverage",
-    "dist",
-    "examples"
-  ]
+  "exclude": ["node_modules", "coverage", "dist", "examples"]
 }


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

Currently we have no check on CI on format so anyone can push it's own format and it will work just fine. I added a new CI job that will run `biome ci .` which will check there is no format errors.
