### PR TITLE
ci: fix dns setting not working properly with github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
         with:
           type: "deploy"
           scw_dns: "storybook.ultraviolet.scaleway.com"
-          root_zone: ${{ env.BRANCH_SLUG == 'main' }}
+          # root_zone: ${{ env.BRANCH_SLUG == 'main' }} # setting a root alias in the DNS zone doesn't work as it already exists. It needs to be fixed in the script of the action.
           scw_access_key: ${{ secrets.SCW_ACCESS_KEY }}
           scw_secret_key: ${{ secrets.SCW_SECRET_KEY }}
           scw_containers_namespace_id: ${{ secrets.SCW_CONTAINERS_NAMESPACE_ID }}


### PR DESCRIPTION
<img width="1391" alt="Screenshot 2024-07-19 at 10 41 22" src="https://github.com/user-attachments/assets/bc684151-e164-4354-aeec-700bb7a088b8">

It seems that setting root zone alias doesn't work properly. The alias already exists and we try to add it again throwing that error: 

> http error 409: ALIAS has to be unique and cannot have multiple values(ALIAS:ultravioletjxvhzygy-main.functions.fnc.fr-par.scw.cloud. and ALIAS:ultravioletjxvhzygy-main.functions.fnc.fr-par.scw.cloud.)

I'm disabling `root_zone` from github action. The root alias will be defined manually (only once is needed) in the DNS until the github action is fixed.