### PR TITLE
fix(DateInput): to have correct color when month only and range

### DIFF
--- a/.changeset/itchy-buckets-enjoy.md
+++ b/.changeset/itchy-buckets-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+Fix `<DateInput />` colors when having both props `selectsRange` and `showMonthYearPicker`

--- a/packages/form/src/components/DateField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/DateField/__tests__/__snapshots__/index.test.tsx.snap
@@ -118,46 +118,58 @@ exports[`DateField > should render correctly 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -174,11 +186,13 @@ exports[`DateField > should render correctly 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -521,46 +535,58 @@ exports[`DateField > should render correctly disabled 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -577,11 +603,13 @@ exports[`DateField > should render correctly disabled 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -925,46 +953,58 @@ exports[`DateField > should trigger events 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -981,11 +1021,13 @@ exports[`DateField > should trigger events 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }

--- a/packages/ui/src/components/DateInput/__stories__/Months.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/Months.stories.tsx
@@ -3,16 +3,22 @@ import { useState } from 'react'
 import { DateInput } from '..'
 
 export const Months: StoryFn = args => {
-  const [date, setDate] = useState<
-    Date | Date[] | [Date | null, Date | null] | null
-  >(new Date('December 17, 1995 03:24:00'))
+  const [startDate, setStartDate] = useState<Date | null>(null)
+  const [endDate, setEndDate] = useState<Date | null>(null)
+  const onChange = (dates: [Date | null, Date | null]) => {
+    const [start, end] = dates
+    setStartDate(start)
+    setEndDate(end)
+  }
 
   return (
     <DateInput
       label="Date"
-      onChange={setDate}
-      value={date as Date}
+      startDate={startDate}
+      endDate={endDate}
+      onChange={onChange}
       showMonthYearPicker
+      selectsRange
       {...args}
     />
   )

--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -118,46 +118,58 @@ exports[`DateInput > render correctly with a array of dates to exclude 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -174,11 +186,13 @@ exports[`DateInput > render correctly with a array of dates to exclude 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -588,46 +602,58 @@ exports[`DateInput > render correctly with a range of date 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -644,11 +670,13 @@ exports[`DateInput > render correctly with a range of date 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -1058,46 +1086,58 @@ exports[`DateInput > render correctly with showMonthYearPicker 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -1114,11 +1154,13 @@ exports[`DateInput > render correctly with showMonthYearPicker 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -1528,46 +1570,58 @@ exports[`DateInput > renders correctly disabled 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -1584,11 +1638,13 @@ exports[`DateInput > renders correctly disabled 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -1999,46 +2055,58 @@ exports[`DateInput > renders correctly error 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -2055,11 +2123,13 @@ exports[`DateInput > renders correctly error 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -2539,46 +2609,58 @@ exports[`DateInput > renders correctly error disabled 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -2595,11 +2677,13 @@ exports[`DateInput > renders correctly error disabled 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -3080,46 +3164,58 @@ exports[`DateInput > renders correctly error disabled required 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -3136,11 +3232,13 @@ exports[`DateInput > renders correctly error disabled required 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -3645,46 +3743,58 @@ exports[`DateInput > renders correctly min-max 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -3701,11 +3811,13 @@ exports[`DateInput > renders correctly min-max 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -4115,46 +4227,58 @@ exports[`DateInput > renders correctly required 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -4171,11 +4295,13 @@ exports[`DateInput > renders correctly required 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -4609,46 +4735,58 @@ exports[`DateInput > renders correctly with date-fns locale es 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -4665,11 +4803,13 @@ exports[`DateInput > renders correctly with date-fns locale es 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -5805,46 +5945,58 @@ exports[`DateInput > renders correctly with date-fns locale fr 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -5861,11 +6013,13 @@ exports[`DateInput > renders correctly with date-fns locale fr 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -7001,46 +7155,58 @@ exports[`DateInput > renders correctly with date-fns locale ru 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -7057,11 +7223,13 @@ exports[`DateInput > renders correctly with date-fns locale ru 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }
@@ -8197,46 +8365,58 @@ exports[`DateInput > renders correctly with default props 1`] = `
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range {
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-selecting-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-selecting-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-selecting-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--in-range {
+.emotion-0 .calendar .react-datepicker__day--in-range,
+.emotion-0 .calendar .react-datepicker__month-text--in-range {
   color: #641cb3;
   background-color: #f1eefc;
 }
 
 .emotion-0 .calendar .react-datepicker__day--in-range[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--in-range:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--in-range[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--in-range:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--in-range:disabled {
   color: #d8c5fc;
   background-color: #f6f5fd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-start {
+.emotion-0 .calendar .react-datepicker__day--range-start,
+.emotion-0 .calendar .react-datepicker__month-text--range-start {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-start[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-start:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-start[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-start:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-start:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--range-end {
+.emotion-0 .calendar .react-datepicker__day--range-end,
+.emotion-0 .calendar .react-datepicker__month-text--range-end {
   color: #ffffff;
   background-color: #8c40ef;
 }
 
 .emotion-0 .calendar .react-datepicker__day--range-end[aria-disabled="true"],
-.emotion-0 .calendar .react-datepicker__day--range-end:disabled {
+.emotion-0 .calendar .react-datepicker__month-text--range-end[aria-disabled="true"],
+.emotion-0 .calendar .react-datepicker__day--range-end:disabled,
+.emotion-0 .calendar .react-datepicker__month-text--range-end:disabled {
   color: #ffffff;
   background-color: #e5dbfd;
 }
@@ -8253,11 +8433,13 @@ exports[`DateInput > renders correctly with default props 1`] = `
   background-color: #e9eaeb;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled {
+.emotion-0 .calendar .react-datepicker__day--disabled,
+.emotion-0 .calendar .react-datepicker__month-text--disabled {
   color: #b5b7bd;
 }
 
-.emotion-0 .calendar .react-datepicker__day--disabled:hover {
+.emotion-0 .calendar .react-datepicker__day--disabled:hover,
+.emotion-0 .calendar .react-datepicker__month-text--disabled:hover {
   color: #b5b7bd;
   background-color: transparent;
 }

--- a/packages/ui/src/components/DateInput/index.tsx
+++ b/packages/ui/src/components/DateInput/index.tsx
@@ -113,7 +113,7 @@ const StyledWrapper = styled.div`
       }
     }
 
-    ${PREFIX}__day--in-selecting-range {
+    ${PREFIX}__day--in-selecting-range,  ${PREFIX}__month-text--in-selecting-range {
       color: ${({ theme }) => theme.colors.primary.text};
       background-color: ${({ theme }) => theme.colors.primary.background};
 
@@ -125,7 +125,7 @@ const StyledWrapper = styled.div`
       }
     }
 
-    ${PREFIX}__day--in-range {
+    ${PREFIX}__day--in-range, ${PREFIX}__month-text--in-range {
       color: ${({ theme }) => theme.colors.primary.text};
       background-color: ${({ theme }) => theme.colors.primary.background};
 
@@ -137,7 +137,7 @@ const StyledWrapper = styled.div`
       }
     }
 
-    ${PREFIX}__day--range-start {
+    ${PREFIX}__day--range-start, ${PREFIX}__month-text--range-start {
       color: ${({ theme }) => theme.colors.primary.textStrong};
       background-color: ${({ theme }) => theme.colors.primary.backgroundStrong};
 
@@ -149,7 +149,7 @@ const StyledWrapper = styled.div`
       }
     }
 
-    ${PREFIX}__day--range-end {
+    ${PREFIX}__day--range-end, ${PREFIX}__month-text--range-end {
       color: ${({ theme }) => theme.colors.primary.textStrong};
       background-color: ${({ theme }) => theme.colors.primary.backgroundStrong};
 
@@ -171,11 +171,11 @@ const StyledWrapper = styled.div`
       background-color: ${({ theme }) => theme.colors.neutral.backgroundHover};
     }
 
-    ${PREFIX}__day--disabled {
+    ${PREFIX}__day--disabled, ${PREFIX}__month-text--disabled {
       color: ${({ theme }) => theme.colors.neutral.textDisabled};
     }
 
-    ${PREFIX}__day--disabled:hover {
+    ${PREFIX}__day--disabled:hover, ${PREFIX}__month-text--disabled:hover {
       color: ${({ theme }) => theme.colors.neutral.textDisabled};
       background-color: transparent;
     }


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<DateInput />` colors when having both props `selectsRange` and `showMonthYearPicker`

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="329" alt="Screenshot 2024-07-26 at 11 14 49" src="https://github.com/user-attachments/assets/b56218dc-ac99-4fd2-9f67-323761720752"> | <img width="342" alt="Screenshot 2024-07-26 at 11 15 18" src="https://github.com/user-attachments/assets/2ce6a15d-506e-4cd7-a093-8eaf264e63b5"> |
