### PR TITLE
refactor: improve tagslist component

### DIFF
--- a/.changeset/poor-scissors-talk.md
+++ b/.changeset/poor-scissors-talk.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+refactor: improve tagslist component

--- a/.changeset/poor-scissors-talk.md
+++ b/.changeset/poor-scissors-talk.md
@@ -2,4 +2,4 @@
 "@ultraviolet/ui": minor
 ---
 
-refactor: improve tagslist component
+Refactoring of `<TagsList />` component to improve display of long text elements

--- a/packages/ui/src/components/TagList/__stories__/ParentWithWidth.stories.tsx
+++ b/packages/ui/src/components/TagList/__stories__/ParentWithWidth.stories.tsx
@@ -5,13 +5,11 @@ import { Stack } from '../../Stack'
 export const ParentWithDefinedWidth: StoryFn<typeof TagList> = args => (
   <Stack gap={2}>
     <div style={{ width: '250px', border: '1px solid gray', padding: '10px' }}>
-      {/* @ts-expect-error we want to set a default title */}
-      <TagList popoverTitle="Additional" {...args} />
+      <TagList {...args} />
     </div>
 
     <div style={{ width: '100px', border: '1px solid gray', padding: '10px' }}>
-      {/* @ts-expect-error we want to set a default title */}
-      <TagList popoverTitle="Additional" {...args} />
+      <TagList {...args} />
     </div>
   </Stack>
 )
@@ -28,4 +26,5 @@ ParentWithDefinedWidth.parameters = {
 ParentWithDefinedWidth.args = {
   tags: ['smooth', 'code', 'hello', 'world', 'please', 'work'],
   threshold: 5,
+  popoverTitle: 'Additional',
 }

--- a/packages/ui/src/components/TagList/__stories__/ParentWithWidth.stories.tsx
+++ b/packages/ui/src/components/TagList/__stories__/ParentWithWidth.stories.tsx
@@ -1,0 +1,31 @@
+import type { StoryFn } from '@storybook/react'
+import { TagList } from '..'
+import { Stack } from '../../Stack'
+
+export const ParentWithDefinedWidth: StoryFn<typeof TagList> = args => (
+  <Stack gap={2}>
+    <div style={{ width: '250px', border: '1px solid gray', padding: '10px' }}>
+      {/* @ts-expect-error we want to set a default title */}
+      <TagList popoverTitle="Additional" {...args} />
+    </div>
+
+    <div style={{ width: '100px', border: '1px solid gray', padding: '10px' }}>
+      {/* @ts-expect-error we want to set a default title */}
+      <TagList popoverTitle="Additional" {...args} />
+    </div>
+  </Stack>
+)
+
+ParentWithDefinedWidth.parameters = {
+  docs: {
+    description: {
+      story:
+        'The `threshold` in the example is 5. Is is ignored because the tags will then overflow the parent.',
+    },
+  },
+}
+
+ParentWithDefinedWidth.args = {
+  tags: ['smooth', 'code', 'hello', 'world', 'please', 'work'],
+  threshold: 5,
+}

--- a/packages/ui/src/components/TagList/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/TagList/__stories__/Template.stories.tsx
@@ -1,7 +1,8 @@
 import type { StoryFn } from '@storybook/react'
 import { TagList } from '..'
 
-export const Template: StoryFn<typeof TagList> = args => (
-  // @ts-expect-error we want to set a default title
-  <TagList popoverTitle="Additional" {...args} />
-)
+export const Template: StoryFn<typeof TagList> = args => <TagList {...args} />
+
+Template.args = {
+  popoverTitle: 'Additional',
+}

--- a/packages/ui/src/components/TagList/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TagList/__stories__/index.stories.tsx
@@ -3,6 +3,13 @@ import { TagList } from '..'
 
 export default {
   component: TagList,
+  decorators: [
+    StoryComponent => (
+      <div style={{ width: 500 }}>
+        <StoryComponent />
+      </div>
+    ),
+  ],
   title: 'Components/Data Display/TagList',
 } as Meta
 
@@ -11,3 +18,4 @@ export { Threshold } from './Threshold.stories'
 export { Multiline } from './Multiline.stories'
 export { Copiable } from './Copiable.stories'
 export { Icons } from './Icons.stories'
+export { ParentWithDefinedWidth } from './ParentWithWidth.stories'

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -29,8 +29,9 @@ exports[`TagList > renders correctly 1`] = `
   max-width: fit-content;
 }
 
-.emotion-2 * {
-  width: 100%!important;
+.emotion-2 span,
+.emotion-2 div {
+  width: 100%;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
   max-width: fit-content;
@@ -257,8 +258,9 @@ exports[`TagList > renders correctly and ignore custom threshold as it does not 
   max-width: fit-content;
 }
 
