### PR TITLE
fix: readOnly case

### DIFF
--- a/.changeset/young-berries-dress.md
+++ b/.changeset/young-berries-dress.md
@@ -3,4 +3,4 @@
 "@ultraviolet/ui": patch
 ---
 
-`readonly` props becomes `readOnly` and fix `data-readonly` case
+`KeyValueField` : `readonly` props becomes `readOnly`

--- a/.changeset/young-berries-dress.md
+++ b/.changeset/young-berries-dress.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+`readonly` props becomes `readOnly` and fix `data-readonly` case

--- a/packages/form/src/components/KeyValueField/__tests__/index.test.tsx
+++ b/packages/form/src/components/KeyValueField/__tests__/index.test.tsx
@@ -72,7 +72,7 @@ describe('KeyValueField', () => {
           maxSizeReachedTooltip:
             'This is a tooltip when the max size is reached',
         }}
-        readonly
+        readOnly
       />,
     )
     const addButton = screen.getByTestId('add-button')

--- a/packages/form/src/components/KeyValueField/index.tsx
+++ b/packages/form/src/components/KeyValueField/index.tsx
@@ -31,7 +31,7 @@ type KeyValueFieldProps<
   inputValue: InputValueProps
   addButton: AddButtonProps
   maxSize?: number
-  readonly?: boolean
+  readOnly?: boolean
   control?: Control<TFieldValues>
 }
 
@@ -48,7 +48,7 @@ export const KeyValueField = <
   inputValue,
   addButton,
   maxSize = 100,
-  readonly = false,
+  readOnly = false,
   control,
 }: KeyValueFieldProps<TFieldValues, TFieldArrayName>) => {
   const { fields, append, remove } = useFieldArray({
@@ -73,14 +73,14 @@ export const KeyValueField = <
               alignItems="end"
             >
               <TextInputFieldV2
-                readOnly={readonly}
+                readOnly={readOnly}
                 required={inputKey.required}
                 name={`${name}.${index}.key`}
                 label={inputKey.label}
                 regex={inputKey.regex}
               />
               <TextInputFieldV2
-                readOnly={readonly}
+                readOnly={readOnly}
                 required={inputValue.required}
                 name={`${name}.${index}.value`}
                 label={inputValue.label}
@@ -91,7 +91,7 @@ export const KeyValueField = <
               />
 
               <Button
-                disabled={readonly}
+                disabled={readOnly}
                 data-testid={`remove-button-${index}`}
                 icon="delete"
                 variant="outlined"
@@ -110,7 +110,7 @@ export const KeyValueField = <
           variant="filled"
           sentiment="neutral"
           fullWidth={addButton.fullWidth}
-          disabled={!canAdd || readonly}
+          disabled={!canAdd || readOnly}
           tooltip={!canAdd ? maxSizeReachedTooltip : addButton.tooltip}
           // @ts-expect-error can't infer properly
           onClick={() => append({ key: '', value: '' })}

--- a/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`TextAreaField > should render correctly 1`] = `
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
@@ -375,7 +375,7 @@ exports[`TextAreaField > should render correctly generated 1`] = `
   border-color: #b3144d;
 }
 
-.emotion-12[data-readOnly='true'] {
+.emotion-12[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }

--- a/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`TextArea > should render correctly when input  has a error sentiment 1`
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
@@ -625,7 +625,7 @@ exports[`TextArea > should render correctly when input has a success sentiment 1
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
@@ -1035,7 +1035,7 @@ exports[`TextArea > should render correctly when input is disabled 1`] = `
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
@@ -1106,7 +1106,7 @@ exports[`TextArea > should render correctly when input is disabled 1`] = `
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
@@ -1454,7 +1454,7 @@ exports[`TextArea > should render correctly when input is readOnly 1`] = `
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
@@ -1525,7 +1525,7 @@ exports[`TextArea > should render correctly when input is readOnly 1`] = `
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }
@@ -1783,7 +1783,7 @@ exports[`TextArea > should render correctly with basic props 1`] = `
   border-color: #b3144d;
 }
 
-.emotion-10[data-readOnly='true'] {
+.emotion-10[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
 }

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -54,7 +54,7 @@ const StyledTextArea = styled('textarea', {
     border-color: ${({ theme }) => theme.colors.danger.border};
   }
 
-  &[data-readOnly='true'] {
+  &[data-readonly='true'] {
     background: ${({ theme }) => theme.colors.neutral.backgroundWeak};
     border-color: ${({ theme }) => theme.colors.neutral.border};
   }
@@ -214,7 +214,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
               }}
               hasSentimentIcon={!!success || !!error}
               data-disabled={disabled}
-              data-readOnly={readOnly}
+              data-readonly={readOnly}
               data-success={!!success}
               data-error={!!error}
               isClearable={!!computedClearable}

--- a/packages/ui/src/components/UnitInput/index.tsx
+++ b/packages/ui/src/components/UnitInput/index.tsx
@@ -287,7 +287,6 @@ export const UnitInput = ({
             aria-invalid={!!error}
             autoFocus={autoFocus}
             disabled={disabled}
-            data-readOnly={readOnly}
             name={`${name}-value`}
             id={id ? `${id}-value` : undefined}
             value={val}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

`KeyValueField` :  prop `readonly` becomes `readOnly` to fit React standard
`TextArea`: `data-readOnly` becomes `data-readonly` to fit standard