### PR TITLE
fix(textinputv2): reset minLength in errors

### DIFF
--- a/.changeset/mean-trainers-mate.md
+++ b/.changeset/mean-trainers-mate.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+fix(textinputv2): reset minLength in errors

--- a/packages/form/src/components/TextInputFieldV2/index.tsx
+++ b/packages/form/src/components/TextInputFieldV2/index.tsx
@@ -93,8 +93,8 @@ export const TextInputField = <
       error={getError(
         {
           regex: regexes,
-          // minLength,
-          // maxLength,
+          minLength,
+          maxLength,
           label: label ?? '',
           value: field.value,
         },


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

minLength not transmitted to errors

#### The following changes where made:

(Describe what you did)

1.

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
