### PR TITLE
feat(SearchInput): redesign and new shortcut feature

### DIFF
--- a/.changeset/silly-penguins-heal.md
+++ b/.changeset/silly-penguins-heal.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": minor
+---
+
+Design update and new features on `<SearchInput />`:
+- New design for the input with a simpler and cleaner look.
+- New prop `shortcut`, when set to true the input will be focusable with `Ctrl + K` on Windows and Linux and `Cmd + K` on macOS. It also add the shortcut into the input placeholder.

--- a/packages/ui/src/components/SearchInput/Key.tsx
+++ b/packages/ui/src/components/SearchInput/Key.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled'
+import { Text } from '../Text'
+
+const Container = styled.div`
+  background: ${({ theme }) => theme.colors.neutral.backgroundWeak};
+  border-radius: ${({ theme }) => theme.radii.default};
+  border: 0.5px solid ${({ theme }) => theme.colors.neutral.border};
+  min-width: 24px;
+  min-height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &[data-disabled='true'] {
+    background: ${({ theme }) => theme.colors.neutral.backgroundDisabled};
+    border-color: ${({ theme }) => theme.colors.neutral.borderDisabled};
+  }
+
+  &[data-children-length='true'] {
+    width: auto;
+    padding: 0 ${({ theme }) => theme.space[1]}; // This part is to leave some space between the text and the border when text is long
+  }
+`
+
+type KeyProps = {
+  children: string
+  disabled?: boolean
+}
+
+export const Key = ({ children, disabled }: KeyProps) => (
+  <Container
+    data-disabled={disabled}
+    data-children-length={children.length > 1}
+  >
+    <Text as="span" variant="caption" sentiment="neutral" disabled={disabled}>
+      {children}
+    </Text>
+  </Container>
+)

--- a/packages/ui/src/components/SearchInput/KeyGroup.tsx
+++ b/packages/ui/src/components/SearchInput/KeyGroup.tsx
@@ -1,0 +1,18 @@
+import type { ComponentProps } from 'react'
+import { Stack } from '../Stack'
+import { Key } from './Key'
+
+type KeyGroupProps = {
+  keys: ComponentProps<typeof Key>['children'][]
+  disabled: ComponentProps<typeof Key>['disabled']
+}
+
+export const KeyGroup = ({ keys, disabled }: KeyGroupProps) => (
+  <Stack gap={0.5} direction="row">
+    {keys.map(key => (
+      <Key key={key} disabled={disabled}>
+        {key}
+      </Key>
+    ))}
+  </Stack>
+)

--- a/packages/ui/src/components/SearchInput/__stories__/Disabled.stories.tsx
+++ b/packages/ui/src/components/SearchInput/__stories__/Disabled.stories.tsx
@@ -1,0 +1,8 @@
+import { Template } from './Template.stories'
+
+export const Disabled = Template.bind({})
+
+Disabled.args = {
+  disabled: true,
+  shortcut: true,
+}

--- a/packages/ui/src/components/SearchInput/__stories__/Error.stories.tsx
+++ b/packages/ui/src/components/SearchInput/__stories__/Error.stories.tsx
@@ -1,0 +1,7 @@
+import { Template } from './Template.stories'
+
+export const Error = Template.bind({})
+
+Error.args = {
+  error: 'An error occurred while searching!',
+}

--- a/packages/ui/src/components/SearchInput/__stories__/Shortcut.stories.tsx
+++ b/packages/ui/src/components/SearchInput/__stories__/Shortcut.stories.tsx
@@ -1,0 +1,16 @@
+import { Template } from './Template.stories'
+
+export const Shortcut = Template.bind({})
+
+Shortcut.args = {
+  shortcut: true,
+}
+
+Shortcut.parameters = {
+  docs: {
+    description: {
+      story:
+        'If set to `true` it will display shortcut keys. When the keys are pressed the input will be focused. Depending on your navigator and operating system the keys might be different. For example, on Windows and Linux it will be `Ctrl + K` and on Mac it will be `⌘ + K`.',
+    },
+  },
+}

--- a/packages/ui/src/components/SearchInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SearchInput/__stories__/index.stories.tsx
@@ -7,3 +7,6 @@ export default {
 } as Meta<typeof SearchInput>
 
 export { Playground } from './Playground.stories'
+export { Shortcut } from './Shortcut.stories'
+export { Disabled } from './Disabled.stories'
+export { Error } from './Error.stories'

