### PR TITLE
feat(CopyButton): add children prop

### DIFF
--- a/.changeset/lovely-terms-roll.md
+++ b/.changeset/lovely-terms-roll.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+Add prop `children` to `<CopyButton />` component to set a text into the button

--- a/packages/ui/src/components/CopyButton/__stories__/Children.stories.tsx
+++ b/packages/ui/src/components/CopyButton/__stories__/Children.stories.tsx
@@ -1,0 +1,16 @@
+import { Template } from './Template.stories'
+
+export const Children = Template.bind({})
+
+Children.args = {
+  children: 'Copy id',
+}
+
+Children.parameters = {
+  docs: {
+    description: {
+      story:
+        'If needed you can add a `children` prop to the component to customize the text inside the button.',
+    },
+  },
+}

--- a/packages/ui/src/components/CopyButton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/CopyButton/__stories__/index.stories.tsx
@@ -15,6 +15,7 @@ export default {
 } as Meta<typeof CopyButton>
 
 export { Playground } from './Playground.stories'
+export { Children } from './Children.stories'
 export { Sentiments } from './Sentiments.stories'
 export { Sizes } from './Sizes.stories'
 export { NoBorder } from './NoBorder.stories'

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -888,6 +888,121 @@ exports[`CopyButton > renders correctly with bordered 1`] = `
     data-testid="testing"
   >
     <div
+      aria-controls=":r9:"
+      aria-describedby=":r9:"
+      class="emotion-0 emotion-1"
+      data-container-full-width="false"
+      tabindex="0"
+    >
+      <button
+        aria-label="Copy"
+        class="emotion-2 emotion-3"
+        type="button"
+      >
+        <svg
+          class="emotion-4 emotion-5"
+          viewBox="0 0 16 16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M6.026 5.007A.1.1 0 0 0 6 5.084v8.333a.1.1 0 0 0 .026.076l.008.007h6.765l.008-.007a.1.1 0 0 0 .026-.076V5.084a.1.1 0 0 0-.026-.077L12.799 5H6.034zM4.5 5.084c0-.828.64-1.584 1.531-1.584h6.77c.891 0 1.532.756 1.532 1.584v8.333c0 .828-.64 1.583-1.531 1.583H6.03c-.89 0-1.531-.755-1.531-1.583z"
+            fill-rule="evenodd"
+          />
+          <path
+            clip-rule="evenodd"
+            d="M3.526 2.507a.1.1 0 0 0-.026.076v8.333a.75.75 0 0 1-1.5 0V2.583C2 1.755 2.64 1 3.531 1h6.77c.891 0 1.532.755 1.532 1.583a.75.75 0 0 1-1.5 0 .1.1 0 0 0-.026-.076L10.3 2.5H3.534z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`CopyButton > renders correctly with children 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: inherit;
+}
+
+.emotion-0[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: 32px;
+  padding: 0 8px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 8px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: none;
+  color: #641cb3;
+}
+
+.emotion-2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  background: #e5dbfd;
+  color: #521094;
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.emotion-4 .fillStroke {
+  stroke: currentColor;
+  fill: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
       aria-controls=":r8:"
       aria-describedby=":r8:"
       class="emotion-0 emotion-1"
@@ -915,6 +1030,7 @@ exports[`CopyButton > renders correctly with bordered 1`] = `
             fill-rule="evenodd"
           />
         </svg>
+        Copy test
       </button>
     </div>
   </div>
@@ -1003,8 +1119,8 @@ exports[`CopyButton > renders correctly with custom class name 1`] = `
     data-testid="testing"
   >
     <div
-      aria-controls=":rb:"
-      aria-describedby=":rb:"
+      aria-controls=":rc:"
+      aria-describedby=":rc:"
       class="emotion-0 emotion-1"
       data-container-full-width="false"
       tabindex="0"
@@ -1118,8 +1234,8 @@ exports[`CopyButton > renders correctly with custom copied text 1`] = `
     data-testid="testing"
   >
     <div
-      aria-controls=":ra:"
-      aria-describedby=":ra:"
+      aria-controls=":rb:"
+      aria-describedby=":rb:"
       class="emotion-0 emotion-1"
       data-container-full-width="false"
       tabindex="0"
@@ -1233,8 +1349,8 @@ exports[`CopyButton > renders correctly with custom copy text 1`] = `
     data-testid="testing"
   >
     <div
-      aria-controls=":r9:"
-      aria-describedby=":r9:"
+      aria-controls=":ra:"
+      aria-describedby=":ra:"
       class="emotion-0 emotion-1"
       data-container-full-width="false"
       tabindex="0"

--- a/packages/ui/src/components/CopyButton/__tests__/index.test.tsx
+++ b/packages/ui/src/components/CopyButton/__tests__/index.test.tsx
@@ -33,6 +33,9 @@ describe('CopyButton', () => {
   test('renders correctly with no border', () =>
     shouldMatchEmotionSnapshot(<CopyButton value="Test" noBorder />))
 
+  test('renders correctly with children', () =>
+    shouldMatchEmotionSnapshot(<CopyButton value="Test">Copy test</CopyButton>))
+
   test('renders correctly with bordered', () =>
     shouldMatchEmotionSnapshot(<CopyButton value="Test" bordered />))
 

--- a/packages/ui/src/components/CopyButton/index.tsx
+++ b/packages/ui/src/components/CopyButton/index.tsx
@@ -16,6 +16,7 @@ type CopyButtonProps = {
   bordered?: boolean
   className?: string
   'data-testid'?: string
+  children?: string
 }
 
 /**
@@ -30,6 +31,7 @@ export const CopyButton = ({
   noBorder,
   bordered,
   className,
+  children,
   'data-testid': dataTestId,
 }: CopyButtonProps) => {
   const [isCopied, setCopied] = useClipboard(value, {
@@ -48,6 +50,8 @@ export const CopyButton = ({
       aria-label="Copy"
       icon={isCopied ? 'check' : 'copy-content'}
       tooltip={isCopied ? copiedText : copyText}
-    />
+    >
+      {children}
+    </Button>
   )
 }


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Add prop `children` to `<CopyButton />` component to set a text into the button

## Relevant logs and/or screenshots

<img width="1043" alt="Screenshot 2024-07-24 at 15 27 53" src="https://github.com/user-attachments/assets/e09aec0e-f10b-47ef-acf4-23aaf268929c">

