### PR TITLE
fix(TextInputV2): width with error prop

### DIFF
--- a/.changeset/lemon-pots-try.md
+++ b/.changeset/lemon-pots-try.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+`<TextInputV2 />` and `<TextInputFieldV2 />`: input width won't change with error

--- a/packages/form/src/components/DateField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/DateField/__tests__/__snapshots__/index.test.tsx.snap
@@ -261,6 +261,7 @@ exports[`DateField > should render correctly 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -635,6 +636,7 @@ exports[`DateField > should render correctly disabled 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1012,6 +1014,7 @@ exports[`DateField > should trigger events 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;

--- a/packages/form/src/components/TextInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TextInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -166,6 +166,7 @@ exports[`TextInputFieldV2 > should render correctly 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -403,6 +404,7 @@ exports[`TextInputFieldV2 > should render correctly generated 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;

--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -319,6 +319,7 @@ exports[`DateInput > render correctly with a array of dates to exclude 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -760,6 +761,7 @@ exports[`DateInput > render correctly with a range of date 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1201,6 +1203,7 @@ exports[`DateInput > renders correctly disabled 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1643,6 +1646,7 @@ exports[`DateInput > renders correctly error 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -2154,6 +2158,7 @@ exports[`DateInput > renders correctly error disabled 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -2680,6 +2685,7 @@ exports[`DateInput > renders correctly error disabled required 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -3202,6 +3208,7 @@ exports[`DateInput > renders correctly min-max 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -3657,6 +3664,7 @@ exports[`DateInput > renders correctly required 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -4110,6 +4118,7 @@ exports[`DateInput > renders correctly with date-fns locale es 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -5277,6 +5286,7 @@ exports[`DateInput > renders correctly with date-fns locale fr 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -6444,6 +6454,7 @@ exports[`DateInput > renders correctly with date-fns locale ru 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -7609,6 +7620,7 @@ exports[`DateInput > renders correctly with default props 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;

--- a/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -156,6 +156,7 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;

--- a/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -3394,6 +3394,8 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-37>.emotion-44 {

--- a/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -7695,8 +7695,6 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {

--- a/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -925,6 +925,7 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -3490,6 +3491,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -6183,6 +6185,7 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -7692,6 +7695,8 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-22>.emotion-29 {
@@ -7789,6 +7794,7 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -8800,6 +8806,7 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -9878,6 +9885,7 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -10448,6 +10456,7 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -11488,6 +11497,7 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -12577,6 +12587,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -13688,6 +13699,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -14798,6 +14810,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -15931,6 +15944,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -17837,6 +17851,7 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;

--- a/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -3394,8 +3394,6 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   background: #ffffff;
   border: 1px solid #d9dadd;
   border-radius: 4px;
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-  border: 1px solid #8c40ef;
 }
 
 .emotion-37>.emotion-44 {

--- a/packages/ui/src/components/TextInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -323,6 +323,7 @@ exports[`TextInputV2 > should render correctly when input  has a error sentiment
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -339,6 +340,7 @@ exports[`TextInputV2 > should render correctly when input  has a error sentiment
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -808,6 +810,7 @@ exports[`TextInputV2 > should render correctly when input has a success sentimen
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -824,6 +827,7 @@ exports[`TextInputV2 > should render correctly when input has a success sentimen
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1293,6 +1297,7 @@ exports[`TextInputV2 > should render correctly when input is disabled 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1309,6 +1314,7 @@ exports[`TextInputV2 > should render correctly when input is disabled 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1685,6 +1691,7 @@ exports[`TextInputV2 > should render correctly when input is readOnly 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1701,6 +1708,7 @@ exports[`TextInputV2 > should render correctly when input is readOnly 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;
@@ -1920,6 +1928,7 @@ exports[`TextInputV2 > should render correctly with basic props 1`] = `
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: 16px;
   background: transparent;
   font-size: 14px;

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -45,6 +45,7 @@ const StyledInput = styled.input<{
   border: none;
   outline: none;
   height: 100%;
+  width: 100%;
   padding-left: ${({ theme }) => theme.space['2']};
   background: transparent;
   font-size: ${({ theme }) => theme.typography.bodySmall.fontSize};
@@ -316,16 +317,16 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
                   {success ? (
                     <Icon
                       name="checkbox-circle-outline"
-                      color="success"
-                      size={16}
+                      sentiment="success"
+                      size="small"
                       disabled={disabled}
                     />
                   ) : null}
                   {error ? (
                     <Icon
                       name="alert"
-                      color="danger"
-                      size={16}
+                      sentiment="danger"
+                      size="small"
                       disabled={disabled}
                     />
                   ) : null}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

With an error,  the width of `<TextInputFieldV2 />` changed.

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="559" alt="Capture d’écran 2024-06-21 à 12 02 20" src="https://github.com/scaleway/ultraviolet/assets/106706307/9a911ba9-3295-427d-a553-491ee7ea738d"> | <img width="559" alt="Capture d’écran 2024-06-21 à 12 02 28" src="https://github.com/scaleway/ultraviolet/assets/106706307/d2c0fa43-d30f-443f-87a1-70c8e3c3f3f3"> |
