### PR TITLE
fix(Alert): change title gap

### DIFF
--- a/.changeset/nasty-ads-tap.md
+++ b/.changeset/nasty-ads-tap.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+Update `<Alert />` title to have gap of `12px` instead of `4px`

--- a/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`SubmitErrorAlert > should display an alert when submitError is present 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
@@ -12440,7 +12440,7 @@ exports[`EstimateCost - Regular Item > render with alert 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;

--- a/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -271,7 +271,7 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -443,7 +443,7 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -620,7 +620,7 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -792,7 +792,7 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -964,7 +964,7 @@ exports[`Alert > renders correctly with buttonText and onClickButton 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1197,7 +1197,7 @@ exports[`Alert > renders correctly with children as component 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1356,7 +1356,7 @@ exports[`Alert > renders correctly with closable and onClose 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1614,7 +1614,7 @@ exports[`Alert > renders correctly with default values 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1878,7 +1878,7 @@ exports[`Alert > renders correctly with disabled 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1906,7 +1906,7 @@ exports[`Alert > renders correctly with disabled 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -2143,7 +2143,7 @@ exports[`Alert > renders correctly with title 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  gap: 12px;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;

--- a/packages/ui/src/components/Alert/index.tsx
+++ b/packages/ui/src/components/Alert/index.tsx
@@ -138,7 +138,7 @@ export const Alert = ({
             prominence={sentiment === 'neutral' ? 'strong' : undefined}
             sentiment={sentiment}
           />
-          <TextStack gap={0.5} direction="row">
+          <TextStack gap={1.5} direction="row">
             {title ? (
               <Text variant="bodyStronger" as="span" sentiment={sentiment}>
                 {title}


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Changed spacing of Alert title from 4px to 12px.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="967" alt="Screenshot 2024-07-24 at 14 15 17" src="https://github.com/user-attachments/assets/ae94864d-2063-471a-900e-f46966ac7734"> | <img width="962" alt="Screenshot 2024-07-24 at 14 15 23" src="https://github.com/user-attachments/assets/87615b53-e738-43fc-bbc3-a664d6428ad3"> |
