### PR TITLE
fix(illustration): change 'dediboxVPS' name to match images name

### DIFF
--- a/.changeset/eighty-bags-eat.md
+++ b/.changeset/eighty-bags-eat.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/illustrations": patch
+---
+
+Change "dediboxVPS" to "dediboxVps" to be aligned with illustrations name

--- a/packages/illustrations/src/assets/products/index.ts
+++ b/packages/illustrations/src/assets/products/index.ts
@@ -8,7 +8,7 @@ import * as containerRegistry from './containerRegistry'
 import * as containers from './containers'
 import * as costManager from './costManager'
 import * as dedibox from './dedibox'
-import * as dediboxVPS from './dediboxVPS'
+import * as dediboxVps from './dediboxVPS'
 import * as distributedDataLab from './distributedDataLab'
 import * as documentDB from './documentDB'
 import * as domainsAndDns from './domainsAndDns'
@@ -55,7 +55,7 @@ export {
   containers,
   costManager,
   dedibox,
-  dediboxVPS,
+  dediboxVps,
   distributedDataLab,
   documentDB,
   domainsAndDns,


### PR DESCRIPTION
## Summary

with website team, we updated ultraviolet to the latest version (2.0.0), which allowed us to dynamically import illustrations (thanks ❤️ ), but we had two errors

<img width="708" alt="Capture d’écran 2024-06-27 à 08 12 53" src="https://github.com/scaleway/ultraviolet/assets/25226974/026faa31-6467-49a4-88ae-0b1d93d7d0e6">

- costManager color, fixed here (https://github.com/scaleway/ultraviolet/pull/3921)
- dediboxVPS image is empty

after investigation, it seems like there's a mismatch with the folder name (dediboxVPS) and image name (dediboxVpsWire)

https://docsch9kc7kt-docs-preview-use-o5fi8r.functions.fnc.fr-par.scw.cloud/en/docs/components/docs-editor/#ultraviolet-illustrations

## Type

- Bug

#### What is expected?

rename dediboxVPS to dediboxVps
