### PR TITLE
fix(SelectInputFieldV2): add tooltip

### DIFF
--- a/.changeset/tough-pianos-agree.md
+++ b/.changeset/tough-pianos-agree.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+fix(SelectInputFieldV2): add tooltip

--- a/packages/form/src/components/SelectInputFieldV2/index.tsx
+++ b/packages/form/src/components/SelectInputFieldV2/index.tsx
@@ -41,6 +41,7 @@ type SelectInputFieldV2Props<
     | 'onFocus'
     | 'optionalInfoPlacement'
     | 'disabled'
+    | 'tooltip'
   >
 
 export const SelectInputFieldV2 = <
@@ -81,6 +82,7 @@ export const SelectInputFieldV2 = <
   shouldUnregister = false,
   control,
   validate,
+  tooltip,
 }: SelectInputFieldV2Props<TFieldValues, TFieldName>) => {
   const {
     field,
@@ -145,6 +147,7 @@ export const SelectInputFieldV2 = <
       optionalInfoPlacement={optionalInfoPlacement}
       aria-label={ariaLabel}
       onChange={handleChange}
+      tooltip={tooltip}
     />
   )
 }


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Add missing `tooltip` prop to `SelectInputFieldV2`.
