### PR TITLE
refactor(inputs): to have 8px padding instead of 16px in small sizes

### DIFF
--- a/.changeset/young-toes-rescue.md
+++ b/.changeset/young-toes-rescue.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": minor
+"@ultraviolet/ui": minor
+---
+
+Refactor all inputs to have `8px` padding in `small` size instead of `16px`

--- a/packages/form/src/components/DateField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/DateField/__tests__/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,10 @@ exports[`DateField > should render correctly 1`] = `
   font-size: 16px;
 }
 
+.emotion-6[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -700,6 +704,10 @@ exports[`DateField > should render correctly disabled 1`] = `
 
 .emotion-6[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-6[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-8 {
@@ -1106,6 +1114,10 @@ exports[`DateField > should trigger events 1`] = `
 
 .emotion-6[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-6[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-8 {

--- a/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
 
 .emotion-6[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-6[data-size='medium'] {
@@ -1005,6 +1006,7 @@ exports[`SelectInputField > should render correctly 1`] = `
 
 .emotion-6[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-6[data-size='medium'] {
@@ -1248,6 +1250,7 @@ exports[`SelectInputField > should render correctly disabled 1`] = `
 
 .emotion-6[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-6[data-size='medium'] {
@@ -1491,6 +1494,7 @@ exports[`SelectInputField > should render correctly grouped 1`] = `
 
 .emotion-6[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-6[data-size='medium'] {
@@ -1734,6 +1738,7 @@ exports[`SelectInputField > should render correctly multiselect 1`] = `
 
 .emotion-6[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-6[data-size='medium'] {
@@ -1977,6 +1982,7 @@ exports[`SelectInputField > should trigger events 1`] = `
 
 .emotion-6[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-6[data-size='medium'] {

--- a/packages/form/src/components/TextInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TextInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -176,6 +176,10 @@ exports[`TextInputFieldV2 > should render correctly 1`] = `
   font-size: 16px;
 }
 
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
+}
+
 <div
     data-testid="testing"
   >
@@ -412,6 +416,10 @@ exports[`TextInputFieldV2 > should render correctly generated 1`] = `
 
 .emotion-12[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-14 {

--- a/packages/form/src/components/UnitInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/UnitInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -241,6 +241,10 @@ exports[`UnitInputField > should handles onChange and selection 1`] = `
   color: #3f4250;
 }
 
+.emotion-12[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-12::-webkit-input-placeholder {
   color: #727683;
 }
@@ -348,6 +352,7 @@ exports[`UnitInputField > should handles onChange and selection 1`] = `
 
 .emotion-21[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-21[data-size='medium'] {
@@ -538,6 +543,7 @@ exports[`UnitInputField > should handles onChange and selection 1`] = `
             <input
               aria-invalid="false"
               class="emotion-12 emotion-13"
+              data-size="large"
               data-testid="unit-input"
               max="9007199254740991"
               min="0"
@@ -841,6 +847,10 @@ exports[`UnitInputField > should render correctly 1`] = `
   color: #3f4250;
 }
 
+.emotion-10[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-10::-webkit-input-placeholder {
   color: #727683;
 }
@@ -948,6 +958,7 @@ exports[`UnitInputField > should render correctly 1`] = `
 
 .emotion-19[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-19[data-size='medium'] {
@@ -1076,6 +1087,7 @@ exports[`UnitInputField > should render correctly 1`] = `
             <input
               aria-invalid="false"
               class="emotion-10 emotion-11"
+              data-size="large"
               data-testid="unit-input"
               max="9007199254740991"
               min="0"

--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -357,6 +357,10 @@ exports[`DateInput > render correctly with a array of dates to exclude 1`] = `
   font-size: 16px;
 }
 
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -825,6 +829,10 @@ exports[`DateInput > render correctly with a range of date 1`] = `
 
 .emotion-12[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-14 {
@@ -1297,6 +1305,10 @@ exports[`DateInput > render correctly with showMonthYearPicker 1`] = `
   font-size: 16px;
 }
 
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1765,6 +1777,10 @@ exports[`DateInput > renders correctly disabled 1`] = `
 
 .emotion-12[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-14 {
@@ -2236,6 +2252,10 @@ exports[`DateInput > renders correctly error 1`] = `
 
 .emotion-12[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-14 {
@@ -2776,6 +2796,10 @@ exports[`DateInput > renders correctly error disabled 1`] = `
 
 .emotion-12[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-14 {
@@ -3333,6 +3357,10 @@ exports[`DateInput > renders correctly error disabled required 1`] = `
   font-size: 16px;
 }
 
+.emotion-14[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3884,6 +3912,10 @@ exports[`DateInput > renders correctly min-max 1`] = `
   font-size: 16px;
 }
 
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4368,6 +4400,10 @@ exports[`DateInput > renders correctly required 1`] = `
   font-size: 16px;
 }
 
+.emotion-14[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4848,6 +4884,10 @@ exports[`DateInput > renders correctly with date-fns locale es 1`] = `
 
 .emotion-12[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-14 {
@@ -6046,6 +6086,10 @@ exports[`DateInput > renders correctly with date-fns locale fr 1`] = `
   font-size: 16px;
 }
 
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -7242,6 +7286,10 @@ exports[`DateInput > renders correctly with date-fns locale ru 1`] = `
   font-size: 16px;
 }
 
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-14 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -8434,6 +8482,10 @@ exports[`DateInput > renders correctly with default props 1`] = `
 
 .emotion-12[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-12[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-14 {

--- a/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1002,6 +1002,10 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   border-color: inherit;
 }
 
+.emotion-7[data-size="small"] {
+  padding: 8px;
+}
+
 .emotion-9 {
   vertical-align: middle;
   fill: #3f4250;
@@ -1033,6 +1037,10 @@ exports[`SearchInput > renders correctly without children props 1`] = `
   font-size: 16px;
 }
 
+.emotion-11[data-size='small'] {
+  padding-left: 8px;
+}
+
 <div
     data-testid="testing"
   >
@@ -1058,6 +1066,7 @@ exports[`SearchInput > renders correctly without children props 1`] = `
             >
               <div
                 class="emotion-7 emotion-8"
+                data-size="large"
               >
                 <svg
                   class="emotion-9 emotion-10"
@@ -1236,6 +1245,10 @@ exports[`SearchInput > renders with disabled prop 1`] = `
   border-color: inherit;
 }
 
+.emotion-7[data-size="small"] {
+  padding: 8px;
+}
+
 .emotion-9 {
   vertical-align: middle;
   fill: #b5b7bd;
@@ -1267,6 +1280,10 @@ exports[`SearchInput > renders with disabled prop 1`] = `
   font-size: 16px;
 }
 
+.emotion-11[data-size='small'] {
+  padding-left: 8px;
+}
+
 <div
     data-testid="testing"
   >
@@ -1292,6 +1309,7 @@ exports[`SearchInput > renders with disabled prop 1`] = `
             >
               <div
                 class="emotion-7 emotion-8"
+                data-size="large"
               >
                 <svg
                   class="emotion-9 emotion-10"
@@ -1471,6 +1489,10 @@ exports[`SearchInput > renders with error prop 1`] = `
   border-color: inherit;
 }
 
+.emotion-7[data-size="small"] {
+  padding: 8px;
+}
+
 .emotion-9 {
   vertical-align: middle;
   fill: #3f4250;
@@ -1500,6 +1522,10 @@ exports[`SearchInput > renders with error prop 1`] = `
 
 .emotion-11[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-11[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-13 {
@@ -1577,6 +1603,7 @@ exports[`SearchInput > renders with error prop 1`] = `
             >
               <div
                 class="emotion-7 emotion-8"
+                data-size="large"
               >
                 <svg
                   class="emotion-9 emotion-10"
@@ -1775,6 +1802,10 @@ exports[`SearchInput > renders with shortcut prop > as array of string 1`] = `
   border-color: inherit;
 }
 
+.emotion-7[data-size="small"] {
+  padding: 8px;
+}
+
 .emotion-9 {
   vertical-align: middle;
   fill: #3f4250;
@@ -1804,6 +1835,10 @@ exports[`SearchInput > renders with shortcut prop > as array of string 1`] = `
 
 .emotion-11[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-11[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-13 {
@@ -1922,6 +1957,7 @@ exports[`SearchInput > renders with shortcut prop > as array of string 1`] = `
             >
               <div
                 class="emotion-7 emotion-8"
+                data-size="large"
               >
                 <svg
                   class="emotion-9 emotion-10"
@@ -2138,6 +2174,10 @@ exports[`SearchInput > renders with shortcut prop > as boolean 1`] = `
   border-color: inherit;
 }
 
+.emotion-7[data-size="small"] {
+  padding: 8px;
+}
+
 .emotion-9 {
   vertical-align: middle;
   fill: #3f4250;
@@ -2167,6 +2207,10 @@ exports[`SearchInput > renders with shortcut prop > as boolean 1`] = `
 
 .emotion-11[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-11[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-13 {
@@ -2285,6 +2329,7 @@ exports[`SearchInput > renders with shortcut prop > as boolean 1`] = `
             >
               <div
                 class="emotion-7 emotion-8"
+                data-size="large"
               >
                 <svg
                   class="emotion-9 emotion-10"

--- a/packages/ui/src/components/SelectInputV2/SelectBar.tsx
+++ b/packages/ui/src/components/SelectInputV2/SelectBar.tsx
@@ -74,6 +74,7 @@ const StyledInputWrapper = styled(Stack)<{
   }
   &[data-size='small'] {
     height: ${INPUT_SIZE_HEIGHT.small}px;
+    padding-left: ${({ theme }) => theme.space[1]};
   }
   &[data-size='medium'] {
     height: ${INPUT_SIZE_HEIGHT.medium}px;

--- a/packages/ui/src/components/TagInput/index.tsx
+++ b/packages/ui/src/components/TagInput/index.tsx
@@ -42,7 +42,7 @@ const TagInputContainer = styled('div', {
 
   padding: ${({ theme, size }) =>
     `calc(${theme.space[TAGINPUT_SIZE_PADDING[size]]} - 1px) ${
-      theme.space['2']
+      size === 'small' ? theme.space['1'] : theme.space['2']
     }`};
   cursor: text;
 

--- a/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
@@ -20,4 +20,5 @@ Template.args = {
   role: 'status',
   'aria-live': 'polite',
   'aria-atomic': 'true',
+  prefix: 'test',
 }

--- a/packages/ui/src/components/TextInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -333,6 +333,10 @@ exports[`TextInputV2 > should render correctly when input  has a error sentiment
   font-size: 16px;
 }
 
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-10 {
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -348,6 +352,10 @@ exports[`TextInputV2 > should render correctly when input  has a error sentiment
 
 .emotion-10[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-12 {
@@ -820,6 +828,10 @@ exports[`TextInputV2 > should render correctly when input has a success sentimen
   font-size: 16px;
 }
 
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-10 {
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -835,6 +847,10 @@ exports[`TextInputV2 > should render correctly when input has a success sentimen
 
 .emotion-10[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
 }
 
 .emotion-12 {
@@ -1307,6 +1323,10 @@ exports[`TextInputV2 > should render correctly when input is disabled 1`] = `
   font-size: 16px;
 }
 
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-10 {
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -1322,6 +1342,10 @@ exports[`TextInputV2 > should render correctly when input is disabled 1`] = `
 
 .emotion-10[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
 }
 
 <div
@@ -1701,6 +1725,10 @@ exports[`TextInputV2 > should render correctly when input is readOnly 1`] = `
   font-size: 16px;
 }
 
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
+}
+
 .emotion-10 {
   -webkit-flex: 1;
   -ms-flex: 1;
@@ -1716,6 +1744,10 @@ exports[`TextInputV2 > should render correctly when input is readOnly 1`] = `
 
 .emotion-10[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
 }
 
 <div
@@ -1936,6 +1968,10 @@ exports[`TextInputV2 > should render correctly with basic props 1`] = `
 
 .emotion-10[data-size='large'] {
   font-size: 16px;
+}
+
+.emotion-10[data-size='small'] {
+  padding-left: 8px;
 }
 
 <div

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -31,6 +31,10 @@ type TextInputSize = keyof typeof TEXTINPUT_SIZE_HEIGHT
 
 export const BasicPrefixStack = styled(Stack)`
   padding: ${({ theme }) => theme.space['2']};
+
+  &[data-size="small"] {
+    padding: ${({ theme }) => theme.space['1']};
+  }
   border-right: 1px solid;
   border-color: inherit;
 `
@@ -65,6 +69,10 @@ export const StyledInput = styled.input<{
 
   &[data-size='large'] {
     font-size: ${({ theme }) => theme.typography.body.fontSize};
+  }
+
+  &[data-size='small'] {
+    padding-left: ${({ theme }) => theme.space['1']};
   }
 `
 
@@ -293,7 +301,11 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
               size={size}
             >
               {prefix ? (
-                <BasicPrefixStack direction="row" alignItems="center">
+                <BasicPrefixStack
+                  direction="row"
+                  alignItems="center"
+                  data-size={size}
+                >
                   {typeof prefix === 'string' ? (
                     <Text
                       as="span"

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -390,6 +390,10 @@ exports[`UnitInput > renders click 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -436,6 +440,10 @@ exports[`UnitInput > renders click 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -568,6 +576,7 @@ exports[`UnitInput > renders click 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -656,6 +665,7 @@ exports[`UnitInput > renders click 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -1024,6 +1034,7 @@ exports[`UnitInput > renders click 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="medium"
             data-testid="unit-input"
             max="9007199254740991"
             min="0"
@@ -1382,6 +1393,10 @@ exports[`UnitInput > renders with default props 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -1489,6 +1504,7 @@ exports[`UnitInput > renders with default props 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -1604,6 +1620,7 @@ exports[`UnitInput > renders with default props 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="large"
             data-testid="unit-input"
             max="9007199254740991"
             min="0"
@@ -2044,6 +2061,10 @@ exports[`UnitInput > renders with default value 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -2090,6 +2111,10 @@ exports[`UnitInput > renders with default value 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -2222,6 +2247,7 @@ exports[`UnitInput > renders with default value 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -2310,6 +2336,7 @@ exports[`UnitInput > renders with default value 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -2463,6 +2490,7 @@ exports[`UnitInput > renders with default value 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="large"
             data-testid="unit-input"
             disabled=""
             max="9007199254740991"
@@ -2904,6 +2932,10 @@ exports[`UnitInput > renders with disabled and placeHolder 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -2950,6 +2982,10 @@ exports[`UnitInput > renders with disabled and placeHolder 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -3082,6 +3118,7 @@ exports[`UnitInput > renders with disabled and placeHolder 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -3170,6 +3207,7 @@ exports[`UnitInput > renders with disabled and placeHolder 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -3313,6 +3351,7 @@ exports[`UnitInput > renders with disabled and placeHolder 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="large"
             data-testid="unit-input"
             disabled=""
             max="9007199254740991"
@@ -3754,6 +3793,10 @@ exports[`UnitInput > renders with error  and success 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -3800,6 +3843,10 @@ exports[`UnitInput > renders with error  and success 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -3946,6 +3993,7 @@ exports[`UnitInput > renders with error  and success 1`] = `
 
 .emotion-17[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-17[data-size='medium'] {
@@ -4034,6 +4082,7 @@ exports[`UnitInput > renders with error  and success 1`] = `
 
 .emotion-17[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-17[data-size='medium'] {
@@ -4204,6 +4253,7 @@ exports[`UnitInput > renders with error  and success 1`] = `
             aria-invalid="true"
             class="emotion-6 emotion-7"
             data-error="true"
+            data-size="large"
             data-success="success"
             data-testid="unit-input"
             max="9007199254740991"
@@ -4659,6 +4709,10 @@ exports[`UnitInput > renders with error 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -4705,6 +4759,10 @@ exports[`UnitInput > renders with error 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -4851,6 +4909,7 @@ exports[`UnitInput > renders with error 1`] = `
 
 .emotion-17[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-17[data-size='medium'] {
@@ -4939,6 +4998,7 @@ exports[`UnitInput > renders with error 1`] = `
 
 .emotion-17[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-17[data-size='medium'] {
@@ -5109,6 +5169,7 @@ exports[`UnitInput > renders with error 1`] = `
             aria-invalid="true"
             class="emotion-6 emotion-7"
             data-error="error"
+            data-size="large"
             data-testid="unit-input"
             max="9007199254740991"
             min="0"
@@ -5599,6 +5660,10 @@ exports[`UnitInput > renders with label and label information 1`] = `
   color: #3f4250;
 }
 
+.emotion-10[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-10::-webkit-input-placeholder {
   color: #727683;
 }
@@ -5645,6 +5710,10 @@ exports[`UnitInput > renders with label and label information 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-10[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-10::-webkit-input-placeholder {
@@ -5777,6 +5846,7 @@ exports[`UnitInput > renders with label and label information 1`] = `
 
 .emotion-19[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-19[data-size='medium'] {
@@ -5865,6 +5935,7 @@ exports[`UnitInput > renders with label and label information 1`] = `
 
 .emotion-19[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-19[data-size='medium'] {
@@ -6019,6 +6090,7 @@ exports[`UnitInput > renders with label and label information 1`] = `
           <input
             aria-invalid="false"
             class="emotion-10 emotion-11"
+            data-size="large"
             data-testid="unit-input"
             disabled=""
             max="9007199254740991"
@@ -6494,6 +6566,10 @@ exports[`UnitInput > renders with label and no label information 1`] = `
   color: #3f4250;
 }
 
+.emotion-10[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-10::-webkit-input-placeholder {
   color: #727683;
 }
@@ -6540,6 +6616,10 @@ exports[`UnitInput > renders with label and no label information 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-10[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-10::-webkit-input-placeholder {
@@ -6672,6 +6752,7 @@ exports[`UnitInput > renders with label and no label information 1`] = `
 
 .emotion-19[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-19[data-size='medium'] {
@@ -6760,6 +6841,7 @@ exports[`UnitInput > renders with label and no label information 1`] = `
 
 .emotion-19[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-19[data-size='medium'] {
@@ -6913,6 +6995,7 @@ exports[`UnitInput > renders with label and no label information 1`] = `
           <input
             aria-invalid="false"
             class="emotion-10 emotion-11"
+            data-size="large"
             data-testid="unit-input"
             disabled=""
             max="9007199254740991"
@@ -7175,6 +7258,10 @@ exports[`UnitInput > renders with min max 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -7282,6 +7369,7 @@ exports[`UnitInput > renders with min max 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -7397,6 +7485,7 @@ exports[`UnitInput > renders with min max 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="large"
             data-testid="unit-input"
             max="100"
             min="10"
@@ -7837,6 +7926,10 @@ exports[`UnitInput > renders with no label and label information 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -7883,6 +7976,10 @@ exports[`UnitInput > renders with no label and label information 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -8015,6 +8112,7 @@ exports[`UnitInput > renders with no label and label information 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -8103,6 +8201,7 @@ exports[`UnitInput > renders with no label and label information 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -8246,6 +8345,7 @@ exports[`UnitInput > renders with no label and label information 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="large"
             data-testid="unit-input"
             disabled=""
             max="9007199254740991"
@@ -8687,6 +8787,10 @@ exports[`UnitInput > renders with size large 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -8733,6 +8837,10 @@ exports[`UnitInput > renders with size large 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -8865,6 +8973,7 @@ exports[`UnitInput > renders with size large 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -8953,6 +9062,7 @@ exports[`UnitInput > renders with size large 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -9110,6 +9220,7 @@ exports[`UnitInput > renders with size large 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="large"
             data-testid="unit-input"
             max="9007199254740991"
             min="0"
@@ -9371,6 +9482,10 @@ exports[`UnitInput > renders with size medioum 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -9478,6 +9593,7 @@ exports[`UnitInput > renders with size medioum 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -9593,6 +9709,7 @@ exports[`UnitInput > renders with size medioum 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="medium"
             data-testid="unit-input"
             max="9007199254740991"
             min="0"
@@ -9854,6 +9971,10 @@ exports[`UnitInput > renders with size small 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -9961,6 +10082,7 @@ exports[`UnitInput > renders with size small 1`] = `
 
 .emotion-15[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-15[data-size='medium'] {
@@ -10076,6 +10198,7 @@ exports[`UnitInput > renders with size small 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="small"
             data-testid="unit-input"
             max="9007199254740991"
             min="0"
@@ -10516,6 +10639,10 @@ exports[`UnitInput > renders with success 1`] = `
   color: #3f4250;
 }
 
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
+}
+
 .emotion-6::-webkit-input-placeholder {
   color: #727683;
 }
@@ -10562,6 +10689,10 @@ exports[`UnitInput > renders with success 1`] = `
   padding-left: 16px;
   background: transparent;
   color: #3f4250;
+}
+
+.emotion-6[data-size="small"] {
+  padding-left: 8px;
 }
 
 .emotion-6::-webkit-input-placeholder {
@@ -10708,6 +10839,7 @@ exports[`UnitInput > renders with success 1`] = `
 
 .emotion-17[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-17[data-size='medium'] {
@@ -10796,6 +10928,7 @@ exports[`UnitInput > renders with success 1`] = `
 
 .emotion-17[data-size='small'] {
   height: 32px;
+  padding-left: 8px;
 }
 
 .emotion-17[data-size='medium'] {
@@ -10965,6 +11098,7 @@ exports[`UnitInput > renders with success 1`] = `
           <input
             aria-invalid="false"
             class="emotion-6 emotion-7"
+            data-size="large"
             data-success="true"
             data-testid="unit-input"
             max="9007199254740991"

--- a/packages/ui/src/components/UnitInput/index.tsx
+++ b/packages/ui/src/components/UnitInput/index.tsx
@@ -31,6 +31,10 @@ const StyledInput = styled.input`
   padding-left: ${({ theme }) => theme.space['2']};
   background: transparent;
   color: ${({ theme }) => theme.colors.neutral.text};
+  &[data-size="small"] {
+    padding-left: ${({ theme }) => theme.space['1']};
+  }
+
   &::placeholder {
     color: ${({ theme }) => theme.colors.neutral.textWeak};
   }
@@ -313,6 +317,7 @@ export const UnitInput = ({
             data-testid="unit-input"
             required={required}
             className={className}
+            data-size={size}
           />
           {error ? <Icon name="alert" sentiment="danger" /> : null}
           {success && !error ? (


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Refactor all inputs to have `8px` padding in `small` size instead of `16px`

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="952" alt="Screenshot 2024-07-25 at 14 52 37" src="https://github.com/user-attachments/assets/b506089f-2e02-426c-92e3-62de9042433f"> | <img width="955" alt="Screenshot 2024-07-25 at 14 52 42" src="https://github.com/user-attachments/assets/89b6b435-f5f4-4074-a635-d232c9ea7a9a"> |
| url  | <img width="793" alt="Screenshot 2024-07-25 at 15 04 07" src="https://github.com/user-attachments/assets/25398053-3e7c-4811-afd5-452e4aa26881"> | <img width="785" alt="Screenshot 2024-07-25 at 15 04 12" src="https://github.com/user-attachments/assets/8c77a784-86d4-4dc5-b4b9-fa8a51e6e8a4"> |
| url  | <img width="963" alt="Screenshot 2024-07-25 at 15 04 30" src="https://github.com/user-attachments/assets/84ad5c64-819e-4a09-84d4-a605af4034e6"> | <img width="968" alt="Screenshot 2024-07-25 at 15 04 34" src="https://github.com/user-attachments/assets/6711ec4b-fd9d-400a-b9cc-dc3639754b4b"> |
| url  | <img width="969" alt="Screenshot 2024-07-25 at 15 06 56" src="https://github.com/user-attachments/assets/e8d56a0f-54ab-43b8-92e5-3dc1d4b9fc32"> | <img width="964" alt="Screenshot 2024-07-25 at 15 06 59" src="https://github.com/user-attachments/assets/e1b6b1fe-8f94-4f3d-a01c-f06f458187a3"> |
| url  | <img width="623" alt="Screenshot 2024-07-25 at 15 10 52" src="https://github.com/user-attachments/assets/8372cae0-907c-4c6d-a06f-628bdd2a0514"> | <img width="646" alt="Screenshot 2024-07-25 at 15 10 55" src="https://github.com/user-attachments/assets/be86540a-da0b-4265-9900-b920553c0b29"> |