-.emotion-2 * {
-  width: 100%!important;
+.emotion-2 span,
+.emotion-2 div {
+  width: 100%;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
   max-width: fit-content;
@@ -461,8 +463,8 @@ exports[`TagList > renders correctly with copiable 1`] = `
         class="emotion-2 emotion-3"
       >
         <div
-          aria-controls=":r12:"
-          aria-describedby=":r12:"
+          aria-controls=":r11:"
+          aria-describedby=":r11:"
           class="emotion-4 emotion-5"
           tabindex="0"
         >
@@ -477,13 +479,13 @@ exports[`TagList > renders correctly with copiable 1`] = `
           </button>
         </div>
         <div
-          aria-controls=":r14:"
-          aria-describedby=":r14:"
+          aria-controls=":r13:"
+          aria-describedby=":r13:"
           class="emotion-4 emotion-5"
           tabindex="0"
         >
           <button
-            class=" emotion-6 emotion-7"
+            class="ellipsed emotion-6 emotion-7"
           >
             <span
               class="emotion-8 emotion-9 emotion-10"
@@ -581,7 +583,7 @@ exports[`TagList > renders correctly with custom threshold 1`] = `
           </span>
         </span>
         <span
-          class=" emotion-4 emotion-5"
+          class="ellipsed emotion-4 emotion-5"
         >
           <span
             class="emotion-6 emotion-7 emotion-8"
@@ -615,6 +617,21 @@ exports[`TagList > renders correctly with custom threshold and extra tags 1`] = 
   align-items: center;
   color: #3f4250;
   gap: 8px;
+}
+
+.emotion-2:has(.ellipsed) {
+  width: calc(100% - 50px);
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.emotion-2 span,
+.emotion-2 div {
+  width: 100%;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
 }
 
 .emotion-4 {
@@ -703,7 +720,7 @@ exports[`TagList > renders correctly with custom threshold and extra tags 1`] = 
           </span>
         </span>
         <span
-          class=" emotion-4 emotion-5"
+          class="ellipsed emotion-4 emotion-5"
         >
           <span
             class="emotion-6 emotion-7 emotion-8"
@@ -759,8 +776,9 @@ exports[`TagList > renders correctly with custom threshold and extra tags and ma
   max-width: fit-content;
 }
 
-.emotion-2 * {
-  width: 100%!important;
+.emotion-2 span,
+.emotion-2 div {
+  width: 100%;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
   max-width: fit-content;
@@ -853,8 +871,8 @@ exports[`TagList > renders correctly with custom threshold and extra tags and ma
         </span>
       </div>
       <div
-        aria-controls=":ro:"
-        aria-describedby=":ro:"
+        aria-controls=":rn:"
+        aria-describedby=":rn:"
         class="emotion-9 emotion-10"
         tabindex="-1"
       >
@@ -963,8 +981,8 @@ exports[`TagList > renders correctly with icons 1`] = `
         class="emotion-2 emotion-3"
       >
         <div
-          aria-controls=":r1c:"
-          aria-describedby=":r1c:"
+          aria-controls=":r1b:"
+          aria-describedby=":r1b:"
           class="emotion-4 emotion-5"
           tabindex="0"
         >
@@ -979,13 +997,13 @@ exports[`TagList > renders correctly with icons 1`] = `
           </button>
         </div>
         <div
-          aria-controls=":r1e:"
-          aria-describedby=":r1e:"
+          aria-controls=":r1d:"
+          aria-describedby=":r1d:"
           class="emotion-4 emotion-5"
           tabindex="0"
         >
           <button
-            class=" emotion-6 emotion-7"
+            class="ellipsed emotion-6 emotion-7"
           >
             <span
               class="emotion-8 emotion-9 emotion-10"
@@ -1112,7 +1130,7 @@ exports[`TagList > renders correctly with multiline 1`] = `
           </span>
         </span>
         <span
-          class=" emotion-4 emotion-5"
+          class="ellipsed emotion-4 emotion-5"
         >
           <span
             class="emotion-6 emotion-7 emotion-8"
@@ -1122,8 +1140,8 @@ exports[`TagList > renders correctly with multiline 1`] = `
         </span>
       </div>
       <div
-        aria-controls=":rt:"
-        aria-describedby=":rt:"
+        aria-controls=":rs:"
+        aria-describedby=":rs:"
         class="emotion-14 emotion-15"
         tabindex="-1"
       >
@@ -1176,8 +1194,9 @@ exports[`TagList > renders correctly with placement 1`] = `
   max-width: fit-content;
 }
 
-.emotion-2 * {
-  width: 100%!important;
+.emotion-2 span,
+.emotion-2 div {
+  width: 100%;
   max-width: -webkit-fit-content;
   max-width: -moz-fit-content;
   max-width: fit-content;

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -22,6 +22,20 @@ exports[`TagList > renders correctly 1`] = `
   gap: 8px;
 }
 
+.emotion-2:has(.ellipsed) {
+  width: calc(100% - 50px);
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.emotion-2 * {
+  width: 100%!important;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
 .emotion-4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -91,36 +105,263 @@ exports[`TagList > renders correctly 1`] = `
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
-        <div
-          class="emotion-2 emotion-3"
+        <span
+          class="ellipsed emotion-4 emotion-5"
         >
           <span
-            class="emotion-4 emotion-5"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              scaleway
-            </span>
+            scaleway
           </span>
-        </div>
-        <div
-          aria-controls=":r1:"
-          aria-describedby=":r1:"
-          class="emotion-9 emotion-10"
-          tabindex="-1"
+        </span>
+      </div>
+      <div
+        aria-controls=":r2:"
+        aria-describedby=":r2:"
+        class="emotion-9 emotion-10"
+        tabindex="-1"
+      >
+        <span
+          class="emotion-11 emotion-12"
+          data-testid="taglist-open"
+        >
+          +1
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TagList > renders correctly and add ellipsis to the first tag as it too long 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #3f4250;
+  gap: 8px;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 4px;
+  padding: 0 8px;
+  gap: 8px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: 24px;
+  color: #3f4250;
+  background: #ffffff;
+  border: solid 1px #d9dadd;
+}
+
+.emotion-7 {
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <span
+          class="ellipsed emotion-4 emotion-5"
         >
           <span
-            class="emotion-11 emotion-12"
-            data-testid="taglist-open"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            +1
+            scaleway is the best cloud provider ever invented
           </span>
-        </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`TagList > renders correctly and ignore custom threshold as it does not fit the parent 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #3f4250;
+  gap: 8px;
+}
+
+.emotion-2:has(.ellipsed) {
+  width: calc(100% - 50px);
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.emotion-2 * {
+  width: 100%!important;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 4px;
+  padding: 0 8px;
+  gap: 8px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: 24px;
+  color: #3f4250;
+  background: #ffffff;
+  border: solid 1px #d9dadd;
+}
+
+.emotion-7 {
+  font-size: 12px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 16px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 232px;
+}
+
+.emotion-9 {
+  display: inherit;
+}
+
+.emotion-9[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-11 {
+  cursor: pointer;
+  color: #641cb3;
+  border: none;
+  font-size: 14px;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  max-width: 350px;
+  overflow: hidden;
+  white-space: pre;
+  text-overflow: ellipsis;
+  background-color: transparent;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <span
+          class="ellipsed emotion-4 emotion-5"
+        >
+          <span
+            class="emotion-6 emotion-7 emotion-8"
+          >
+            scaleway
+          </span>
+        </span>
+      </div>
+      <div
+        aria-controls=":ri:"
+        aria-describedby=":ri:"
+        class="emotion-9 emotion-10"
+        tabindex="-1"
+      >
+        <span
+          class="emotion-11 emotion-12"
+          data-testid="taglist-open"
+        >
+          +2
+        </span>
       </div>
     </div>
   </div>
@@ -212,45 +453,44 @@ exports[`TagList > renders correctly with copiable 1`] = `
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
         <div
-          class="emotion-2 emotion-3"
+          aria-controls=":r12:"
+          aria-describedby=":r12:"
+          class="emotion-4 emotion-5"
+          tabindex="0"
         >
-          <div
-            aria-controls=":re:"
-            aria-describedby=":re:"
-            class="emotion-4 emotion-5"
-            tabindex="0"
+          <button
+            class=" emotion-6 emotion-7"
           >
-            <button
-              class="emotion-6 emotion-7"
+            <span
+              class="emotion-8 emotion-9 emotion-10"
             >
-              <span
-                class="emotion-8 emotion-9 emotion-10"
-              >
-                scaleway
-              </span>
-            </button>
-          </div>
-          <div
-            aria-controls=":rg:"
-            aria-describedby=":rg:"
-            class="emotion-4 emotion-5"
-            tabindex="0"
+              scaleway
+            </span>
+          </button>
+        </div>
+        <div
+          aria-controls=":r14:"
+          aria-describedby=":r14:"
+          class="emotion-4 emotion-5"
+          tabindex="0"
+        >
+          <button
+            class=" emotion-6 emotion-7"
           >
-            <button
-              class="emotion-6 emotion-7"
+            <span
+              class="emotion-8 emotion-9 emotion-10"
             >
-              <span
-                class="emotion-8 emotion-9 emotion-10"
-              >
-                cloud
-              </span>
-            </button>
-          </div>
+              cloud
+            </span>
+          </button>
         </div>
       </div>
     </div>
@@ -324,32 +564,31 @@ exports[`TagList > renders correctly with custom threshold 1`] = `
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
-        <div
-          class="emotion-2 emotion-3"
+        <span
+          class=" emotion-4 emotion-5"
         >
           <span
-            class="emotion-4 emotion-5"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              scaleway
-            </span>
+            scaleway
           </span>
+        </span>
+        <span
+          class=" emotion-4 emotion-5"
+        >
           <span
-            class="emotion-4 emotion-5"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              cloud
-            </span>
+            cloud
           </span>
-        </div>
+        </span>
       </div>
     </div>
   </div>
@@ -447,45 +686,44 @@ exports[`TagList > renders correctly with custom threshold and extra tags 1`] = 
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
-        <div
-          class="emotion-2 emotion-3"
+        <span
+          class=" emotion-4 emotion-5"
         >
           <span
-            class="emotion-4 emotion-5"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              scaleway
-            </span>
+            scaleway
           </span>
-          <span
-            class="emotion-4 emotion-5"
-          >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              cloud
-            </span>
-          </span>
-        </div>
-        <div
-          aria-controls=":r8:"
-          aria-describedby=":r8:"
-          class="emotion-14 emotion-15"
-          tabindex="-1"
+        </span>
+        <span
+          class=" emotion-4 emotion-5"
         >
           <span
-            class="emotion-16 emotion-17"
-            data-testid="taglist-open"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            +1
+            cloud
           </span>
-        </div>
+        </span>
+      </div>
+      <div
+        aria-controls=":re:"
+        aria-describedby=":re:"
+        class="emotion-14 emotion-15"
+        tabindex="-1"
+      >
+        <span
+          class="emotion-16 emotion-17"
+          data-testid="taglist-open"
+        >
+          +1
+        </span>
       </div>
     </div>
   </div>
@@ -512,6 +750,20 @@ exports[`TagList > renders correctly with custom threshold and extra tags and ma
   align-items: center;
   color: #3f4250;
   gap: 8px;
+}
+
+.emotion-2:has(.ellipsed) {
+  width: calc(100% - 100px);
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.emotion-2 * {
+  width: 100%!important;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
 }
 
 .emotion-4 {
@@ -583,36 +835,35 @@ exports[`TagList > renders correctly with custom threshold and extra tags and ma
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
-        <div
-          class="emotion-2 emotion-3"
+        <span
+          class="ellipsed emotion-4 emotion-5"
         >
           <span
-            class="emotion-4 emotion-5"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              scaleway
-            </span>
+            scaleway
           </span>
-        </div>
-        <div
-          aria-controls=":ra:"
-          aria-describedby=":ra:"
-          class="emotion-9 emotion-10"
-          tabindex="-1"
+        </span>
+      </div>
+      <div
+        aria-controls=":ro:"
+        aria-describedby=":ro:"
+        class="emotion-9 emotion-10"
+        tabindex="-1"
+      >
+        <span
+          class="emotion-11 emotion-12"
+          data-testid="taglist-open"
         >
-          <span
-            class="emotion-11 emotion-12"
-            data-testid="taglist-open"
-          >
-            +2
-          </span>
-        </div>
+          +2
+        </span>
       </div>
     </div>
   </div>
@@ -704,45 +955,44 @@ exports[`TagList > renders correctly with icons 1`] = `
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
         <div
-          class="emotion-2 emotion-3"
+          aria-controls=":r1c:"
+          aria-describedby=":r1c:"
+          class="emotion-4 emotion-5"
+          tabindex="0"
         >
-          <div
-            aria-controls=":ri:"
-            aria-describedby=":ri:"
-            class="emotion-4 emotion-5"
-            tabindex="0"
+          <button
+            class=" emotion-6 emotion-7"
           >
-            <button
-              class="emotion-6 emotion-7"
+            <span
+              class="emotion-8 emotion-9 emotion-10"
             >
-              <span
-                class="emotion-8 emotion-9 emotion-10"
-              >
-                scaleway
-              </span>
-            </button>
-          </div>
-          <div
-            aria-controls=":rk:"
-            aria-describedby=":rk:"
-            class="emotion-4 emotion-5"
-            tabindex="0"
+              scaleway
+            </span>
+          </button>
+        </div>
+        <div
+          aria-controls=":r1e:"
+          aria-describedby=":r1e:"
+          class="emotion-4 emotion-5"
+          tabindex="0"
+        >
+          <button
+            class=" emotion-6 emotion-7"
           >
-            <button
-              class="emotion-6 emotion-7"
+            <span
+              class="emotion-8 emotion-9 emotion-10"
             >
-              <span
-                class="emotion-8 emotion-9 emotion-10"
-              >
-                cloud
-              </span>
-            </button>
-          </div>
+              cloud
+            </span>
+          </button>
         </div>
       </div>
     </div>
@@ -845,58 +1095,55 @@ exports[`TagList > renders correctly with multiline 1`] = `
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
-        <div
-          class="emotion-2 emotion-3"
+        <span
+          class=" emotion-4 emotion-5"
         >
           <span
-            class="emotion-4 emotion-5"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              scaleway
-            </span>
+            scaleway
           </span>
-          <span
-            class="emotion-4 emotion-5"
-          >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              cloud
-            </span>
-          </span>
-        </div>
-        <div
-          aria-controls=":rd:"
-          aria-describedby=":rd:"
-          class="emotion-14 emotion-15"
-          tabindex="-1"
+        </span>
+        <span
+          class=" emotion-4 emotion-5"
         >
           <span
-            class="emotion-16 emotion-17"
-            data-testid="taglist-open"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            +1
+            cloud
           </span>
-        </div>
+        </span>
+      </div>
+      <div
+        aria-controls=":rt:"
+        aria-describedby=":rt:"
+        class="emotion-14 emotion-15"
+        tabindex="-1"
+      >
+        <span
+          class="emotion-16 emotion-17"
+          data-testid="taglist-open"
+        >
+          +1
+        </span>
       </div>
     </div>
   </div>
 </DocumentFragment>
 `;
 
-exports[`TagList > renders correctly with not tags 1`] = `
+exports[`TagList > renders correctly with no tags 1`] = `
 <DocumentFragment>
   <div
     data-testid="testing"
-  >
-    <div />
-  </div>
+  />
 </DocumentFragment>
 `;
 
@@ -920,6 +1167,20 @@ exports[`TagList > renders correctly with placement 1`] = `
   align-items: center;
   color: #3f4250;
   gap: 8px;
+}
+
+.emotion-2:has(.ellipsed) {
+  width: calc(100% - 50px);
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.emotion-2 * {
+  width: 100%!important;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
 }
 
 .emotion-4 {
@@ -991,36 +1252,35 @@ exports[`TagList > renders correctly with placement 1`] = `
 <div
     data-testid="testing"
   >
-    <div>
+    <div
+      class="emotion-0 emotion-1"
+      style="visibility: visible;"
+    >
       <div
-        class="emotion-0 emotion-1"
+        class="emotion-2 emotion-3"
       >
-        <div
-          class="emotion-2 emotion-3"
+        <span
+          class="ellipsed emotion-4 emotion-5"
         >
           <span
-            class="emotion-4 emotion-5"
+            class="emotion-6 emotion-7 emotion-8"
           >
-            <span
-              class="emotion-6 emotion-7 emotion-8"
-            >
-              scaleway
-            </span>
+            scaleway
           </span>
-        </div>
-        <div
-          aria-controls=":r3:"
-          aria-describedby=":r3:"
-          class="emotion-9 emotion-10"
-          tabindex="-1"
+        </span>
+      </div>
+      <div
+        aria-controls=":r5:"
+        aria-describedby=":r5:"
+        class="emotion-9 emotion-10"
+        tabindex="-1"
+      >
+        <span
+          class="emotion-11 emotion-12"
+          data-testid="taglist-open"
         >
-          <span
-            class="emotion-11 emotion-12"
-            data-testid="taglist-open"
-          >
-            +1
-          </span>
-        </div>
+          +1
+        </span>
       </div>
     </div>
   </div>

--- a/packages/ui/src/components/TagList/__tests__/index.test.tsx
+++ b/packages/ui/src/components/TagList/__tests__/index.test.tsx
@@ -1,117 +1,189 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { renderWithTheme, shouldMatchEmotionSnapshot } from '@utils/test'
-import { describe, expect, test } from 'vitest'
+import { renderWithTheme } from '@utils/test'
+import { afterAll, describe, expect, test, vi } from 'vitest'
+import type { TagType } from '..'
 import { TagList } from '..'
 
+// - This function mocks the offsetWidth of DOM elements:
+// as JSDOM ( used by testing-library ) only emulates the DOM elements
+// so it does not render the elements in any way to be able to know their size or position.
+// - These mocks are done in a way to follow the code execution,
+// so if you change the code you might need to change this as well
+const mockOffsetWidth = (tags: TagType[], customContainerWidth?: number) => {
+  const TAGS_PARENT_WIDTH = 500
+  const TAG_WIDTH = 100
+  const POPOVER_TRIGGER_WIDTH = 50
+
+  const containerWidth = customContainerWidth || TAGS_PARENT_WIDTH
+
+  const mockOffsetWidthFunction = vi.spyOn(
+    HTMLElement.prototype,
+    'offsetWidth',
+    'get',
+  )
+
+  mockOffsetWidthFunction.mockReturnValueOnce(containerWidth)
+  tags.forEach(() => {
+    mockOffsetWidthFunction.mockReturnValueOnce(TAG_WIDTH)
+  })
+  mockOffsetWidthFunction.mockReturnValueOnce(POPOVER_TRIGGER_WIDTH)
+  mockOffsetWidthFunction.mockReturnValueOnce(TAG_WIDTH * tags.length)
+  mockOffsetWidthFunction.mockReturnValueOnce(containerWidth)
+}
+
 describe('TagList', () => {
-  test('renders correctly', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList popoverTitle="Additional" tags={['scaleway', 'cloud']} />
-      </div>,
-    ))
+  afterAll(() => {
+    vi.resetAllMocks()
+  })
 
-  test('renders correctly with not tags', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList popoverTitle="Additional" />
-      </div>,
-    ))
+  test('renders correctly', () => {
+    const tags = ['scaleway', 'cloud']
 
-  test('renders correctly with placement', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList
-          popoverTitle="Additional"
-          tags={['scaleway', 'cloud']}
-          popoverPlacement="top"
-        />
-      </div>,
-    ))
+    mockOffsetWidth(tags)
 
-  test('renders correctly with custom threshold', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList
-          popoverTitle="Additional"
-          threshold={2}
-          tags={['scaleway', 'cloud']}
-        />
-      </div>,
-    ))
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" tags={tags} />,
+    )
 
-  test('renders correctly with custom threshold and extra tags', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList
-          popoverTitle="Additional"
-          threshold={2}
-          tags={['scaleway', 'cloud', 'provider']}
-        />
-      </div>,
-    ))
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  test('renders correctly with custom threshold and extra tags and maxLength inferior to the combined size of tags', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList
-          popoverTitle="Additional"
-          maxLength={10}
-          threshold={2}
-          tags={['scaleway', 'cloud', 'provider']}
-        />
-      </div>,
-    ))
+  test('renders correctly with no tags', () => {
+    mockOffsetWidth([])
 
-  test('renders correctly with multiline', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList
-          popoverTitle="Additional"
-          multiline
-          threshold={2}
-          tags={['scaleway', 'cloud', 'provider']}
-        />
-      </div>,
-    ))
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" />,
+    )
 
-  test('renders correctly with copiable', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList
-          popoverTitle="Additional"
-          copiable
-          threshold={2}
-          tags={['scaleway', 'cloud']}
-        />
-      </div>,
-    ))
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  test('renders correctly with icons', () =>
-    shouldMatchEmotionSnapshot(
-      <div>
-        <TagList
-          popoverTitle="Additional"
-          copiable
-          threshold={4}
-          tags={['scaleway', 'cloud']}
-        />
-      </div>,
-    ))
+  test('renders correctly with placement', () => {
+    const tags = ['scaleway', 'cloud']
 
-  test('renders correctly when clicking on popover', async () => {
-    renderWithTheme(
+    mockOffsetWidth(tags)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" tags={tags} popoverPlacement="top" />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly with custom threshold', () => {
+    const tags = ['scaleway', 'cloud']
+
+    mockOffsetWidth(tags)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" threshold={2} tags={tags} />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly with custom threshold and extra tags', () => {
+    const tags = ['scaleway', 'cloud', 'provider']
+
+    mockOffsetWidth(tags)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" threshold={2} tags={tags} />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly and ignore custom threshold as it does not fit the parent', () => {
+    const tags = ['scaleway', 'cloud', 'provider']
+
+    mockOffsetWidth(tags, 150)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" threshold={2} tags={tags} />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly and add ellipsis to the first tag as it too long', () => {
+    const tags = ['scaleway is the best cloud provider ever invented']
+
+    mockOffsetWidth(tags, 50)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" tags={tags} />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly with custom threshold and extra tags and maxLength inferior to the combined size of tags', () => {
+    const tags = ['scaleway', 'cloud', 'provider']
+
+    mockOffsetWidth(tags)
+
+    const { asFragment } = renderWithTheme(
       <TagList
         popoverTitle="Additional"
-        threshold={1}
-        tags={[
-          { label: 'smooth', icon: 'id' },
-          'code',
-          { label: 'hello', icon: 'lock' },
-          { label: 'world', icon: 'plus' },
-        ]}
+        maxLength={10}
+        threshold={2}
+        tags={tags}
       />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly with multiline', () => {
+    const tags = ['scaleway', 'cloud', 'provider']
+
+    mockOffsetWidth(tags)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" multiline threshold={2} tags={tags} />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly with copiable', () => {
+    const tags = ['scaleway', 'cloud']
+
+    mockOffsetWidth(tags)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" copiable threshold={2} tags={tags} />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly with icons', () => {
+    const tags = ['scaleway', 'cloud']
+
+    mockOffsetWidth(tags)
+
+    const { asFragment } = renderWithTheme(
+      <TagList popoverTitle="Additional" copiable threshold={4} tags={tags} />,
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders correctly when clicking on popover', async () => {
+    const tags: TagType[] = [
+      { label: 'smooth', icon: 'id' },
+      'code',
+      { label: 'hello', icon: 'lock' },
+      { label: 'world', icon: 'plus' },
+    ]
+
+    mockOffsetWidth(tags)
+
+    renderWithTheme(
+      <TagList popoverTitle="Additional" threshold={1} tags={tags} />,
     )
 
     expect(screen.queryByText('Additional')).not.toBeInTheDocument()

--- a/packages/ui/src/components/TagList/index.tsx
+++ b/packages/ui/src/components/TagList/index.tsx
@@ -28,14 +28,14 @@ const TagsWrapper = styled.span`
 `
 
 const StyledTagContainer = styled.div<{
-  elementsGap: string
+  gap: string
   multiline?: boolean
   popoverTriggerWidth?: number
 }>`
   display: flex;
   align-items: center;
   color: ${({ theme }) => theme.colors.neutral.text};
-  gap: ${({ elementsGap }) => elementsGap};
+  gap: ${({ gap }) => gap};
   ${({ multiline }) => multiline && `flex-wrap: wrap;`};
 
   // to handle the case where we have one tag and we need to ellipsis it
@@ -247,7 +247,7 @@ export const TagList = ({
   return (
     <StyledContainer className={className} data-testid={dataTestId}>
       <StyledTagContainer
-        elementsGap={TAGS_GAP}
+        gap={TAGS_GAP}
         multiline={multiline}
         popoverTriggerWidth={popoverTriggerWidth}
         ref={containerRef}
@@ -270,7 +270,7 @@ export const TagList = ({
             whiteSpace: 'nowrap',
           }}
         >
-          <StyledTagContainer elementsGap={TAGS_GAP}>
+          <StyledTagContainer gap={TAGS_GAP}>
             {potentiallyVisibleTags.map((tag, index) => renderTag(tag, index))}
           </StyledTagContainer>
         </div>,
@@ -284,7 +284,7 @@ export const TagList = ({
           onClose={() => setIsPopoverVisible(false)}
           placement={popoverPlacement}
           content={
-            <StyledTagContainer multiline elementsGap={TAGS_GAP}>
+            <StyledTagContainer multiline gap={TAGS_GAP}>
               {hiddenTags.map((tag, index) => renderTag(tag, index))}
             </StyledTagContainer>
           }

--- a/packages/ui/src/components/TagList/index.tsx
+++ b/packages/ui/src/components/TagList/index.tsx
@@ -1,8 +1,12 @@
 import styled from '@emotion/styled'
-import { useState } from 'react'
+import { consoleLightTheme } from '@ultraviolet/themes'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ComponentProps } from 'react'
+import { createPortal } from 'react-dom'
 import { Popover } from '../Popover'
 import { Tag } from '../Tag'
+
+const TAGS_GAP = consoleLightTheme.space['1']
 
 const StyledContainer = styled.div`
   display: flex;
@@ -23,25 +27,46 @@ const TagsWrapper = styled.span`
   padding-right: 8px;
 `
 
-const StyledTagContainer = styled.div<{ multiline?: boolean }>`
+const StyledTagContainer = styled.div<{
+  elementsGap: string
+  multiline?: boolean
+  popoverTriggerWidth?: number
+}>`
   display: flex;
   align-items: center;
   color: ${({ theme }) => theme.colors.neutral.text};
-  gap: ${({ theme }) => theme.space['1']};
+  gap: ${({ elementsGap }) => elementsGap};
   ${({ multiline }) => multiline && `flex-wrap: wrap;`};
+
+  // to handle the case where we have one tag and we need to ellipsis it
+  ${({ popoverTriggerWidth }) =>
+    popoverTriggerWidth &&
+    `
+      &:has(.ellipsed) {
+        width: calc(100% - ${popoverTriggerWidth}px); // to let space for the +X button
+        max-width: fit-content;
+      }
+    
+      & * {
+        width: 100% !important;
+        max-width: fit-content;
+      }
+  `};
 `
+
+type TagType =
+  | string
+  | { label: string; icon: NonNullable<ComponentProps<typeof Tag>['icon']> }
 
 type TagListProps = {
   /**
    * This property define maximum characters length of all tags until it hide tags into tooltip.
    */
   maxLength?: number
-  tags?: (
-    | string
-    | { label: string; icon: NonNullable<ComponentProps<typeof Tag>['icon']> }
-  )[]
+  tags?: TagType[]
   /**
    * This property define maximum characters length of all tags until it hide tags into tooltip.
+   * NB: this will be overridden if the parent width is smaller and cannot show all the tags
    */
   threshold?: number
   /**
@@ -82,77 +107,197 @@ export const TagList = ({
   className,
   'data-testid': dataTestId,
 }: TagListProps) => {
-  let tmpThreshold = threshold
-  if (
-    tags.length > 0 &&
-    tags
-      .slice(0, tmpThreshold)
-      .reduce<string>((acc, tag) => acc + getTagLabel(tag), '').length >
-      maxLength
-  ) {
-    // If total tags length in characters is above maxLength,
-    // threshold is decremented in order to prevent too many long tags displayed.
-    tmpThreshold -= 1
-  }
-  const hasManyTags = tags.length > tmpThreshold || false
-  const visibleTagsCount = hasManyTags ? tmpThreshold : tags.length
+  const containerRef = useRef<HTMLDivElement>(null)
+  const measureRef = useRef<HTMLDivElement>(null)
+  const popoverTriggerRef = useRef<HTMLDivElement>(null)
 
-  const [isVisible, setIsVisible] = useState(false)
+  const [isPopoverVisible, setIsPopoverVisible] = useState(false)
+  const [popoverTriggerWidth, setPopoverTriggerWidth] = useState(0)
+  const [visibleTags, setVisibleTags] = useState<TagType[]>([])
+  const [hiddenTags, setHiddenTags] = useState<TagType[]>([])
+
+  // Compute tmpThreshold, potentially visible tags and surely hidden tags
+  const memoizedResult = useMemo(() => {
+    let tmpThreshold = threshold
+    if (
+      tags.length > 0 &&
+      tags
+        .slice(0, tmpThreshold)
+        .reduce<string>((acc, tag) => acc + getTagLabel(tag), '').length >
+        maxLength
+    ) {
+      tmpThreshold -= 1
+    }
+
+    const potentiallyVisibleTagsLength =
+      tags.length > tmpThreshold || false ? tmpThreshold : tags.length
+    const potentiallyVisibleTags = tags.slice(0, potentiallyVisibleTagsLength)
+    const surelyHiddenTags = tags.slice(potentiallyVisibleTagsLength)
+
+    return {
+      tmpThreshold,
+      potentiallyVisibleTags,
+      surelyHiddenTags,
+    }
+  }, [maxLength, tags, threshold])
+
+  const { tmpThreshold, potentiallyVisibleTags, surelyHiddenTags } =
+    memoizedResult
+
+  // compute visible tags and hidden ones based on the container width and
+  // what can fit into it from the potentially visible tags
+  useEffect(() => {
+    if (!tags.length || !containerRef.current || !measureRef.current) {
+      return
+    }
+
+    if (multiline) {
+      setVisibleTags(potentiallyVisibleTags)
+      setHiddenTags(surelyHiddenTags)
+
+      return
+    }
+
+    const parentWidth = containerRef.current.parentElement?.clientWidth || 0
+    let accumulatedWidth = 0
+    const measuredVisibleTags = []
+    const measuredHiddenTags = []
+
+    const measureElements = measureRef.current.children[0].children
+    for (let i = 0; i < measureElements.length; i += 1) {
+      accumulatedWidth +=
+        (measureElements[i] as HTMLDivElement).offsetWidth +
+        parseInt(TAGS_GAP, 10)
+      if (accumulatedWidth <= parentWidth) {
+        measuredVisibleTags.push(tags[i])
+      } else {
+        measuredHiddenTags.push(tags[i])
+      }
+    }
+
+    setVisibleTags(measuredVisibleTags)
+    setHiddenTags(measuredHiddenTags.concat(surelyHiddenTags))
+  }, [multiline, potentiallyVisibleTags, surelyHiddenTags, tags, tmpThreshold])
+
+  // get the popover trigger ref when we show it to be able to:
+  // - add a first tag with ellipsis when the first tag does not fit in the parent container
+  // - adjust the size of the first tag we do this only when we show one tag and we have more hidden ones
+  useEffect(() => {
+    if (popoverTriggerRef.current?.clientWidth) {
+      const newPopoverTriggerWidth = popoverTriggerRef.current.clientWidth
+
+      // a check to know if we need to ellipsis the first tag when needed
+      if (visibleTags.length === 1 && hiddenTags.length > 0) {
+        setPopoverTriggerWidth(newPopoverTriggerWidth)
+      }
+
+      // add a first tag with ellipsis when the first tag does not fit in the parent container
+      if (visibleTags.length === 0 && hiddenTags.length > 0) {
+        const visibleTagsCopy = [...visibleTags]
+        const hiddenTagsCopy = [...hiddenTags]
+
+        const tagToMove = hiddenTagsCopy.pop()
+        visibleTagsCopy.push(tagToMove as TagType)
+
+        setVisibleTags(visibleTagsCopy)
+        setHiddenTags(hiddenTagsCopy)
+
+        return
+      }
+
+      // remove the last tag if we have a popover and add it to the hidden tags
+      const tagsContainer = containerRef.current
+      const tagsContainerWidth = containerRef.current?.clientWidth || 0
+      const parentWidth = tagsContainer?.parentElement?.clientWidth || 0
+
+      if (
+        hiddenTags.length > 0 &&
+        tagsContainerWidth + newPopoverTriggerWidth > parentWidth
+      ) {
+        const visibleTagsCopy = [...visibleTags]
+        const hiddenTagsCopy = [...hiddenTags]
+
+        const tagToMove = visibleTagsCopy.pop()
+        hiddenTagsCopy.unshift(tagToMove as TagType)
+
+        setVisibleTags(visibleTagsCopy)
+        setHiddenTags(hiddenTagsCopy)
+      }
+    }
+  }, [hiddenTags, threshold, visibleTags, visibleTags.length])
 
   if (!tags.length) {
     return null
   }
 
+  const renderTag = (tag: TagType, index: number, isEllipsis = false) => (
+    <Tag
+      // useful when two tags are identical `${tag}-${index}`
+      key={`${getTagLabel(tag)}-${index}`}
+      copiable={copiable}
+      copyText={copyText}
+      copiedText={copiedText}
+      icon={typeof tag === 'object' ? tag.icon : undefined}
+      className={isEllipsis ? 'ellipsed' : ''}
+    >
+      {getTagLabel(tag)}
+    </Tag>
+  )
+
   return (
     <StyledContainer className={className} data-testid={dataTestId}>
-      <StyledTagContainer multiline={multiline}>
-        {tags.slice(0, visibleTagsCount).map((tag, index) => (
-          <Tag
-            // useful when two tags are identical `${tag}-${index}`
-            // eslint-disable-next-line react/no-array-index-key
-            key={`${getTagLabel(tag)}-${index}`}
-            copiable={copiable}
-            copyText={copyText}
-            copiedText={copiedText}
-            icon={typeof tag === 'object' ? tag.icon : undefined}
-          >
-            {getTagLabel(tag)}
-          </Tag>
-        ))}
+      <StyledTagContainer
+        elementsGap={TAGS_GAP}
+        multiline={multiline}
+        popoverTriggerWidth={popoverTriggerWidth}
+        ref={containerRef}
+      >
+        {visibleTags.map((tag, index) =>
+          renderTag(
+            tag,
+            index,
+            // add ellipsis to first tag when it's the only that could fit in the parent container
+            index === 0 && visibleTags.length === 1 && hiddenTags.length > 0,
+          ),
+        )}
       </StyledTagContainer>
-      {hasManyTags ? (
+      {createPortal(
+        <div
+          ref={measureRef}
+          style={{
+            visibility: 'hidden',
+            position: 'absolute',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <StyledTagContainer elementsGap={TAGS_GAP}>
+            {potentiallyVisibleTags.map((tag, index) => renderTag(tag, index))}
+          </StyledTagContainer>
+        </div>,
+        document.body,
+      )}
+      {hiddenTags.length > 0 && (
         <Popover
           title={popoverTitle}
-          visible={isVisible}
+          visible={isPopoverVisible}
           size="small"
-          onClose={() => setIsVisible(false)}
+          onClose={() => setIsPopoverVisible(false)}
           placement={popoverPlacement}
           content={
-            <StyledTagContainer multiline>
-              {tags.slice(visibleTagsCount).map((tag, index) => (
-                <Tag
-                  // useful when two tags are identical `${tag}-${index}`
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`${getTagLabel(tag)}-${index}`}
-                  copiable={copiable}
-                  copyText={copyText}
-                  copiedText={copiedText}
-                  icon={typeof tag === 'object' ? tag.icon : undefined}
-                >
-                  {getTagLabel(tag)}
-                </Tag>
-              ))}
+            <StyledTagContainer multiline elementsGap={TAGS_GAP}>
+              {hiddenTags.map((tag, index) => renderTag(tag, index))}
             </StyledTagContainer>
           }
         >
           <TagsWrapper
+            ref={popoverTriggerRef}
             data-testid={`${dataTestId ?? 'taglist'}-open`}
-            onClick={() => setIsVisible(true)}
+            onClick={() => setIsPopoverVisible(true)}
           >
-            +{tags.length - tmpThreshold}
+            +{hiddenTags.length}
           </TagsWrapper>
         </Popover>
-      ) : null}
+      )}
     </StyledContainer>
   )
 }

--- a/packages/ui/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
@@ -776,7 +776,7 @@ exports[`Text > with italic 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Text > with multiple nested chidldren renders correctly 1`] = `
+exports[`Text > with multiple nested children renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   font-size: 16px;

--- a/packages/ui/src/components/Text/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Text/__tests__/index.test.tsx
@@ -55,7 +55,7 @@ describe('Text', () => {
       </div>,
     ))
 
-  test(`with multiple nested chidldren renders correctly`, () =>
+  test(`with multiple nested children renders correctly`, () =>
     shouldMatchEmotionSnapshot(
       <Text as="div" variant="body">
         Lorem


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

Allow TagList component to to not overflow it's parent by ignoring the provided threshold in this case.
When we have only one tag to show, we show and we ellipsis it with a tooltip so the TagList dosen't overflow as well.

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/a8758daa-c704-430e-a095-c3e9a033750c">

## Relevant logs and/or screenshots

|   Before   |      After |
| :--------: | ---------: |
| ![before](https://github.com/user-attachments/assets/0fe1004a-1a4c-4a5c-862d-45b508d0776c) | ![after](https://github.com/user-attachments/assets/07b04a87-7edc-4cd7-8746-88368fc19009) | 
