### PR TITLE
fix(DateInput): wrong type

### DIFF
--- a/.changeset/breezy-boats-complain.md
+++ b/.changeset/breezy-boats-complain.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<DateInput />` type

--- a/packages/ui/src/components/DateInput/index.tsx
+++ b/packages/ui/src/components/DateInput/index.tsx
@@ -188,7 +188,7 @@ const StyledText = styled(Text)`
 
 type DateInputProps = Pick<
   ReactDatePickerProps<boolean | undefined, boolean>,
-  'locale' | 'onChange' | 'showMonthYearPicker'
+  'locale' | 'onChange'
 > & {
   autoFocus?: boolean
   disabled?: boolean
@@ -218,6 +218,7 @@ type DateInputProps = Pick<
   size?: 'small' | 'medium' | 'large'
   readOnly?: boolean
   tooltip?: string
+  showMonthYearPicker?: boolean
 }
 
 const DEFAULT_FORMAT: DateInputProps['format'] = value =>


### PR DESCRIPTION
There is a type issue with `showMonthYearPicker` apparently being required.