### PR TITLE
fix(TagInputField): regex to work with array of string value

### DIFF
--- a/.changeset/bright-bottles-pay.md
+++ b/.changeset/bright-bottles-pay.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Fix `<TagInputField />` regex to work with array of string value

--- a/packages/form/src/components/TagInputField/index.tsx
+++ b/packages/form/src/components/TagInputField/index.tsx
@@ -69,7 +69,8 @@ export const TagInputField = <
       validate: {
         ...(regexes
           ? {
-              pattern: value => validateRegex(value, regexes),
+              pattern: value =>
+                (value as string[]).every(val => validateRegex(val, regexes)),
             }
           : {}),
         ...validate,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

TagInputField no checking each values independently when using `regex` parameter.
