### PR TITLE
fix(Modal): focus on close

### DIFF
--- a/.changeset/seven-laws-pump.md
+++ b/.changeset/seven-laws-pump.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<Modal />`: when a modal is closed, focus should be on disclosure

--- a/packages/ui/src/components/Modal/Disclosure.tsx
+++ b/packages/ui/src/components/Modal/Disclosure.tsx
@@ -1,11 +1,5 @@
 import type { PropsWithRef } from 'react'
-import {
-  cloneElement,
-  createRef,
-  isValidElement,
-  useEffect,
-  useMemo,
-} from 'react'
+import { cloneElement, isValidElement, useEffect, useMemo } from 'react'
 import type { DisclosureProps } from './types'
 
 export const Disclosure = ({
@@ -15,9 +9,8 @@ export const Disclosure = ({
   handleClose,
   toggle,
   id,
+  disclosureRef,
 }: DisclosureProps) => {
-  const disclosureRef = createRef<HTMLElement>()
-
   useEffect(() => {
     const element = disclosureRef.current
     element?.addEventListener('click', handleOpen)

--- a/packages/ui/src/components/Modal/index.tsx
+++ b/packages/ui/src/components/Modal/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import type { ReactElement, ReactNode } from 'react'
 import type React from 'react'
-import { useCallback, useId, useState } from 'react'
+import { useCallback, useId, useRef, useState } from 'react'
 import { Button } from '../Button'
 import { Dialog } from './Dialog'
 import { Disclosure } from './Disclosure'
@@ -77,6 +77,7 @@ export const Modal = ({
   // Used for disclosure usage only
   const [visible, setVisible] = useState(false)
   const controlId = useId()
+  const disclosureRef = useRef<HTMLElement>(null)
 
   const handleOpen = useCallback(() => {
     setVisible(true)
@@ -92,7 +93,8 @@ export const Modal = ({
       }
       setVisible(false)
     }
-  }, [onBeforeClose, onClose])
+    disclosureRef.current?.focus()
+  }, [disclosureRef, onBeforeClose, onClose])
 
   const handleToggle = useCallback(() => {
     setVisible(current => !current)
@@ -111,6 +113,7 @@ export const Modal = ({
           handleClose={handleClose}
           visible={visible}
           toggle={handleToggle}
+          disclosureRef={disclosureRef}
         />
       ) : null}
       <Dialog

--- a/packages/ui/src/components/Modal/types.ts
+++ b/packages/ui/src/components/Modal/types.ts
@@ -41,6 +41,7 @@ export type DisclosureProps = {
   visible: ModalState['visible']
   toggle: ModalState['toggle']
   id: string
+  disclosureRef: React.RefObject<HTMLElement>
 }
 
 export type DialogProps = {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

`<Modal />`: when a modal is closed, focus should be on disclosure 
This also fixes the issue for MenuV2.item when it is used with a modal.
