### PR TITLE
fix(Icon): update docs and restore default name to alert

### DIFF
--- a/.changeset/weak-buckets-build.md
+++ b/.changeset/weak-buckets-build.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/icons": patch
+---
+
+Restore default name of `<Icon />` to `alert`

--- a/packages/icons/src/components/Icon/__stories__/Size.stories.tsx
+++ b/packages/icons/src/components/Icon/__stories__/Size.stories.tsx
@@ -3,8 +3,6 @@ import { Stack } from '@ultraviolet/ui'
 import type { ComponentProps } from 'react'
 import { Icon } from '..'
 
-const sizes: ComponentProps<typeof Icon>['size'][] = [40, 50, 60]
-
 export const Size = (args: ComponentProps<typeof Icon>) => (
   <Stack>
     <Stack direction="row" gap={3}>
@@ -13,11 +11,6 @@ export const Size = (args: ComponentProps<typeof Icon>) => (
     <Stack direction="row" gap={3}>
       <Icon name="eye" size="large" {...args} /> large
     </Stack>
-    {sizes.map(size => (
-      <Stack direction="row" gap={3}>
-        <Icon key={size} name="eye" size={size} {...args} /> {size}px
-      </Stack>
-    ))}
   </Stack>
 )
 

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -136,7 +136,7 @@ type IconProps = {
 export const Icon = forwardRef<SVGSVGElement, IconProps>(
   (
     {
-      name = 'sparkles',
+      name = 'alert',
       color = 'currentColor',
       sentiment,
       size = '1em',


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

- Fix story of icon for sizes
- Fix default name being restored to "alert"

## Relevant logs and/or screenshots

Before:
<img width="1066" alt="Screenshot 2024-07-22 at 18 40 34" src="https://github.com/user-attachments/assets/bcf1b765-3132-4b13-8aef-67551939db6c">

After:
<img width="1042" alt="Screenshot 2024-07-22 at 18 40 10" src="https://github.com/user-attachments/assets/f0f6685d-3393-443a-9db3-c0b3cffd77fe">

