### PR TITLE
fix(SearchInput): only handle keyboard event

### DIFF
--- a/.changeset/dry-mice-sin.md
+++ b/.changeset/dry-mice-sin.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+fix(SearchInput): only handle keyboard event

--- a/packages/ui/src/components/SearchInput/index.tsx
+++ b/packages/ui/src/components/SearchInput/index.tsx
@@ -216,6 +216,10 @@ export const SearchInput = forwardRef(
 
     const handleKeyReleased = useCallback(
       (event: KeyboardEvent) => {
+        if (!(event instanceof KeyboardEvent)) {
+          return
+        }
+
         const { key } = event
         setKeyPressed(keyPressed.filter(k => k !== key.toUpperCase()))
       },


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Only handle `KeyboardEvent` in `SearchInput`.

#### The following changes where made:

When an user click on a autocomplete item, an `Event` with type `keydown` is dispatched.
Now the `SearchInput` component doesn't handle these events.
