### PR TITLE
ci: remove dns deployement on preprod env

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       IMAGE_NAME: rg.fr-par.scw.cloud/ultraviolet/storybook
       DEPLOYMENT_NAME: "storybook"
+      SCW_DNS: ${{ github.ref_name == 'main' && 'storybook.ultraviolet.scaleway.com' || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Inject slug/short variables
@@ -93,7 +94,7 @@ jobs:
         with:
           type: "deploy"
           # scw_dns: ${{ secrets.SCW_DNS }}
-          scw_dns: storybook.ultraviolet.scaleway.com
+          scw_dns: ${{ env.SCW_DNS }}
           root_zone: ${{ env.BRANCH_SLUG == 'main' }}
           scw_access_key: ${{ secrets.SCW_ACCESS_KEY }}
           scw_secret_key: ${{ secrets.SCW_SECRET_KEY }}

--- a/.github/workflows/teardown_pull_request.yml
+++ b/.github/workflows/teardown_pull_request.yml
@@ -10,6 +10,7 @@ jobs:
     env:
       IMAGE_NAME: rg.fr-par.scw.cloud/ultraviolet/storybook
       STORYBOOK_DEPLOYMENT_NAME: storybook
+      SCW_DNS: ${{ github.ref_name == 'main' && 'storybook.ultraviolet.scaleway.com' || '' }}
 
     steps:
       - uses: actions/checkout@v4 # v4.1.4
@@ -26,7 +27,7 @@ jobs:
         id: deploy
         with:
           type: "teardown"
-          scw_dns: ${{ secrets.SCW_DNS }}
+          scw_dns: ${{ env.SCW_DNS }}
           root_zone: ${{ env.BRANCH_SLUG == 'main' }}
           scw_access_key: ${{ secrets.SCW_ACCESS_KEY }}
           scw_secret_key: ${{ secrets.SCW_SECRET_KEY }}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

DNS deployment is quite long with serverless and we don't really need it in preprod. So I added a condition to remove it when the branch is not main.
