### PR TITLE
feat: add aria label to svg for accessibility purpose

### DIFF
--- a/.changeset/chatty-cups-drive.md
+++ b/.changeset/chatty-cups-drive.md
@@ -3,4 +3,4 @@
 "@ultraviolet/ui": minor
 ---
 
-feat: add title tag to SVG for accessibility purpose
+feat: add aria-label to SVG for accessibility purpose

--- a/.changeset/chatty-cups-drive.md
+++ b/.changeset/chatty-cups-drive.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/icons": minor
+"@ultraviolet/ui": minor
+---
+
+feat: add title tag to SVG for accessibility purpose

--- a/.changeset/chatty-cups-drive.md
+++ b/.changeset/chatty-cups-drive.md
@@ -3,4 +3,4 @@
 "@ultraviolet/ui": minor
 ---
 
-feat: add aria-label to SVG for accessibility purpose
+feat: add `aria-label` to `SVG` for accessibility purpose

--- a/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -595,6 +595,7 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                   </svg>
                 </button>
                 <svg
+                  aria-label="show dropdown"
                   class="emotion-16 emotion-15"
                   viewBox="0 0 16 16"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1145,6 +1146,7 @@ exports[`SelectInputField > should render correctly 1`] = `
                 class="emotion-10 emotion-11"
               >
                 <svg
+                  aria-label="show dropdown"
                   class="emotion-12 emotion-13"
                   viewBox="0 0 16 16"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1389,6 +1391,7 @@ exports[`SelectInputField > should render correctly disabled 1`] = `
                 class="emotion-10 emotion-11"
               >
                 <svg
+                  aria-label="show dropdown"
                   class="emotion-12 emotion-13"
                   viewBox="0 0 16 16"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1633,6 +1636,7 @@ exports[`SelectInputField > should render correctly grouped 1`] = `
                 class="emotion-10 emotion-11"
               >
                 <svg
+                  aria-label="show dropdown"
                   class="emotion-12 emotion-13"
                   viewBox="0 0 16 16"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1877,6 +1881,7 @@ exports[`SelectInputField > should render correctly multiselect 1`] = `
                 class="emotion-10 emotion-11"
               >
                 <svg
+                  aria-label="show dropdown"
                   class="emotion-12 emotion-13"
                   viewBox="0 0 16 16"
                   xmlns="http://www.w3.org/2000/svg"
@@ -2204,6 +2209,7 @@ exports[`SelectInputField > should trigger events 1`] = `
                   </svg>
                 </button>
                 <svg
+                  aria-label="show dropdown"
                   class="emotion-16 emotion-15"
                   viewBox="0 0 16 16"
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/form/src/components/UnitInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/UnitInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -592,6 +592,7 @@ exports[`UnitInputField > should handles onChange and selection 1`] = `
                     class="emotion-25 emotion-26"
                   >
                     <svg
+                      aria-label="show dropdown"
                       class="emotion-27 emotion-7"
                       viewBox="0 0 16 16"
                       xmlns="http://www.w3.org/2000/svg"
