### PR TITLE
fix(Modal): stop propagation on mousedown

### DIFF
--- a/.changeset/lucky-islands-worry.md
+++ b/.changeset/lucky-islands-worry.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+fix(Modal): stop propagation on mousedown

--- a/packages/ui/src/components/Modal/components/Dialog.tsx
+++ b/packages/ui/src/components/Modal/components/Dialog.tsx
@@ -267,6 +267,7 @@ export const Dialog = ({
         onClick={stopClick}
         onCancel={stopCancel}
         onClose={stopCancel}
+        onMouseDown={stopClick}
         aria-modal
         ref={dialogRef}
         tabIndex={0}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Stop propagation on mousedown in Modal.
