### PR TITLE
fix(badge): font weight and sizes

### DIFF
--- a/.changeset/curvy-rocks-film.md
+++ b/.changeset/curvy-rocks-film.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Badge />` font weight on each sizes

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
@@ -7463,11 +7463,11 @@ exports[`EstimateCost - Regular Item > render basic props with overlay beta 1`] 
 }
 
 .emotion-40 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7492,8 +7492,6 @@ exports[`EstimateCost - Regular Item > render basic props with overlay beta 1`] 
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -8085,11 +8083,11 @@ exports[`EstimateCost - Regular Item > render basic props with overlay beta 1`] 
 }
 
 .emotion-133 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8114,8 +8112,6 @@ exports[`EstimateCost - Regular Item > render basic props with overlay beta 1`] 
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.test.tsx.snap
@@ -275,11 +275,11 @@ exports[`EstimateCost - index > render isBeta with discount 1`] = `
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -304,8 +304,6 @@ exports[`EstimateCost - index > render isBeta with discount 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -873,11 +871,11 @@ exports[`EstimateCost - index > render isBeta with discount 1`] = `
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -902,8 +900,6 @@ exports[`EstimateCost - index > render isBeta with discount 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -1557,11 +1553,11 @@ exports[`EstimateCost - index > render isBeta with discount equal to 100% 1`] = 
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1586,8 +1582,6 @@ exports[`EstimateCost - index > render isBeta with discount equal to 100% 1`] = 
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -2155,11 +2149,11 @@ exports[`EstimateCost - index > render isBeta with discount equal to 100% 1`] = 
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2184,8 +2178,6 @@ exports[`EstimateCost - index > render isBeta with discount equal to 100% 1`] = 
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -2844,11 +2836,11 @@ exports[`EstimateCost - index > render isBeta with discount more than 100% 1`] =
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2873,8 +2865,6 @@ exports[`EstimateCost - index > render isBeta with discount more than 100% 1`] =
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -3442,11 +3432,11 @@ exports[`EstimateCost - index > render isBeta with discount more than 100% 1`] =
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3471,8 +3461,6 @@ exports[`EstimateCost - index > render isBeta with discount more than 100% 1`] =
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -4136,11 +4124,11 @@ exports[`EstimateCost - index > render isBeta without discount 1`] = `
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4165,8 +4153,6 @@ exports[`EstimateCost - index > render isBeta without discount 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -4734,11 +4720,11 @@ exports[`EstimateCost - index > render isBeta without discount 1`] = `
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4763,8 +4749,6 @@ exports[`EstimateCost - index > render isBeta without discount 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -17010,11 +16994,11 @@ exports[`EstimateCost - index > render with discount 1, isBeta and defaultTimeUn
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -17039,8 +17023,6 @@ exports[`EstimateCost - index > render with discount 1, isBeta and defaultTimeUn
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -17608,11 +17590,11 @@ exports[`EstimateCost - index > render with discount 1, isBeta and defaultTimeUn
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -17637,8 +17619,6 @@ exports[`EstimateCost - index > render with discount 1, isBeta and defaultTimeUn
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -22401,11 +22381,11 @@ exports[`EstimateCost - index > render with isBeta but undefined discount 1`] = 
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -22430,8 +22410,6 @@ exports[`EstimateCost - index > render with isBeta but undefined discount 1`] = 
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -22999,11 +22977,11 @@ exports[`EstimateCost - index > render with isBeta but undefined discount 1`] = 
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -23028,8 +23006,6 @@ exports[`EstimateCost - index > render with isBeta but undefined discount 1`] = 
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -23965,11 +23941,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -23994,8 +23970,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -24007,11 +23981,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -24036,8 +24010,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -25161,11 +25133,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -25190,8 +25162,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -25201,11 +25171,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -25230,8 +25200,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -26171,11 +26139,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -26200,8 +26168,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -26213,11 +26179,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -26242,8 +26208,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -27367,11 +27331,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -27396,8 +27360,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -27407,11 +27369,11 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -27436,8 +27398,6 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -28105,11 +28065,11 @@ exports[`EstimateCost - index > render with isBeta, price, discount 50% 1`] = `
 }
 
 .emotion-36 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -28134,8 +28094,6 @@ exports[`EstimateCost - index > render with isBeta, price, discount 50% 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -28703,11 +28661,11 @@ exports[`EstimateCost - index > render with isBeta, price, discount 50% 1`] = `
 }
 
 .emotion-120 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -28732,8 +28690,6 @@ exports[`EstimateCost - index > render with isBeta, price, discount 50% 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;
@@ -31628,11 +31584,11 @@ exports[`EstimateCost - index > render with item discount 50% and text 1`] = `
 }
 
 .emotion-18 {
-  font-size: 16px;
+  font-size: 10px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -31657,8 +31613,6 @@ exports[`EstimateCost - index > render with item discount 50% and text 1`] = `
   width: fit-content;
   height: 16px;
   text-transform: uppercase;
-  font-size: 10px;
-  color: inherit;
   color: #222638;
   background: #fbc600;
   border: 1px solid #fbc600;

--- a/packages/ui/src/components/Badge/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Badge/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Badge > renders correctly prominence default 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -32,8 +32,6 @@ exports[`Badge > renders correctly prominence default 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -54,11 +52,11 @@ exports[`Badge > renders correctly prominence default 1`] = `
 exports[`Badge > renders correctly prominence strong 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -83,8 +81,6 @@ exports[`Badge > renders correctly prominence strong 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #ffffff;
   background: #151a2d;
   border: 1px solid #151a2d;
@@ -105,11 +101,11 @@ exports[`Badge > renders correctly prominence strong 1`] = `
 exports[`Badge > renders correctly sentiment danger 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -134,8 +130,6 @@ exports[`Badge > renders correctly sentiment danger 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #b3144d;
   background: #ffebf2;
   border: 1px solid #ffebf2;
@@ -156,11 +150,11 @@ exports[`Badge > renders correctly sentiment danger 1`] = `
 exports[`Badge > renders correctly sentiment info 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -185,8 +179,6 @@ exports[`Badge > renders correctly sentiment info 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #005da3;
   background: #e0f2ff;
   border: 1px solid #e0f2ff;
@@ -207,11 +199,11 @@ exports[`Badge > renders correctly sentiment info 1`] = `
 exports[`Badge > renders correctly sentiment neutral 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -236,8 +228,6 @@ exports[`Badge > renders correctly sentiment neutral 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -258,11 +248,11 @@ exports[`Badge > renders correctly sentiment neutral 1`] = `
 exports[`Badge > renders correctly sentiment primary 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -287,8 +277,6 @@ exports[`Badge > renders correctly sentiment primary 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #641cb3;
   background: #f1eefc;
   border: 1px solid #f1eefc;
@@ -309,11 +297,11 @@ exports[`Badge > renders correctly sentiment primary 1`] = `
 exports[`Badge > renders correctly sentiment secondary 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -338,8 +326,6 @@ exports[`Badge > renders correctly sentiment secondary 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #ac22e7;
   background: #f9ebff;
   border: 1px solid #f9ebff;
@@ -360,11 +346,11 @@ exports[`Badge > renders correctly sentiment secondary 1`] = `
 exports[`Badge > renders correctly sentiment success 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -389,8 +375,6 @@ exports[`Badge > renders correctly sentiment success 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #22674e;
   background: #daf6ec;
   border: 1px solid #daf6ec;
@@ -411,11 +395,11 @@ exports[`Badge > renders correctly sentiment success 1`] = `
 exports[`Badge > renders correctly sentiment warning 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -440,8 +424,6 @@ exports[`Badge > renders correctly sentiment warning 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #7c5400;
   background: #fff6e6;
   border: 1px solid #fff6e6;
@@ -462,11 +444,11 @@ exports[`Badge > renders correctly sentiment warning 1`] = `
 exports[`Badge > renders correctly size large 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 14px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 20px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -491,8 +473,6 @@ exports[`Badge > renders correctly size large 1`] = `
   width: fit-content;
   height: 32px;
   text-transform: uppercase;
-  font-size: 14px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -513,11 +493,11 @@ exports[`Badge > renders correctly size large 1`] = `
 exports[`Badge > renders correctly size medium 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -542,8 +522,6 @@ exports[`Badge > renders correctly size medium 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -564,11 +542,11 @@ exports[`Badge > renders correctly size medium 1`] = `
 exports[`Badge > renders correctly size small 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 10px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -593,8 +571,6 @@ exports[`Badge > renders correctly size small 1`] = `
   width: fit-content;
   height: 16px;
   text-transform: uppercase;
-  font-size: 10px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -615,11 +591,11 @@ exports[`Badge > renders correctly size small 1`] = `
 exports[`Badge > renders correctly when disabled 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -644,8 +620,6 @@ exports[`Badge > renders correctly when disabled 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #727683;
   background: #e9eaeb;
   border: none;
@@ -666,11 +640,11 @@ exports[`Badge > renders correctly when disabled 1`] = `
 exports[`Badge > renders correctly with default values 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -695,8 +669,6 @@ exports[`Badge > renders correctly with default values 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -717,11 +689,11 @@ exports[`Badge > renders correctly with default values 1`] = `
 exports[`Badge > renders correctly with icon 1`] = `
 <DocumentFragment>
   .emotion-1 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -746,8 +718,6 @@ exports[`Badge > renders correctly with icon 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;

--- a/packages/ui/src/components/Badge/index.tsx
+++ b/packages/ui/src/components/Badge/index.tsx
@@ -29,6 +29,12 @@ export const PROMINENCES = {
   strong: 'strong',
 }
 
+export const TEXT_VARIANT = {
+  large: 'bodySmall',
+  medium: 'caption',
+  small: 'captionSmall',
+} as const
+
 /**
  * Generate all styles available for badge based on prominence and sentiments
  */
@@ -105,8 +111,6 @@ const StyledSpan = styled(Text, {
   width: fit-content;
   height: ${({ size }) => size}px;
   text-transform: uppercase;
-  font-size: ${({ fontSize }) => fontSize}px;
-  color: inherit;
   ${({ sentimentStyles }) => sentimentStyles}
 `
 
@@ -164,7 +168,7 @@ export const Badge = ({
         disabled ? generatedStyles['disabled'] : generatedStyles[sentiment]
       }
       size={sizeValue}
-      variant="bodyStrong"
+      variant={TEXT_VARIANT[size]}
       as="span"
       fontSize={TEXT_SIZES[size]}
       prominence={disabled ? 'weak' : 'default'}

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -304,11 +304,11 @@ exports[`Tab > renders correctly with counter, badge and subtitle 1`] = `
 }
 
 .emotion-8 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -333,8 +333,6 @@ exports[`Tab > renders correctly with counter, badge and subtitle 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -1477,11 +1477,11 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
 }
 
 .emotion-10 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1506,8 +1506,6 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #ffffff;
   background: #8c40ef;
   border: 1px solid #8c40ef;
@@ -1516,11 +1514,11 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
 }
 
 .emotion-32 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1545,8 +1543,6 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
@@ -2755,11 +2751,11 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
 }
 
 .emotion-15 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2784,8 +2780,6 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #ffffff;
   background: #8c40ef;
   border: 1px solid #8c40ef;
@@ -2794,11 +2788,11 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
 }
 
 .emotion-37 {
-  font-size: 16px;
+  font-size: 12px;
   font-family: Inter,Asap,sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 16px;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2823,8 +2817,6 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   width: fit-content;
   height: 24px;
   text-transform: uppercase;
-  font-size: 12px;
-  color: inherit;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<Badge />` font weight on each sizes

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="251" alt="Screenshot 2024-07-18 at 14 20 19" src="https://github.com/user-attachments/assets/1e9b9576-d308-411b-a7ff-71a7742028c4"> | <img width="283" alt="Screenshot 2024-07-18 at 14 20 25" src="https://github.com/user-attachments/assets/e303230c-325a-463f-ace8-c2f54b7f8807"> |
