### PR TITLE
ci: fix teardown error

### DIFF
--- a/.github/workflows/teardown_pull_request.yml
+++ b/.github/workflows/teardown_pull_request.yml
@@ -37,5 +37,5 @@ jobs:
         uses: bobheadxi/deployments@v1.5.0
         with:
           step: delete-env
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ env.STORYBOOK_BRANCH_SLUG }}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Seems like the secret tokens we have doesn't have the right permission to remove deployment. Let's use the one provided by Github directly.

## Relevant logs and/or screenshots

<img width="1392" alt="Screenshot 2024-07-08 at 10 31 42" src="https://github.com/scaleway/ultraviolet/assets/15812968/b43f4fb3-100f-4b5c-a412-751c70b55037">