@@ -1135,6 +1136,7 @@ exports[`UnitInputField > should render correctly 1`] = `
                     class="emotion-23 emotion-24"
                   >
                     <svg
+                      aria-label="show dropdown"
                       class="emotion-25 emotion-26"
                       viewBox="0 0 16 16"
                       xmlns="http://www.w3.org/2000/svg"

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -217,7 +217,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
     return (
       <SystemIcon
         ref={ref}
-        id={uniqueId}
+        id={title ? uniqueId : undefined}
         sentiment={computedSentiment}
         prominence={prominence}
         size={size}

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { consoleLightTheme as theme } from '@ultraviolet/themes'
 import type { FunctionComponent, SVGProps } from 'react'
-import { forwardRef, useMemo } from 'react'
+import { forwardRef, useEffect, useId, useMemo } from 'react'
 import capitalize from '../../utils/capitalize'
 import { ICONS } from './Icons'
 import { SMALL_ICONS } from './SmallIcons'
@@ -125,6 +125,10 @@ type IconProps = {
   variant?: 'outlined' | 'filled'
   'data-testid'?: string
   disabled?: boolean
+  /**
+   * A title to be used by the SCG for accessibility purpose.
+   */
+  title?: string
 } & Pick<
   SVGProps<SVGSVGElement>,
   'className' | 'stroke' | 'cursor' | 'strokeWidth'
@@ -148,9 +152,12 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
       cursor,
       strokeWidth,
       disabled,
+      title,
     },
     ref,
   ) => {
+    const uniqueId = useId()
+
     const computedSentiment = sentiment ?? color
     const SystemIcon = useMemo(() => {
       if (size === 'small' || size === 16) {
@@ -183,9 +190,34 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
       return '0 0 20 20'
     }, [name, size])
 
+    useEffect(() => {
+      if (title) {
+        const svgElement = document.getElementById(uniqueId)
+
+        if (svgElement) {
+          const titleTag = svgElement.querySelector('title')
+
+          // if a title already exist, update it
+          if (titleTag) {
+            titleTag.textContent = title
+          }
+          // insert the title
+          else {
+            const newTitleTag = document.createElementNS(
+              'http://www.w3.org/2000/svg',
+              'title',
+            )
+            svgElement.insertBefore(newTitleTag, svgElement.firstChild)
+            newTitleTag.textContent = title
+          }
+        }
+      }
+    }, [title, uniqueId])
+
     return (
       <SystemIcon
         ref={ref}
+        id={uniqueId}
         sentiment={computedSentiment}
         prominence={prominence}
         size={size}

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { consoleLightTheme as theme } from '@ultraviolet/themes'
 import type { FunctionComponent, SVGProps } from 'react'
-import { forwardRef, useEffect, useId, useMemo } from 'react'
+import { forwardRef, useMemo } from 'react'
 import capitalize from '../../utils/capitalize'
 import { ICONS } from './Icons'
 import { SMALL_ICONS } from './SmallIcons'
@@ -125,13 +125,9 @@ type IconProps = {
   variant?: 'outlined' | 'filled'
   'data-testid'?: string
   disabled?: boolean
-  /**
-   * A title to be used by the SVG for accessibility purpose.
-   */
-  title?: string
 } & Pick<
   SVGProps<SVGSVGElement>,
-  'className' | 'stroke' | 'cursor' | 'strokeWidth'
+  'className' | 'stroke' | 'cursor' | 'strokeWidth' | 'aria-label'
 >
 
 /**
@@ -152,12 +148,10 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
       cursor,
       strokeWidth,
       disabled,
-      title,
+      'aria-label': ariaLabel,
     },
     ref,
   ) => {
-    const uniqueId = useId()
-
     const computedSentiment = sentiment ?? color
     const SystemIcon = useMemo(() => {
       if (size === 'small' || size === 16) {
@@ -190,34 +184,9 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
       return '0 0 20 20'
     }, [name, size])
 
-    useEffect(() => {
-      if (title) {
-        const svgElement = document.getElementById(uniqueId)
-
-        if (svgElement) {
-          const titleTag = svgElement.querySelector('title')
-
-          // if a title already exist, update it
-          if (titleTag) {
-            titleTag.textContent = title
-          }
-          // insert the title
-          else {
-            const newTitleTag = document.createElementNS(
-              'http://www.w3.org/2000/svg',
-              'title',
-            )
-            svgElement.insertBefore(newTitleTag, svgElement.firstChild)
-            newTitleTag.textContent = title
-          }
-        }
-      }
-    }, [title, uniqueId])
-
     return (
       <SystemIcon
         ref={ref}
-        id={title ? uniqueId : undefined}
         sentiment={computedSentiment}
         prominence={prominence}
         size={size}
@@ -228,6 +197,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
         cursor={cursor}
         strokeWidth={strokeWidth}
         disabled={disabled}
+        aria-label={ariaLabel}
       />
     )
   },

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -126,7 +126,7 @@ type IconProps = {
   'data-testid'?: string
   disabled?: boolean
   /**
-   * A title to be used by the SCG for accessibility purpose.
+   * A title to be used by the SVG for accessibility purpose.
    */
   title?: string
 } & Pick<

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -251,7 +251,6 @@ type CommonProps = {
   disabled?: boolean
   iconPosition?: 'left' | 'right'
   iconVariant?: ComponentProps<typeof Icon>['variant']
-  iconTitle?: string
   fullWidth?: boolean
   isLoading?: boolean
   'aria-label'?: string
@@ -325,7 +324,6 @@ export const Button = forwardRef<Element, FinalProps>(
       icon,
       iconPosition = 'left',
       iconVariant,
-      iconTitle,
       fullWidth = false,
       isLoading = false,
       children,
@@ -353,12 +351,7 @@ export const Button = forwardRef<Element, FinalProps>(
     const content = (
       <>
         {!isLoading && icon ? (
-          <Icon
-            name={icon}
-            size="small"
-            variant={iconVariant}
-            title={iconTitle}
-          />
+          <Icon name={icon} size="small" variant={iconVariant} />
         ) : null}
         {isLoading ? (
           <Loader

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -251,6 +251,7 @@ type CommonProps = {
   disabled?: boolean
   iconPosition?: 'left' | 'right'
   iconVariant?: ComponentProps<typeof Icon>['variant']
+  iconTitle?: string
   fullWidth?: boolean
   isLoading?: boolean
   'aria-label'?: string
@@ -324,6 +325,7 @@ export const Button = forwardRef<Element, FinalProps>(
       icon,
       iconPosition = 'left',
       iconVariant,
+      iconTitle,
       fullWidth = false,
       isLoading = false,
       children,
@@ -351,7 +353,12 @@ export const Button = forwardRef<Element, FinalProps>(
     const content = (
       <>
         {!isLoading && icon ? (
-          <Icon name={icon} size="small" variant={iconVariant} />
+          <Icon
+            name={icon}
+            size="small"
+            variant={iconVariant}
+            title={iconTitle}
+          />
         ) : null}
         {isLoading ? (
           <Loader

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1082,6 +1082,7 @@ exports[`UnitInput > renders click 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -1668,6 +1669,7 @@ exports[`UnitInput > renders with default props 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -2539,6 +2541,7 @@ exports[`UnitInput > renders with default value 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -3400,6 +3403,7 @@ exports[`UnitInput > renders with disabled and placeHolder 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -4313,6 +4317,7 @@ exports[`UnitInput > renders with error  and success 1`] = `
                   class="emotion-21 emotion-22"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-23 emotion-9"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -5228,6 +5233,7 @@ exports[`UnitInput > renders with error 1`] = `
                   class="emotion-21 emotion-22"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-23 emotion-9"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -6139,6 +6145,7 @@ exports[`UnitInput > renders with label and label information 1`] = `
                   class="emotion-23 emotion-24"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-25 emotion-26"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -7044,6 +7051,7 @@ exports[`UnitInput > renders with label and no label information 1`] = `
                   class="emotion-23 emotion-24"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-25 emotion-26"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -7533,6 +7541,7 @@ exports[`UnitInput > renders with min max 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -8394,6 +8403,7 @@ exports[`UnitInput > renders with no label and label information 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -9268,6 +9278,7 @@ exports[`UnitInput > renders with size large 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -9757,6 +9768,7 @@ exports[`UnitInput > renders with size medioum 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -10246,6 +10258,7 @@ exports[`UnitInput > renders with size small 1`] = `
                   class="emotion-19 emotion-20"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-21 emotion-22"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"
@@ -11158,6 +11171,7 @@ exports[`UnitInput > renders with success 1`] = `
                   class="emotion-21 emotion-22"
                 >
                   <svg
+                    aria-label="show dropdown"
                     class="emotion-23 emotion-9"
                     viewBox="0 0 16 16"
                     xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

add `aria-label` to `Icon` for accessibility purpose.

![Screenshot 2024-07-26 at 12 30 27](https://github.com/user-attachments/assets/58e25e12-c783-48b1-9a79-88a7a53df1da)

