### PR TITLE
docs(TextInputV2): fix storybook documentation to remove test text

### DIFF
--- a/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/TextInputV2/__stories__/Template.stories.tsx
@@ -20,5 +20,4 @@ Template.args = {
   role: 'status',
   'aria-live': 'polite',
   'aria-atomic': 'true',
-  prefix: 'test',
 }


### PR DESCRIPTION
## Summary

## Type

- Documentation

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1042" alt="Screenshot 2024-08-27 at 14 18 52" src="https://github.com/user-attachments/assets/f0dfe51f-7ea3-4d29-84c0-390ba2cf34d3"> | <img width="1031" alt="Screenshot 2024-08-27 at 14 18 55" src="https://github.com/user-attachments/assets/c14586ce-a925-4cd4-adac-906f5a0431d7"> |