--- a/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,190 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SearchInput > renders correctly without children props 1`] = `
+exports[`SearchInput > Key > renders correctly with disabled 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 0.5px solid #d9dadd;
+  min-width: 24px;
+  min-height: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-0[data-children-length='true'] {
+  width: auto;
+  padding: 0 8px;
+}
+
+.emotion-2 {
+  color: #b5b7bd;
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-children-length="false"
+      data-disabled="true"
+    >
+      <span
+        class="emotion-2 emotion-3"
+      >
+        K
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > Key > renders correctly with long key 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 0.5px solid #d9dadd;
+  min-width: 24px;
+  min-height: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-0[data-children-length='true'] {
+  width: auto;
+  padding: 0 8px;
+}
+
+.emotion-2 {
+  color: #3f4250;
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-children-length="true"
+    >
+      <span
+        class="emotion-2 emotion-3"
+      >
+        Ctrl
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > Key > renders correctly with single key 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 0.5px solid #d9dadd;
+  min-width: 24px;
+  min-height: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-0[data-children-length='true'] {
+  width: auto;
+  padding: 0 8px;
+}
+
+.emotion-2 {
+  color: #3f4250;
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-children-length="false"
+    >
+      <span
+        class="emotion-2 emotion-3"
+      >
+        K
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > render correctly with shortcut and check if it works 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: inherit;
@@ -10,7 +194,15 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   width: 100%;
 }
 
-.emotion-2 {
+.emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -33,7 +225,112 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   flex-wrap: nowrap;
 }
 
-.emotion-4 {
+.emotion-3 .emotion-14 {
+  border: none;
+}
+
+.emotion-3 .emotion-18 {
+  padding: 0;
+}
+
+.emotion-3 .emotion-20 {
+  border: none;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-3 .emotion-14 {
+  border: none;
+}
+
+.emotion-3 .emotion-18 {
+  padding: 0;
+}
+
+.emotion-3 .emotion-20 {
+  border: none;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-9 {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -47,69 +344,145 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   border-radius: 4px;
 }
 
-.emotion-4>.emotion-11 {
+.emotion-11>.emotion-18 {
   color: #3f4250;
 }
 
-.emotion-4>.emotion-11::-webkit-input-placeholder {
+.emotion-11>.emotion-18::-webkit-input-placeholder {
   color: #727683;
 }
 
-.emotion-4>.emotion-11::-moz-placeholder {
+.emotion-11>.emotion-18::-moz-placeholder {
   color: #727683;
 }
 
-.emotion-4>.emotion-11:-ms-input-placeholder {
+.emotion-11>.emotion-18:-ms-input-placeholder {
   color: #727683;
 }
 
-.emotion-4>.emotion-11::placeholder {
+.emotion-11>.emotion-18::placeholder {
   color: #727683;
 }
 
-.emotion-4[data-success='true'] {
+.emotion-11[data-success='true'] {
   border-color: #22674e;
 }
 
-.emotion-4[data-error='true'] {
+.emotion-11[data-error='true'] {
   border-color: #b3144d;
 }
 
-.emotion-4[data-readonly='true'] {
+.emotion-11[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
 
-.emotion-4[data-disabled='true'] {
+.emotion-11[data-disabled='true'] {
   background: #f3f3f4;
   border-color: #e9eaeb;
 }
 
-.emotion-4[data-disabled='true']>.emotion-11 {
+.emotion-11[data-disabled='true']>.emotion-18 {
   color: #b5b7bd;
 }
 
-.emotion-4[data-disabled='true']>.emotion-11::-webkit-input-placeholder {
+.emotion-11[data-disabled='true']>.emotion-18::-webkit-input-placeholder {
   color: #b5b7bd;
 }
 
-.emotion-4[data-disabled='true']>.emotion-11::-moz-placeholder {
+.emotion-11[data-disabled='true']>.emotion-18::-moz-placeholder {
   color: #b5b7bd;
 }
 
-.emotion-4[data-disabled='true']>.emotion-11:-ms-input-placeholder {
+.emotion-11[data-disabled='true']>.emotion-18:-ms-input-placeholder {
   color: #b5b7bd;
 }
 
-.emotion-4[data-disabled='true']>.emotion-11::placeholder {
+.emotion-11[data-disabled='true']>.emotion-18::placeholder {
   color: #b5b7bd;
 }
 
-.emotion-4:not([data-disabled='true']):not([data-readonly]):hover {
+.emotion-11:not([data-disabled='true']):not([data-readonly]):hover {
   border-color: #8c40ef;
 }
 
-.emotion-6 {
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: 48px;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+}
+
+.emotion-11>.emotion-18 {
+  color: #3f4250;
+}
+
+.emotion-11>.emotion-18::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.emotion-11>.emotion-18::-moz-placeholder {
+  color: #727683;
+}
+
+.emotion-11>.emotion-18:-ms-input-placeholder {
+  color: #727683;
+}
+
+.emotion-11>.emotion-18::placeholder {
+  color: #727683;
+}
+
+.emotion-11[data-success='true'] {
+  border-color: #22674e;
+}
+
+.emotion-11[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.emotion-11[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+}
+
+.emotion-11[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18 {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18::-webkit-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18::-moz-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18:-ms-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18::placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -135,21 +508,61 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   border-color: inherit;
 }
 
-.emotion-8 {
+.emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 16px;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-15 {
   vertical-align: middle;
-  fill: currentColor;
+  fill: #3f4250;
   height: 1em;
   width: 1em;
   min-width: 1em;
   min-height: 1em;
 }
 
-.emotion-8 .fillStroke {
-  stroke: currentColor;
+.emotion-15 .fillStroke {
+  stroke: #3f4250;
   fill: none;
 }
 
-.emotion-10 {
+.emotion-15 {
+  vertical-align: middle;
+  fill: #3f4250;
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  min-height: 1em;
+}
+
+.emotion-15 .fillStroke {
+  stroke: #3f4250;
+  fill: none;
+}
+
+.emotion-17 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -162,8 +575,207 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   font-size: 14px;
 }
 
-.emotion-10[data-size='large'] {
+.emotion-17[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-17 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 16px;
+  background: transparent;
+  font-size: 14px;
+}
+
+.emotion-17[data-size='large'] {
+  font-size: 16px;
+}
+
+.emotion-19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 0 16px;
+  border-left: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 0 16px;
+  border-left: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-23 {
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 0.5px solid #d9dadd;
+  min-width: 24px;
+  min-height: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-23[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-23[data-children-length='true'] {
+  width: auto;
+  padding: 0 8px;
+}
+
+.emotion-23 {
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 0.5px solid #d9dadd;
+  min-width: 24px;
+  min-height: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-23[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-23[data-children-length='true'] {
+  width: auto;
+  padding: 0 8px;
+}
+
+.emotion-25 {
+  color: #3f4250;
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-25 {
+  color: #3f4250;
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 <div
@@ -171,27 +783,41 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   >
     <div>
       <div
-        aria-controls=":r0:"
-        aria-describedby=":r0:"
+        aria-controls=":rs:"
+        aria-describedby=":rs:"
         class="emotion-0 emotion-1"
         tabindex="0"
       >
         <div
-          class="emotion-2 emotion-3"
+          class="emotion-2 emotion-3 emotion-4"
         >
+          <div
+            class="emotion-5 emotion-4"
+          >
+            <div
+              class="emotion-7 emotion-4"
+            >
+              <label
+                class="emotion-9 emotion-10"
+                for=":rt:"
+              >
+                input-label
+              </label>
+            </div>
+          </div>
           <div>
             <div
-              class="emotion-4 emotion-5"
+              class="emotion-11 emotion-12"
               data-disabled="false"
               data-error="false"
               data-readonly="false"
               data-success="false"
             >
               <div
-                class="emotion-6 emotion-7"
+                class="emotion-13 emotion-14"
               >
                 <svg
-                  class="emotion-8 emotion-9"
+                  class="emotion-15 emotion-16"
                   viewBox="0 0 20 20"
                   xmlns="http://www.w3.org/2000/svg"
                 >
@@ -204,15 +830,1803 @@ exports[`SearchInput > renders correctly without children props 1`] = `
               </div>
               <input
                 aria-invalid="false"
-                class="emotion-10 emotion-11"
+                class="emotion-17 emotion-18"
                 data-size="large"
-                id=":r1:"
+                data-testid="search-bar"
+                id=":rt:"
+                placeholder="Type something"
+                type="text"
+                value=""
+              />
+              <div
+                class="emotion-19 emotion-20"
+              >
+                <div
+                  class="emotion-21 emotion-4"
+                >
+                  <div
+                    class="emotion-23 emotion-24"
+                    data-children-length="true"
+                  >
+                    <span
+                      class="emotion-25 emotion-10"
+                    >
+                      Ctrl
+                    </span>
+                  </div>
+                  <div
+                    class="emotion-23 emotion-24"
+                    data-children-length="false"
+                  >
+                    <span
+                      class="emotion-25 emotion-10"
+                    >
+                      K
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > render correctly with shortcut and check if it works 2`] = `
+<DocumentFragment>
+  @keyframes animation-0 {
+  0% {
+    opacity: 0;
+    -webkit-transform: translate3d(0px, 4px, 0);
+    -moz-transform: translate3d(0px, 4px, 0);
+    -ms-transform: translate3d(0px, 4px, 0);
+    transform: translate3d(0px, 4px, 0);
+  }
+
+  100% {
+    opacity: 1;
+    -webkit-transform: translate3d(0px, 4px, 0);
+    -moz-transform: translate3d(0px, 4px, 0);
+    -ms-transform: translate3d(0px, 4px, 0);
+    transform: translate3d(0px, 4px, 0);
+  }
+}
+
+.emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-3 .emotion-14 {
+  border: none;
+}
+
+.emotion-3 .emotion-18 {
+  padding: 0;
+}
+
+.emotion-3 .e7tir8v3 {
+  border: none;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-3 .emotion-14 {
+  border: none;
+}
+
+.emotion-3 .emotion-18 {
+  padding: 0;
+}
+
+.emotion-3 .e7tir8v3 {
+  border: none;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-9 {
+  color: #3f4250;
+  font-size: 16px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: 48px;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
+}
+
+.emotion-11>.emotion-18 {
+  color: #3f4250;
+}
+
+.emotion-11>.emotion-18::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.emotion-11>.emotion-18::-moz-placeholder {
+  color: #727683;
+}
+
+.emotion-11>.emotion-18:-ms-input-placeholder {
+  color: #727683;
+}
+
+.emotion-11>.emotion-18::placeholder {
+  color: #727683;
+}
+
+.emotion-11[data-success='true'] {
+  border-color: #22674e;
+}
+
+.emotion-11[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.emotion-11[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+}
+
+.emotion-11[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18 {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18::-webkit-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18::-moz-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18:-ms-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11[data-disabled='true']>.emotion-18::placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-11:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 16px;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 16px;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-15 {
+  vertical-align: middle;
+  fill: #3f4250;
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  min-height: 1em;
+}
+
+.emotion-15 .fillStroke {
+  stroke: #3f4250;
+  fill: none;
+}
+
+.emotion-15 {
+  vertical-align: middle;
+  fill: #3f4250;
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  min-height: 1em;
+}
+
+.emotion-15 .fillStroke {
+  stroke: #3f4250;
+  fill: none;
+}
+
+.emotion-17 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 16px;
+  background: transparent;
+  font-size: 14px;
+}
+
+.emotion-17[data-size='large'] {
+  font-size: 16px;
+}
+
+.emotion-17 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 16px;
+  background: transparent;
+  font-size: 14px;
+}
+
+.emotion-17[data-size='large'] {
+  font-size: 16px;
+}
+
+.emotion-19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 0 16px;
+}
+
+.emotion-19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 0 16px;
+}
+
+.emotion-21 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 32px;
+  padding: 0 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: none;
+  color: #3f4250;
+}
+
+.emotion-21:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-21:active {
+  box-shadow: 0px 0px 0px 3px #151a2d5c;
+}
+
+.emotion-21:hover,
+.emotion-21:active {
+  background: #e9eaeb;
+  color: #222638;
+}
+
+.emotion-23 {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.emotion-23 .fillStroke {
+  stroke: currentColor;
+  fill: none;
+}
+
+.emotion-26 {
+  background: #151a2d;
+  color: #ffffff;
+  border-radius: 4px;
+  padding: 4px 8px;
+  text-align: center;
+  position: absolute;
+  max-width: 0px;
+  max-height: 410px;
+  overflow: auto;
+  overflow-wrap: break-word;
+  font-size: 0.8rem;
+  inset: 0 auto auto 0;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  -webkit-transform: translate3d(0px, 4px, 0);
+  -moz-transform: translate3d(0px, 4px, 0);
+  -ms-transform: translate3d(0px, 4px, 0);
+  transform: translate3d(0px, 4px, 0);
+  width: 100%;
+  text-align: initial;
+  min-width: 610px;
+  padding: 16px 8px;
+  background: #ffffff;
+  box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
+}
+
+.emotion-26[data-animated="true"] {
+  -webkit-animation: 0ms animation-0 forwards;
+  animation: 0ms animation-0 forwards;
+}
+
+.emotion-26[data-has-arrow="true"]::after {
+  content: " ";
+  position: absolute;
+  top: -5px;
+  left: 0px;
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  margin-left: -8px;
+  border-width: 8px;
+  border-style: solid;
+  border-color: #151a2d transparent transparent transparent;
+  pointer-events: none;
+}
+
+.emotion-26[data-visible-in-dom="false"] {
+  display: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div>
+      <div
+        aria-controls=":rs:"
+        aria-describedby=":rs:"
+        class="emotion-0 emotion-1"
+        tabindex="0"
+      >
+        <div
+          class="emotion-2 emotion-3 emotion-4"
+        >
+          <div
+            class="emotion-5 emotion-4"
+          >
+            <div
+              class="emotion-7 emotion-4"
+            >
+              <label
+                class="emotion-9 emotion-10"
+                for=":rt:"
+              >
+                input-label
+              </label>
+            </div>
+          </div>
+          <div>
+            <div
+              class="emotion-11 emotion-12"
+              data-disabled="false"
+              data-error="false"
+              data-readonly="false"
+              data-success="false"
+            >
+              <div
+                class="emotion-13 emotion-14"
+              >
+                <svg
+                  class="emotion-15 emotion-16"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-invalid="false"
+                class="emotion-17 emotion-18"
+                data-size="large"
+                data-testid="search-bar"
+                id=":rt:"
+                placeholder="Type something"
+                type="text"
+                value="k"
+              />
+              <div
+                class="emotion-19 emotion-20"
+              >
+                <button
+                  aria-label="clear value"
+                  class="emotion-21 emotion-22"
+                  type="button"
+                >
+                  <svg
+                    class="emotion-23 emotion-16"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="emotion-25 emotion-26 emotion-27"
+          data-animated="false"
+          data-has-arrow="false"
+          data-testid="popup-search-bar"
+          id=":rs:"
+          role="dialog"
+          style="opacity: 1;"
+        >
+          <div>
+            <a
+              data-testid="children-1"
+              href="/"
+            >
+              Result 1
+            </a>
+            <a
+              data-testid="children-2"
+              href="/"
+            >
+              Result 2
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > renders correctly without children props 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-3 .emotion-8 {
+  border: none;
+}
+
+.emotion-3 .emotion-12 {
+  padding: 0;
+}
+
+.emotion-3 .e7tir8v3 {
+  border: none;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: 48px;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+}
+
+.emotion-5>.emotion-12 {
+  color: #3f4250;
+}
+
+.emotion-5>.emotion-12::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::-moz-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12:-ms-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::placeholder {
+  color: #727683;
+}
+
+.emotion-5[data-success='true'] {
+  border-color: #22674e;
+}
+
+.emotion-5[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.emotion-5[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+}
+
+.emotion-5[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12 {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-webkit-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-moz-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12:-ms-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 16px;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-9 {
+  vertical-align: middle;
+  fill: #3f4250;
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  min-height: 1em;
+}
+
+.emotion-9 .fillStroke {
+  stroke: #3f4250;
+  fill: none;
+}
+
+.emotion-11 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 16px;
+  background: transparent;
+  font-size: 14px;
+}
+
+.emotion-11[data-size='large'] {
+  font-size: 16px;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div>
+      <div
+        aria-controls=":r3:"
+        aria-describedby=":r3:"
+        class="emotion-0 emotion-1"
+        tabindex="0"
+      >
+        <div
+          class="emotion-2 emotion-3 emotion-4"
+        >
+          <div>
+            <div
+              class="emotion-5 emotion-6"
+              data-disabled="false"
+              data-error="false"
+              data-readonly="false"
+              data-success="false"
+            >
+              <div
+                class="emotion-7 emotion-8"
+              >
+                <svg
+                  class="emotion-9 emotion-10"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-invalid="false"
+                class="emotion-11 emotion-12"
+                data-size="large"
+                id=":r4:"
                 placeholder="Type something"
                 type="text"
                 value=""
               />
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > renders with disabled and shortcut prop 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-3 .emotion-8 {
+  border: none;
+}
+
+.emotion-3 .emotion-12 {
+  padding: 0;
+}
+
+.emotion-3 .emotion-14 {
+  border: none;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: 48px;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+}
+
+.emotion-5>.emotion-12 {
+  color: #3f4250;
+}
+
+.emotion-5>.emotion-12::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::-moz-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12:-ms-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::placeholder {
+  color: #727683;
+}
+
+.emotion-5[data-success='true'] {
+  border-color: #22674e;
+}
+
+.emotion-5[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.emotion-5[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+}
+
+.emotion-5[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12 {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-webkit-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-moz-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12:-ms-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 16px;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-9 {
+  vertical-align: middle;
+  fill: #b5b7bd;
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  min-height: 1em;
+}
+
+.emotion-9 .fillStroke {
+  stroke: #b5b7bd;
+  fill: none;
+}
+
+.emotion-11 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 16px;
+  background: transparent;
+  font-size: 14px;
+}
+
+.emotion-11[data-size='large'] {
+  font-size: 16px;
+}
+
+.emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 0 16px;
+  border-left: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-17 {
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 0.5px solid #d9dadd;
+  min-width: 24px;
+  min-height: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-17[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-17[data-children-length='true'] {
+  width: auto;
+  padding: 0 8px;
+}
+
+.emotion-19 {
+  color: #b5b7bd;
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div>
+      <div
+        aria-controls=":r9:"
+        aria-describedby=":r9:"
+        class="emotion-0 emotion-1"
+        tabindex="0"
+      >
+        <div
+          class="emotion-2 emotion-3 emotion-4"
+        >
+          <div>
+            <div
+              class="emotion-5 emotion-6"
+              data-disabled="true"
+              data-error="false"
+              data-readonly="false"
+              data-success="false"
+            >
+              <div
+                class="emotion-7 emotion-8"
+              >
+                <svg
+                  class="emotion-9 emotion-10"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-invalid="false"
+                class="emotion-11 emotion-12"
+                data-size="large"
+                disabled=""
+                id=":ra:"
+                placeholder="Type something"
+                type="text"
+                value=""
+              />
+              <div
+                class="emotion-13 emotion-14"
+              >
+                <div
+                  class="emotion-15 emotion-4"
+                >
+                  <div
+                    class="emotion-17 emotion-18"
+                    data-children-length="true"
+                    data-disabled="true"
+                  >
+                    <span
+                      class="emotion-19 emotion-20"
+                    >
+                      Ctrl
+                    </span>
+                  </div>
+                  <div
+                    class="emotion-17 emotion-18"
+                    data-children-length="false"
+                    data-disabled="true"
+                  >
+                    <span
+                      class="emotion-19 emotion-20"
+                    >
+                      K
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > renders with disabled prop 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-3 .emotion-8 {
+  border: none;
+}
+
+.emotion-3 .emotion-12 {
+  padding: 0;
+}
+
+.emotion-3 .e7tir8v3 {
+  border: none;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: 48px;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+}
+
+.emotion-5>.emotion-12 {
+  color: #3f4250;
+}
+
+.emotion-5>.emotion-12::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::-moz-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12:-ms-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::placeholder {
+  color: #727683;
+}
+
+.emotion-5[data-success='true'] {
+  border-color: #22674e;
+}
+
+.emotion-5[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.emotion-5[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+}
+
+.emotion-5[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12 {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-webkit-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-moz-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12:-ms-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 16px;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-9 {
+  vertical-align: middle;
+  fill: #b5b7bd;
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  min-height: 1em;
+}
+
+.emotion-9 .fillStroke {
+  stroke: #b5b7bd;
+  fill: none;
+}
+
+.emotion-11 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 16px;
+  background: transparent;
+  font-size: 14px;
+}
+
+.emotion-11[data-size='large'] {
+  font-size: 16px;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div>
+      <div
+        aria-controls=":r6:"
+        aria-describedby=":r6:"
+        class="emotion-0 emotion-1"
+        tabindex="0"
+      >
+        <div
+          class="emotion-2 emotion-3 emotion-4"
+        >
+          <div>
+            <div
+              class="emotion-5 emotion-6"
+              data-disabled="true"
+              data-error="false"
+              data-readonly="false"
+              data-success="false"
+            >
+              <div
+                class="emotion-7 emotion-8"
+              >
+                <svg
+                  class="emotion-9 emotion-10"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-invalid="false"
+                class="emotion-11 emotion-12"
+                data-size="large"
+                disabled=""
+                id=":r7:"
+                placeholder="Type something"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SearchInput > renders with error prop 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-3 .emotion-8 {
+  border: none;
+}
+
+.emotion-3 .emotion-12 {
+  padding: 0;
+}
+
+.emotion-3 .e7tir8v3 {
+  border: none;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: 48px;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+}
+
+.emotion-5>.emotion-12 {
+  color: #3f4250;
+}
+
+.emotion-5>.emotion-12::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::-moz-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12:-ms-input-placeholder {
+  color: #727683;
+}
+
+.emotion-5>.emotion-12::placeholder {
+  color: #727683;
+}
+
+.emotion-5[data-success='true'] {
+  border-color: #22674e;
+}
+
+.emotion-5[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.emotion-5[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+}
+
+.emotion-5[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12 {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-webkit-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::-moz-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12:-ms-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5[data-disabled='true']>.emotion-12::placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-5:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 16px;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-9 {
+  vertical-align: middle;
+  fill: #3f4250;
+  height: 1em;
+  width: 1em;
+  min-width: 1em;
+  min-height: 1em;
+}
+
+.emotion-9 .fillStroke {
+  stroke: #3f4250;
+  fill: none;
+}
+
+.emotion-11 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 16px;
+  background: transparent;
+  font-size: 14px;
+}
+
+.emotion-11[data-size='large'] {
+  font-size: 16px;
+}
+
+.emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 0 16px;
+}
+
+.emotion-15 {
+  vertical-align: middle;
+  fill: #b3144d;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.emotion-15 .fillStroke {
+  stroke: #b3144d;
+  fill: none;
+}
+
+.emotion-17 {
+  color: #b3144d;
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div>
+      <div
+        aria-controls=":re:"
+        aria-describedby=":re:"
+        class="emotion-0 emotion-1"
+        tabindex="0"
+      >
+        <div
+          class="emotion-2 emotion-3 emotion-4"
+        >
+          <div>
+            <div
+              class="emotion-5 emotion-6"
+              data-disabled="false"
+              data-error="true"
+              data-readonly="false"
+              data-success="false"
+            >
+              <div
+                class="emotion-7 emotion-8"
+              >
+                <svg
+                  class="emotion-9 emotion-10"
+                  viewBox="0 0 20 20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-invalid="true"
+                class="emotion-11 emotion-12"
+                data-size="large"
+                id=":rf:"
+                placeholder="Type something"
+                type="text"
+                value=""
+              />
+              <div
+                class="emotion-13 emotion-14"
+              >
+                <svg
+                  class="emotion-15 emotion-10"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14M8 4a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4m0 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <p
+            class="emotion-17 emotion-18"
+          >
+            there is an error
+          </p>
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/SearchInput/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SearchInput/__tests__/index.test.tsx
@@ -3,8 +3,20 @@ import userEvent from '@testing-library/user-event'
 import { renderWithTheme, shouldMatchEmotionSnapshot } from '@utils/test'
 import { describe, expect, test } from 'vitest'
 import { SearchInput } from '..'
+import { Key } from '../Key'
 
 describe('SearchInput', () => {
+  describe('Key', () => {
+    test('renders correctly with single key', () =>
+      shouldMatchEmotionSnapshot(<Key>K</Key>))
+
+    test('renders correctly with long key', () =>
+      shouldMatchEmotionSnapshot(<Key>Ctrl</Key>))
+
+    test('renders correctly with disabled', () =>
+      shouldMatchEmotionSnapshot(<Key disabled>K</Key>))
+  })
+
   test('renders correctly without children props', () =>
     shouldMatchEmotionSnapshot(
       <SearchInput
@@ -12,6 +24,46 @@ describe('SearchInput', () => {
         popupPlacement="bottom"
         onSearch={() => {}}
         onClose={() => {}}
+      >
+        <div />
+      </SearchInput>,
+    ))
+
+  test('renders with disabled prop', () =>
+    shouldMatchEmotionSnapshot(
+      <SearchInput
+        placeholder="Type something"
+        popupPlacement="bottom"
+        onSearch={() => {}}
+        onClose={() => {}}
+        disabled
+      >
+        <div />
+      </SearchInput>,
+    ))
+
+  test('renders with disabled and shortcut prop', () =>
+    shouldMatchEmotionSnapshot(
+      <SearchInput
+        placeholder="Type something"
+        popupPlacement="bottom"
+        onSearch={() => {}}
+        onClose={() => {}}
+        disabled
+        shortcut
+      >
+        <div />
+      </SearchInput>,
+    ))
+
+  test('renders with error prop', () =>
+    shouldMatchEmotionSnapshot(
+      <SearchInput
+        placeholder="Type something"
+        popupPlacement="bottom"
+        onSearch={() => {}}
+        onClose={() => {}}
+        error="there is an error"
       >
         <div />
       </SearchInput>,
@@ -110,5 +162,38 @@ describe('SearchInput', () => {
     await waitFor(() => {
       expect(popupSearchInput).not.toBeVisible()
     })
+  })
+
+  test('render correctly with shortcut and check if it works', async () => {
+    const { asFragment } = renderWithTheme(
+      <SearchInput
+        size="large"
+        placeholder="Type something"
+        label="input-label"
+        data-testid="search-bar"
+        popupPlacement="bottom"
+        onSearch={() => {}}
+        shortcut
+      >
+        <div>
+          <a href="/" data-testid="children-1">
+            Result 1
+          </a>
+          <a href="/" data-testid="children-2">
+            Result 2
+          </a>
+        </div>
+      </SearchInput>,
+    )
+    expect(asFragment()).toMatchSnapshot()
+
+    const SearchInputElement = screen.getByTestId('search-bar')
+    console.log(navigator.userAgent)
+
+    await userEvent.keyboard('{Control>}k')
+    await userEvent.keyboard('{Meta>}k')
+    expect(SearchInputElement).toHaveFocus()
+
+    expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/packages/ui/src/components/SearchInput/index.tsx
+++ b/packages/ui/src/components/SearchInput/index.tsx
@@ -155,7 +155,7 @@ export const SearchInput = forwardRef(
 
     const isMacOS = navigator.userAgent.includes('Mac')
 
-    const handleShortCut = useCallback(
+    const handleShortcut = useCallback(
       (event: KeyboardEvent) => {
         const { ctrlKey, metaKey, key } = event
 
@@ -172,13 +172,13 @@ export const SearchInput = forwardRef(
 
     useEffect(() => {
       if (shortcut && !disabled) {
-        document.body.addEventListener('keydown', handleShortCut)
+        document.body.addEventListener('keydown', handleShortcut)
       }
 
       return () => {
-        document.body.removeEventListener('keydown', handleShortCut)
+        document.body.removeEventListener('keydown', handleShortcut)
       }
-    }, [handleShortCut, shortcut, disabled])
+    }, [handleShortcut, shortcut, disabled])
 
     return (
       <div>

--- a/packages/ui/src/components/SearchInput/index.tsx
+++ b/packages/ui/src/components/SearchInput/index.tsx
@@ -1,9 +1,23 @@
 import styled from '@emotion/styled'
 import { Icon } from '@ultraviolet/icons'
 import type { Ref } from 'react'
-import { forwardRef, useEffect, useReducer, useRef, useState } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import { Popup } from '../Popup'
-import { TextInputV2 } from '../TextInputV2'
+import {
+  BasicPrefixStack,
+  BasicSuffixStack,
+  StyledInput,
+  TextInputV2,
+} from '../TextInputV2'
+import { KeyGroup } from './KeyGroup'
 import type { SearchInputProps } from './types'
 
 const StyledPopup = styled(Popup)`
@@ -11,8 +25,22 @@ const StyledPopup = styled(Popup)`
   text-align: initial;
   min-width: 610px;
   padding: ${({ theme }) => `${theme.space['2']} ${theme.space['1']}`};
-  background: ${({ theme }) => theme.colors.neutral.background};
-  box-shadow: ${({ theme }) => theme.shadows.modal};
+  background: ${({ theme }) => theme.colors.other.elevation.background.raised};
+  box-shadow: ${({ theme }) => `${theme.shadows.raised[0]}, ${theme.shadows.raised[1]}`};
+`
+
+const StyledTextInputV2 = styled(TextInputV2)`
+  ${BasicPrefixStack} {
+    border: none;
+  }
+
+  ${StyledInput} {
+    padding: 0;
+  }
+
+  ${BasicSuffixStack} {
+    border: none;
+  }
 `
 
 /**
@@ -29,13 +57,15 @@ export const SearchInput = forwardRef(
       label,
       loading,
       size,
-      suffix,
       popupPlacement,
       threshold = 0,
       children,
       onSearch,
       onClose,
       'data-testid': dataTestId,
+      shortcut = false,
+      error,
+      disabled,
     }: SearchInputProps,
     ref: Ref<HTMLInputElement>,
   ) => {
@@ -44,6 +74,11 @@ export const SearchInput = forwardRef(
     const [containerWidth, setContainerWidth] = useState(0)
     const [searchTerms, setSearchTerms] = useState('')
     const [isOpen, toggleIsOpen] = useReducer(state => !state, false)
+    const innerSearchInputRef = useRef<HTMLInputElement>(null)
+    useImperativeHandle(
+      ref,
+      () => innerSearchInputRef.current as HTMLInputElement,
+    )
 
     const content =
       typeof children === 'function'
@@ -118,6 +153,33 @@ export const SearchInput = forwardRef(
       }
     }
 
+    const isMacOS = navigator.userAgent.includes('Mac')
+
+    const handleShortCut = useCallback(
+      (event: KeyboardEvent) => {
+        const { ctrlKey, metaKey, key } = event
+
+        if (
+          (key === 'k' || key === 'K') &&
+          ((!isMacOS && ctrlKey) || (isMacOS && metaKey))
+        ) {
+          event.preventDefault()
+          innerSearchInputRef.current?.focus()
+        }
+      },
+      [isMacOS, innerSearchInputRef],
+    )
+
+    useEffect(() => {
+      if (shortcut && !disabled) {
+        document.body.addEventListener('keydown', handleShortCut)
+      }
+
+      return () => {
+        document.body.removeEventListener('keydown', handleShortCut)
+      }
+    }, [handleShortCut, shortcut, disabled])
+
     return (
       <div>
         <StyledPopup
@@ -134,11 +196,21 @@ export const SearchInput = forwardRef(
           maxHeight={410}
           debounceDelay={0}
         >
-          <TextInputV2
-            ref={ref}
-            prefix={<Icon name="search" />}
-            suffix={suffix}
+          <StyledTextInputV2
+            ref={innerSearchInputRef}
+            prefix={
+              <Icon name="search" disabled={disabled} sentiment="neutral" />
+            }
+            suffix={
+              shortcut && searchTerms.length === 0 ? (
+                <KeyGroup
+                  disabled={disabled}
+                  keys={[isMacOS ? '⌘' : 'Ctrl', 'K']}
+                />
+              ) : undefined
+            }
             data-testid={dataTestId}
+            error={error}
             value={searchTerms}
             size={size}
             label={label}
@@ -146,6 +218,7 @@ export const SearchInput = forwardRef(
             loading={loading}
             onChange={onSearchCallback}
             clearable
+            disabled={disabled}
           />
         </StyledPopup>
       </div>

--- a/packages/ui/src/components/SearchInput/types.ts
+++ b/packages/ui/src/components/SearchInput/types.ts
@@ -20,7 +20,11 @@ export type SearchInputProps = {
   onSearch: (value: string) => void
   onClose?: () => void
   ['data-testid']?: string
+  /**
+   * If set to true images will be shown with key shortcut to focus the input on the right of the search bar
+   */
+  shortcut?: boolean
 } & Pick<
   ComponentProps<typeof TextInputV2>,
-  'placeholder' | 'size' | 'label' | 'loading' | 'suffix'
+  'placeholder' | 'size' | 'label' | 'loading' | 'error' | 'disabled'
 >

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -16,7 +16,7 @@ export const TEXTINPUT_SIZE_HEIGHT = {
 } as const
 type TextInputSize = keyof typeof TEXTINPUT_SIZE_HEIGHT
 
-const BasicPrefixStack = styled(Stack)`
+export const BasicPrefixStack = styled(Stack)`
   padding: ${({ theme }) => theme.space['2']};
   border-right: 1px solid;
   border-color: inherit;
@@ -26,7 +26,7 @@ const StateStack = styled(Stack)`
   padding: ${({ theme }) => `0 ${theme.space['2']}`};
 `
 
-const BasicSuffixStack = styled(Stack)`
+export const BasicSuffixStack = styled(Stack)`
   padding: ${({ theme }) => `0 ${theme.space['2']}`};
   border-left: 1px solid;
   border-color: inherit;
@@ -38,7 +38,7 @@ const CTASuffixStack = styled(Stack)`
   border-color: inherit;
 `
 
-const StyledInput = styled.input<{
+export const StyledInput = styled.input<{
   'data-size': TextInputSize
 }>`
   flex: 1;


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

#### What is expected?

Design update and new features on `<SearchInput />`:
- New design for the input with a simpler and cleaner look.
- New prop `shortcut`, when set to true the input will be focusable with `Ctrl + K` on Windows and Linux and `Cmd + K` on macOS. It also add the shortcut into the input placeholder.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2024-06-28 at 10 46 09](https://github.com/scaleway/ultraviolet/assets/15812968/9b0fa199-bd02-4b23-bea6-54be0fcd01b6) | ![Screenshot 2024-06-28 at 10 46 14](https://github.com/scaleway/ultraviolet/assets/15812968/bd5d0723-993f-4db0-a9c7-559766d3614b) |
