### PR TITLE
refactor: improve accessibility focus on selectable card

### DIFF
--- a/.changeset/large-cycles-visit.md
+++ b/.changeset/large-cycles-visit.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": minor
+"@ultraviolet/ui": minor
+---
+
+Improve accessibility focus for `<SelectableCard />` and `<SwitchButton />`

--- a/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
@@ -1072,6 +1072,368 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
 </DocumentFragment>
 `;
 
+exports[`SelectableCardField > should render correctly with errors 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 16px;
+  border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -4px;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0 .emotion-3,
+.emotion-0 .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 4px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-5[aria-disabled='false'],
+.emotion-5[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-5[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-5[aria-disabled='true']>label,
+.emotion-5[aria-disabled='true'] .emotion-8 {
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
+  fill: #f3f3f4;
+}
+
+.emotion-5[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-5[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-5[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-5 input+svg {
+  display: none;
+}
+
+.emotion-5 label {
+  display: none;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9 {
+  height: 24px;
+  width: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-15[data-has-label='true'] {
+  padding-left: 32px;
+}
+
+.emotion-15[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <form
+      novalidate=""
+    >
+      <div
+        class="emotion-0 emotion-1"
+        data-checked="false"
+        data-disabled="false"
+        data-error="true"
+        data-has-label="false"
+        data-type="radio"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="emotion-2 emotion-3"
+        >
+          <div
+            aria-disabled="false"
+            class="emotion-4 emotion-5 emotion-6"
+            data-checked="false"
+            data-error="true"
+          >
+            <input
+              aria-disabled="false"
+              aria-invalid="true"
+              class="emotion-7 emotion-8"
+              id="test-checked"
+              name="test"
+              tabindex="-1"
+              type="radio"
+              value="checked"
+            />
+            <svg
+              class="emotion-9 emotion-10"
+              viewBox="0 0 24 24"
+            >
+              <g>
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke-width="2"
+                />
+                <circle
+                  class="emotion-11 emotion-12"
+                  cx="12"
+                  cy="12"
+                  r="8"
+                />
+                <circle
+                  class="emotion-13 emotion-14"
+                  cx="12"
+                  cy="12"
+                  r="5"
+                />
+              </g>
+            </svg>
+          </div>
+        </div>
+        <div
+          class="emotion-15 emotion-16"
+          data-has-label="false"
+        >
+          Radio field error
+        </div>
+      </div>
+      <button
+        type="submit"
+      >
+        Submit
+      </button>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`SelectableCardField > should trigger events correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {

--- a/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
@@ -56,13 +56,11 @@ exports[`SelectableCardField > should render correctly 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -298,6 +296,8 @@ exports[`SelectableCardField > should render correctly 1`] = `
         data-error="false"
         data-has-label="false"
         data-type="radio"
+        role="button"
+        tabindex="0"
       >
         <div
           class="emotion-2 emotion-3"
@@ -314,6 +314,7 @@ exports[`SelectableCardField > should render correctly 1`] = `
               class="emotion-7 emotion-8"
               id="test-test"
               name="test"
+              tabindex="-1"
               type="radio"
               value="test"
             />
@@ -412,13 +413,11 @@ exports[`SelectableCardField > should render correctly checked 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -654,6 +653,8 @@ exports[`SelectableCardField > should render correctly checked 1`] = `
         data-error="false"
         data-has-label="false"
         data-type="radio"
+        role="button"
+        tabindex="0"
       >
         <div
           class="emotion-2 emotion-3"
@@ -671,6 +672,7 @@ exports[`SelectableCardField > should render correctly checked 1`] = `
               class="emotion-7 emotion-8"
               id="test-checked"
               name="test"
+              tabindex="-1"
               type="radio"
               value="checked"
             />
@@ -769,13 +771,11 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1011,6 +1011,7 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
         data-error="false"
         data-has-label="false"
         data-type="radio"
+        role="button"
       >
         <div
           class="emotion-2 emotion-3"
@@ -1028,6 +1029,7 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
               disabled=""
               id="test-disabled"
               name="test"
+              tabindex="-1"
               type="radio"
               value="disabled"
             />
@@ -1065,367 +1067,6 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
           Radio field disabled
         </div>
       </div>
-    </form>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCardField > should render correctly with errors 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  padding: 16px;
-  border-radius: 4px;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -4px;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0 .emotion-3,
-.emotion-0 .eqr7bqq1 {
-  width: 100%;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-5 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  gap: 8px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-}
-
-.emotion-5[aria-disabled='false'],
-.emotion-5[aria-disabled='false']>label {
-  cursor: pointer;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
-  fill: #8c40ef;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
-  fill: #e5dbfd;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
-  fill: #b3144d;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
-  fill: #ffd3e3;
-}
-
-.emotion-5[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-5[aria-disabled='true']>label,
-.emotion-5[aria-disabled='true'] .emotion-8 {
-  cursor: not-allowed;
-}
-
-.emotion-5[aria-disabled='true'] .emotion-10 {
-  fill: #e9eaeb;
-  cursor: not-allowed;
-}
-
-.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
-  fill: #f3f3f4;
-}
-
-.emotion-5[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-5[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-5[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-5 input+svg {
-  display: none;
-}
-
-.emotion-5 label {
-  display: none;
-}
-
-.emotion-7 {
-  cursor: pointer;
-  position: absolute;
-  height: 24px;
-  width: 24px;
-  opacity: 0;
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.emotion-7+.emotion-10 .emotion-14 {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-7:checked+svg .emotion-14 {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
-  fill: #8c40ef;
-}
-
-.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
-  fill: #d8c5fc;
-}
-
-.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
-  fill: #e51963;
-}
-
-.emotion-7[aria-disabled='false']:active+.emotion-10 {
-  background-color: #5e127e40;
-  fill: #8c40ef;
-}
-
-.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
-  fill: #f1eefc;
-}
-
-.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-.emotion-7[aria-invalid='true']:focus+.emotion-10 {
-  background-color: #f91b6c40;
-  fill: #e51963;
-}
-
-.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
-  fill: #ffebf2;
-}
-
-.emotion-9 {
-  height: 24px;
-  width: 24px;
-  min-width: 24px;
-  min-height: 24px;
-  border-radius: 100%;
-  fill: #d9dadd;
-}
-
-.emotion-9 .emotion-12 {
-  fill: #ffffff;
-}
-
-.emotion-15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-15[data-has-label='true'] {
-  padding-left: 32px;
-}
-
-.emotion-15[data-has-label='false'] {
-  display: contents;
-}
-
-<div
-    data-testid="testing"
-  >
-    <form
-      novalidate=""
-    >
-      <div
-        class="emotion-0 emotion-1"
-        data-checked="false"
-        data-disabled="false"
-        data-error="true"
-        data-has-label="false"
-        data-type="radio"
-      >
-        <div
-          class="emotion-2 emotion-3"
-        >
-          <div
-            aria-disabled="false"
-            class="emotion-4 emotion-5 emotion-6"
-            data-checked="false"
-            data-error="true"
-          >
-            <input
-              aria-disabled="false"
-              aria-invalid="true"
-              class="emotion-7 emotion-8"
-              id="test-checked"
-              name="test"
-              type="radio"
-              value="checked"
-            />
-            <svg
-              class="emotion-9 emotion-10"
-              viewBox="0 0 24 24"
-            >
-              <g>
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke-width="2"
-                />
-                <circle
-                  class="emotion-11 emotion-12"
-                  cx="12"
-                  cy="12"
-                  r="8"
-                />
-                <circle
-                  class="emotion-13 emotion-14"
-                  cx="12"
-                  cy="12"
-                  r="5"
-                />
-              </g>
-            </svg>
-          </div>
-        </div>
-        <div
-          class="emotion-15 emotion-16"
-          data-has-label="false"
-        >
-          Radio field error
-        </div>
-      </div>
-      <button
-        type="submit"
-      >
-        Submit
-      </button>
     </form>
   </div>
 </DocumentFragment>
@@ -1487,13 +1128,11 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1729,6 +1368,8 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
         data-error="false"
         data-has-label="false"
         data-type="radio"
+        role="button"
+        tabindex="0"
       >
         <div
           class="emotion-2 emotion-3"
@@ -1745,6 +1386,7 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
               class="emotion-7 emotion-8"
               id="test-events"
               name="test"
+              tabindex="-1"
               type="radio"
               value="events"
             />

--- a/packages/form/src/components/SelectableCardField/__tests__/index.test.tsx
+++ b/packages/form/src/components/SelectableCardField/__tests__/index.test.tsx
@@ -73,7 +73,7 @@ describe('SelectableCardField', () => {
         <button type="submit">Submit</button>
       </>,
     )
-    await userEvent.click(screen.getByRole('button'))
+    await userEvent.click(screen.getAllByRole('button')[1])
     const input = screen.getByRole('radio', { hidden: true })
     expect(input).toHaveAttribute('aria-invalid', 'true')
     expect(asFragment()).toMatchSnapshot()

--- a/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -133,13 +133,11 @@ exports[`SelectableCardField > should render correctly 1`] = `
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -361,6 +359,8 @@ exports[`SelectableCardField > should render correctly 1`] = `
                 data-disabled="false"
                 data-has-label="true"
                 data-type="radio"
+                role="button"
+                tabindex="0"
               >
                 <div
                   class="emotion-12 emotion-13"
@@ -376,6 +376,7 @@ exports[`SelectableCardField > should render correctly 1`] = `
                       class="emotion-17 emotion-18"
                       id="test-radio 1"
                       name="test"
+                      tabindex="-1"
                       type="radio"
                       value="radio 1"
                     />
@@ -419,6 +420,8 @@ exports[`SelectableCardField > should render correctly 1`] = `
                 data-disabled="false"
                 data-has-label="true"
                 data-type="radio"
+                role="button"
+                tabindex="0"
               >
                 <div
                   class="emotion-12 emotion-13"
@@ -434,6 +437,7 @@ exports[`SelectableCardField > should render correctly 1`] = `
                       class="emotion-17 emotion-18"
                       id="test-radio 2"
                       name="test"
+                      tabindex="-1"
                       type="radio"
                       value="radio 2"
                     />
@@ -613,13 +617,11 @@ exports[`SelectableCardField > should render correctly checked as a checkbox 1`]
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -966,6 +968,8 @@ exports[`SelectableCardField > should render correctly checked as a checkbox 1`]
                 data-has-label="true"
                 data-testid="checked"
                 data-type="checkbox"
+                role="button"
+                tabindex="0"
               >
                 <div
                   aria-disabled="false"
@@ -1169,13 +1173,11 @@ exports[`SelectableCardField > should render correctly checked as radiofield 1`]
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1398,6 +1400,8 @@ exports[`SelectableCardField > should render correctly checked as radiofield 1`]
                 data-has-label="true"
                 data-testid="checked"
                 data-type="radio"
+                role="button"
+                tabindex="0"
               >
                 <div
                   class="emotion-12 emotion-13"
@@ -1414,6 +1418,7 @@ exports[`SelectableCardField > should render correctly checked as radiofield 1`]
                       class="emotion-17 emotion-18"
                       id="test-checked"
                       name="test"
+                      tabindex="-1"
                       type="radio"
                       value="checked"
                     />
@@ -1593,13 +1598,11 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1945,6 +1948,8 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
                 data-disabled="false"
                 data-has-label="true"
                 data-type="checkbox"
+                role="button"
+                tabindex="0"
               >
                 <div
                   aria-disabled="false"
@@ -2011,6 +2016,8 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
                 data-disabled="false"
                 data-has-label="true"
                 data-type="checkbox"
+                role="button"
+                tabindex="0"
               >
                 <div
                   aria-disabled="false"

--- a/packages/ui/src/components/Radio/index.tsx
+++ b/packages/ui/src/components/Radio/index.tsx
@@ -162,6 +162,7 @@ type RadioProps = {
     | 'id'
     | 'name'
     | 'required'
+    | 'tabIndex'
   > &
   (
     | {
@@ -196,6 +197,7 @@ export const Radio = forwardRef(
       tooltip,
       'aria-label': ariaLabel,
       'data-testid': dataTestId,
+      tabIndex,
     }: RadioProps,
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
@@ -228,6 +230,7 @@ export const Radio = forwardRef(
               name={computedName}
               autoFocus={autoFocus}
               ref={ref}
+              tabIndex={tabIndex}
             />
             <Ring viewBox="0 0 24 24">
               <RadioMarkedIcon />

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -56,13 +56,11 @@ exports[`SelectableCard > renders correctly with checkbox type 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -420,6 +418,8 @@ exports[`SelectableCard > renders correctly with checkbox type 1`] = `
       data-disabled="false"
       data-has-label="false"
       data-type="checkbox"
+      role="button"
+      tabindex="0"
     >
       <div
         aria-disabled="false"
@@ -539,13 +539,11 @@ exports[`SelectableCard > renders correctly with checkbox type and checked prop 
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -903,6 +901,8 @@ exports[`SelectableCard > renders correctly with checkbox type and checked prop 
       data-disabled="false"
       data-has-label="false"
       data-type="checkbox"
+      role="button"
+      tabindex="0"
     >
       <div
         aria-disabled="false"
@@ -1023,13 +1023,11 @@ exports[`SelectableCard > renders correctly with checkbox type and disabled prop
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1387,6 +1385,7 @@ exports[`SelectableCard > renders correctly with checkbox type and disabled prop
       data-disabled="true"
       data-has-label="false"
       data-type="checkbox"
+      role="button"
     >
       <div
         aria-disabled="true"
@@ -1507,13 +1506,11 @@ exports[`SelectableCard > renders correctly with checkbox type and isError prop 
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1885,6 +1882,8 @@ exports[`SelectableCard > renders correctly with checkbox type and isError prop 
       data-error="true"
       data-has-label="false"
       data-type="checkbox"
+      role="button"
+      tabindex="0"
     >
       <div
         aria-disabled="false"
@@ -2042,13 +2041,11 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
 }
 
 .emotion-4:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-4:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-4:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-4:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-4:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-4:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -2415,6 +2412,8 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
           data-disabled="false"
           data-has-label="false"
           data-type="checkbox"
+          role="button"
+          tabindex="0"
         >
           <div
             aria-disabled="false"
@@ -2536,13 +2535,11 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -2900,6 +2897,7 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
       data-disabled="true"
       data-has-label="false"
       data-type="checkbox"
+      role="button"
     >
       <div
         aria-disabled="true"
@@ -3024,13 +3022,11 @@ exports[`SelectableCard > renders correctly with default props 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -3262,6 +3258,8 @@ exports[`SelectableCard > renders correctly with default props 1`] = `
       data-disabled="false"
       data-has-label="false"
       data-type="radio"
+      role="button"
+      tabindex="0"
     >
       <div
         class="emotion-2 emotion-3"
@@ -3277,6 +3275,7 @@ exports[`SelectableCard > renders correctly with default props 1`] = `
             class="emotion-7 emotion-8"
             id="radio-choice"
             name="radio"
+            tabindex="-1"
             type="radio"
             value="choice"
           />
@@ -3374,13 +3373,11 @@ exports[`SelectableCard > renders correctly with radio type and checked prop 1`]
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -3612,6 +3609,8 @@ exports[`SelectableCard > renders correctly with radio type and checked prop 1`]
       data-disabled="false"
       data-has-label="false"
       data-type="radio"
+      role="button"
+      tabindex="0"
     >
       <div
         class="emotion-2 emotion-3"
@@ -3628,6 +3627,7 @@ exports[`SelectableCard > renders correctly with radio type and checked prop 1`]
             class="emotion-7 emotion-8"
             id="radio-choice"
             name="radio"
+            tabindex="-1"
             type="radio"
             value="choice"
           />
@@ -3725,13 +3725,11 @@ exports[`SelectableCard > renders correctly with radio type and disabled prop 1`
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -3963,6 +3961,7 @@ exports[`SelectableCard > renders correctly with radio type and disabled prop 1`
       data-disabled="true"
       data-has-label="false"
       data-type="radio"
+      role="button"
     >
       <div
         class="emotion-2 emotion-3"
@@ -3979,6 +3978,7 @@ exports[`SelectableCard > renders correctly with radio type and disabled prop 1`
             disabled=""
             id="radio-choice"
             name="radio"
+            tabindex="-1"
             type="radio"
             value="choice"
           />
@@ -4076,13 +4076,11 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -4315,6 +4313,8 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
       data-error="true"
       data-has-label="false"
       data-type="radio"
+      role="button"
+      tabindex="0"
     >
       <div
         class="emotion-2 emotion-3"
@@ -4331,6 +4331,7 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
             class="emotion-7 emotion-8"
             id="radio-choice"
             name="radio"
+            tabindex="-1"
             type="radio"
             value="choice"
           />
@@ -4462,13 +4463,11 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
 }
 
 .emotion-4:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-4:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-4:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-4:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-4:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-4:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -4709,6 +4708,8 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
           data-disabled="false"
           data-has-label="false"
           data-type="radio"
+          role="button"
+          tabindex="0"
         >
           <div
             class="emotion-6 emotion-7"
@@ -4724,6 +4725,7 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
                 class="emotion-11 emotion-12"
                 id="radio-choice"
                 name="radio"
+                tabindex="-1"
                 type="radio"
                 value="choice"
               />
@@ -4823,13 +4825,11 @@ exports[`SelectableCard > renders correctly with showTick and type checkbox 1`] 
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -5179,6 +5179,8 @@ exports[`SelectableCard > renders correctly with showTick and type checkbox 1`] 
       data-disabled="false"
       data-has-label="false"
       data-type="checkbox"
+      role="button"
+      tabindex="0"
     >
       <div
         aria-disabled="false"
@@ -5298,13 +5300,11 @@ exports[`SelectableCard > renders correctly with showTick and type radio 1`] = `
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -5528,6 +5528,8 @@ exports[`SelectableCard > renders correctly with showTick and type radio 1`] = `
       data-disabled="false"
       data-has-label="false"
       data-type="radio"
+      role="button"
+      tabindex="0"
     >
       <div
         class="emotion-2 emotion-3"

--- a/packages/ui/src/components/SelectableCard/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectableCard/__tests__/index.test.tsx
@@ -1,5 +1,7 @@
-import { shouldMatchEmotionSnapshot } from '@utils/test'
-import { describe, test } from 'vitest'
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithTheme, shouldMatchEmotionSnapshot } from '@utils/test'
+import { describe, test, vi } from 'vitest'
 import { SelectableCard } from '..'
 
 describe('SelectableCard', () => {
@@ -173,4 +175,19 @@ describe('SelectableCard', () => {
         )}
       </SelectableCard>,
     ))
+
+  test('accessibility working with space key pressed to select', async () => {
+    const onChange = vi.fn()
+
+    renderWithTheme(
+      <SelectableCard onChange={onChange} name="radio" value="choice">
+        Radio card
+      </SelectableCard>,
+    )
+
+    const button = screen.getByRole('button')
+    act(() => button.focus())
+
+    await userEvent.keyboard('{Space}')
+  })
 })

--- a/packages/ui/src/components/SelectableCard/index.tsx
+++ b/packages/ui/src/components/SelectableCard/index.tsx
@@ -3,6 +3,7 @@ import type {
   ChangeEventHandler,
   FocusEventHandler,
   ForwardedRef,
+  KeyboardEventHandler,
   ReactNode,
 } from 'react'
 import { forwardRef, useCallback, useRef } from 'react'
@@ -46,7 +47,6 @@ const Container = styled(Stack)`
   }
 
   &:hover,
-  &:focus-within,
   &:active {
     &:not([data-error='true']):not([data-disabled='true']) {
       border: 1px solid ${({ theme }) => theme.colors.primary.border};
@@ -177,6 +177,18 @@ export const SelectableCard = forwardRef(
       [tooltip],
     )
 
+    const onKeyDown: KeyboardEventHandler = useCallback(
+      event => {
+        if (event.key === ' ') {
+          if (innerRef?.current) {
+            event.preventDefault()
+            innerRef.current.click()
+          }
+        }
+      },
+      [innerRef],
+    )
+
     return (
       <ParentContainer>
         <Container
@@ -185,6 +197,7 @@ export const SelectableCard = forwardRef(
               innerRef.current.click()
             }
           }}
+          onKeyDown={onKeyDown}
           className={className}
           data-checked={checked}
           data-disabled={disabled}
@@ -197,6 +210,8 @@ export const SelectableCard = forwardRef(
           direction="column"
           gap={0.5}
           flex={1}
+          tabIndex={disabled ? undefined : 0}
+          role="button"
         >
           {type === 'radio' ? (
             <StyledRadio
@@ -214,6 +229,7 @@ export const SelectableCard = forwardRef(
               ref={innerRef}
               data-error={isError}
               label={label}
+              tabIndex={!showTick ? -1 : undefined}
             />
           ) : (
             <StyledCheckbox

--- a/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -133,13 +133,11 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -482,6 +480,8 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -549,6 +549,8 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -750,13 +752,11 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -987,6 +987,8 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="radio"
+              role="button"
+              tabindex="0"
             >
               <div
                 class="emotion-12 emotion-13"
@@ -1003,6 +1005,7 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
                     class="emotion-17 emotion-18"
                     id="radio-value-1"
                     name="radio"
+                    tabindex="-1"
                     type="radio"
                     value="value-1"
                   />
@@ -1046,6 +1049,8 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="radio"
+              role="button"
+              tabindex="0"
             >
               <div
                 class="emotion-12 emotion-13"
@@ -1061,6 +1066,7 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
                     class="emotion-17 emotion-18"
                     id="radio-value-2"
                     name="radio"
+                    tabindex="-1"
                     type="radio"
                     value="value-2"
                   />
@@ -1259,13 +1265,11 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
 }
 
 .emotion-13:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-13:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-13:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-13:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-13:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-13:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1613,6 +1617,8 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -1680,6 +1686,8 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -1881,13 +1889,11 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -2230,6 +2236,8 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -2297,6 +2305,8 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -2498,13 +2508,11 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -2859,6 +2867,8 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -2926,6 +2936,8 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -3132,13 +3144,11 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-10:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-10:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-10:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-10:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -3493,6 +3503,8 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"
@@ -3560,6 +3572,8 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
               data-disabled="false"
               data-has-label="true"
               data-type="checkbox"
+              role="button"
+              tabindex="0"
             >
               <div
                 aria-disabled="false"

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -202,13 +202,11 @@ exports[`SwitchButton > renders correctly 1`] = `
 }
 
 .emotion-3:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-3:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-3:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-3:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-3:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-3:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -219,14 +217,12 @@ exports[`SwitchButton > renders correctly 1`] = `
 }
 
 .emotion-3:hover,
-.emotion-3:focus-within,
 .emotion-3:active {
   box-shadow: none;
   border: none;
 }
 
 .emotion-3:hover:not([data-error='true'][data-disabled='true']),
-.emotion-3:focus-within:not([data-error='true'][data-disabled='true']),
 .emotion-3:active:not([data-error='true'][data-disabled='true']) {
   border: none;
 }
@@ -442,6 +438,8 @@ exports[`SwitchButton > renders correctly 1`] = `
           data-disabled="false"
           data-has-label="true"
           data-type="radio"
+          role="button"
+          tabindex="0"
         >
           <div
             class="emotion-5 emotion-6"
@@ -457,6 +455,7 @@ exports[`SwitchButton > renders correctly 1`] = `
                 class="emotion-10 emotion-11"
                 id="test-left"
                 name="test"
+                tabindex="-1"
                 type="radio"
                 value="left"
               />
@@ -500,6 +499,8 @@ exports[`SwitchButton > renders correctly 1`] = `
           data-disabled="false"
           data-has-label="true"
           data-type="radio"
+          role="button"
+          tabindex="0"
         >
           <div
             class="emotion-5 emotion-6"
@@ -516,6 +517,7 @@ exports[`SwitchButton > renders correctly 1`] = `
                 class="emotion-10 emotion-11"
                 id="test-right"
                 name="test"
+                tabindex="-1"
                 type="radio"
                 value="right"
               />
@@ -649,13 +651,11 @@ exports[`SwitchButton > renders correctly medium 1`] = `
 }
 
 .emotion-3:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-3:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-3:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-3:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-3:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-3:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -666,14 +666,12 @@ exports[`SwitchButton > renders correctly medium 1`] = `
 }
 
 .emotion-3:hover,
-.emotion-3:focus-within,
 .emotion-3:active {
   box-shadow: none;
   border: none;
 }
 
 .emotion-3:hover:not([data-error='true'][data-disabled='true']),
-.emotion-3:focus-within:not([data-error='true'][data-disabled='true']),
 .emotion-3:active:not([data-error='true'][data-disabled='true']) {
   border: none;
 }
@@ -889,6 +887,8 @@ exports[`SwitchButton > renders correctly medium 1`] = `
           data-disabled="false"
           data-has-label="true"
           data-type="radio"
+          role="button"
+          tabindex="0"
         >
           <div
             class="emotion-5 emotion-6"
@@ -904,6 +904,7 @@ exports[`SwitchButton > renders correctly medium 1`] = `
                 class="emotion-10 emotion-11"
                 id="test-left"
                 name="test"
+                tabindex="-1"
                 type="radio"
                 value="left"
               />
@@ -947,6 +948,8 @@ exports[`SwitchButton > renders correctly medium 1`] = `
           data-disabled="false"
           data-has-label="true"
           data-type="radio"
+          role="button"
+          tabindex="0"
         >
           <div
             class="emotion-5 emotion-6"
@@ -963,6 +966,7 @@ exports[`SwitchButton > renders correctly medium 1`] = `
                 class="emotion-10 emotion-11"
                 id="test-right"
                 name="test"
+                tabindex="-1"
                 type="radio"
                 value="right"
               />
@@ -1096,13 +1100,11 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
 }
 
 .emotion-3:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-3:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-3:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-3:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-3:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-3:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1113,14 +1115,12 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
 }
 
 .emotion-3:hover,
-.emotion-3:focus-within,
 .emotion-3:active {
   box-shadow: none;
   border: none;
 }
 
 .emotion-3:hover:not([data-error='true'][data-disabled='true']),
-.emotion-3:focus-within:not([data-error='true'][data-disabled='true']),
 .emotion-3:active:not([data-error='true'][data-disabled='true']) {
   border: none;
 }
@@ -1336,6 +1336,8 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
           data-disabled="false"
           data-has-label="true"
           data-type="radio"
+          role="button"
+          tabindex="0"
         >
           <div
             class="emotion-5 emotion-6"
@@ -1351,6 +1353,7 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
                 class="emotion-10 emotion-11"
                 id="test-left"
                 name="test"
+                tabindex="-1"
                 type="radio"
                 value="left"
               />
@@ -1394,6 +1397,8 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
           data-disabled="false"
           data-has-label="true"
           data-type="radio"
+          role="button"
+          tabindex="0"
         >
           <div
             class="emotion-5 emotion-6"
@@ -1410,6 +1415,7 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
                 class="emotion-10 emotion-11"
                 id="test-right"
                 name="test"
+                tabindex="-1"
                 type="radio"
                 value="right"
               />
@@ -1551,13 +1557,11 @@ exports[`SwitchButton > renders with tooltip 1`] = `
 }
 
 .emotion-5:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-5:focus-within:not([data-error='true']):not([data-disabled='true']),
 .emotion-5:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
 .emotion-5:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-5:focus-within:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
 .emotion-5:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
@@ -1568,14 +1572,12 @@ exports[`SwitchButton > renders with tooltip 1`] = `
 }
 
 .emotion-5:hover,
-.emotion-5:focus-within,
 .emotion-5:active {
   box-shadow: none;
   border: none;
 }
 
 .emotion-5:hover:not([data-error='true'][data-disabled='true']),
-.emotion-5:focus-within:not([data-error='true'][data-disabled='true']),
 .emotion-5:active:not([data-error='true'][data-disabled='true']) {
   border: none;
 }
@@ -1797,6 +1799,8 @@ exports[`SwitchButton > renders with tooltip 1`] = `
             data-disabled="false"
             data-has-label="true"
             data-type="radio"
+            role="button"
+            tabindex="0"
           >
             <div
               class="emotion-7 emotion-8"
@@ -1812,6 +1816,7 @@ exports[`SwitchButton > renders with tooltip 1`] = `
                   class="emotion-12 emotion-13"
                   id="test-left"
                   name="test"
+                  tabindex="-1"
                   type="radio"
                   value="left"
                 />
@@ -1855,6 +1860,8 @@ exports[`SwitchButton > renders with tooltip 1`] = `
             data-disabled="false"
             data-has-label="true"
             data-type="radio"
+            role="button"
+            tabindex="0"
           >
             <div
               class="emotion-7 emotion-8"
@@ -1871,6 +1878,7 @@ exports[`SwitchButton > renders with tooltip 1`] = `
                   class="emotion-12 emotion-13"
                   id="test-right"
                   name="test"
+                  tabindex="-1"
                   type="radio"
                   value="right"
                 />

--- a/packages/ui/src/components/SwitchButton/index.tsx
+++ b/packages/ui/src/components/SwitchButton/index.tsx
@@ -20,7 +20,6 @@ const StyledSelectableCard = styled(SelectableCard)`
   white-space: nowrap;
 
   &:hover,
-  &:focus-within,
   &:active {
     box-shadow: none;
     border: none;


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Our current `SelectableCard` and `SwitchButton` doesn't show a proper outline border when tab is used on them. I fixed it.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1048" alt="Screenshot 2024-08-29 at 15 47 36" src="https://github.com/user-attachments/assets/db96523e-1a8e-4438-a3c9-1bac3d93a55b"> | <img width="1055" alt="Screenshot 2024-08-29 at 15 47 22" src="https://github.com/user-attachments/assets/7e054613-3203-4bd0-ad94-6d84ea6e40a5"> |
