### PR TITLE
fix(NumberInputFieldV2): to validate or not depending if step is integer

### DIFF
--- a/.changeset/many-bottles-exercise.md
+++ b/.changeset/many-bottles-exercise.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Improve validation of `<NumberInputFieldV2 />` by checking if the step is an integer and so the value

--- a/examples/next-login/src/constants.tsx
+++ b/examples/next-login/src/constants.tsx
@@ -13,4 +13,15 @@ export const mockErrors: FormErrors = {
   required: () => 'This field is required',
   max: ({ max }) => `This field is too high (maximum is : ${max})`,
   min: ({ min }) => `This field is too low (minimum is: ${min})`,
+  isInteger: ({ isInteger }) => {
+    if (typeof isInteger === 'number') {
+      if (Number.isInteger(isInteger)) {
+        return 'This field should be a decimal number'
+      }
+
+      return 'This field should be a whole number'
+    }
+
+    return 'This field should be a number'
+  },
 }

--- a/packages/form/src/components/NumberInputFieldV2/__stories__/Required.stories.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/__stories__/Required.stories.tsx
@@ -17,4 +17,5 @@ Required.args = {
   name: 'value',
   required: true,
   label: 'This field is required',
+  step: 1,
 }

--- a/packages/form/src/components/NumberInputFieldV2/index.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/index.tsx
@@ -86,7 +86,7 @@ export const NumberInputFieldV2 = <
       required,
       validate: {
         ...validate,
-        step: value =>
+        isInteger: value =>
           Number.isInteger(step)
             ? Number.isInteger(value) && Number.isInteger(value)
             : !Number.isInteger(value) && !Number.isInteger(value),
@@ -118,7 +118,7 @@ export const NumberInputFieldV2 = <
       label={label}
       labelDescription={labelDescription}
       placeholder={placeholder}
-      error={getError({ label: label ?? '', max, min, step }, error)}
+      error={getError({ label: label ?? '', max, min, isInteger: step }, error)}
       success={success}
       helper={helper}
       tooltip={tooltip}

--- a/packages/form/src/components/NumberInputFieldV2/index.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/index.tsx
@@ -84,7 +84,13 @@ export const NumberInputFieldV2 = <
       max,
       min,
       required,
-      validate,
+      validate: {
+        ...validate,
+        step: value =>
+          Number.isInteger(step)
+            ? Number.isInteger(value) && Number.isInteger(value)
+            : !Number.isInteger(value) && !Number.isInteger(value),
+      },
     },
   })
 
@@ -112,7 +118,7 @@ export const NumberInputFieldV2 = <
       label={label}
       labelDescription={labelDescription}
       placeholder={placeholder}
-      error={getError({ label: label ?? '', max, min }, error)}
+      error={getError({ label: label ?? '', max, min, step }, error)}
       success={success}
       helper={helper}
       tooltip={tooltip}

--- a/packages/form/src/components/NumberInputFieldV2/index.tsx
+++ b/packages/form/src/components/NumberInputFieldV2/index.tsx
@@ -4,6 +4,7 @@ import { useController } from 'react-hook-form'
 import type { FieldPath, FieldValues, Path, PathValue } from 'react-hook-form'
 import { useErrors } from '../../providers'
 import type { BaseFieldProps } from '../../types'
+import { isInteger } from '../../validators/isInteger'
 
 type NumberInputV2Props<
   TFieldValues extends FieldValues,
@@ -86,10 +87,7 @@ export const NumberInputFieldV2 = <
       required,
       validate: {
         ...validate,
-        isInteger: value =>
-          Number.isInteger(step)
-            ? Number.isInteger(value) && Number.isInteger(value)
-            : !Number.isInteger(value) && !Number.isInteger(value),
+        isInteger: isInteger(step),
       },
     },
   })

--- a/packages/form/src/mocks/mockErrors.ts
+++ b/packages/form/src/mocks/mockErrors.ts
@@ -13,4 +13,5 @@ export const mockErrors: FormErrors = {
   required: () => 'This field is required',
   max: ({ max }) => `This field is too high (maximum is : ${max})`,
   min: ({ min }) => `This field is too low (minimum is: ${min})`,
+  step: ({ step }) => `This field should be a multiple of ${step}`,
 }

--- a/packages/form/src/mocks/mockErrors.ts
+++ b/packages/form/src/mocks/mockErrors.ts
@@ -13,5 +13,15 @@ export const mockErrors: FormErrors = {
   required: () => 'This field is required',
   max: ({ max }) => `This field is too high (maximum is : ${max})`,
   min: ({ min }) => `This field is too low (minimum is: ${min})`,
-  step: ({ step }) => `This field should be a multiple of ${step}`,
+  isInteger: ({ isInteger }) => {
+    if (typeof isInteger === 'number') {
+      if (Number.isInteger(isInteger)) {
+        return 'This field should be a decimal number'
+      }
+
+      return 'This field should be a whole number'
+    }
+
+    return 'This field should be a number'
+  },
 }

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -11,6 +11,7 @@ import type {
 } from 'react-hook-form'
 
 export type MetaField = {
+  step?: number | string
   min?: number | string
   max?: number | string
   minLength?: number
@@ -29,6 +30,7 @@ export type RequiredErrors = {
 export type FormErrors = {
   [key in
     | 'required'
+    | 'step'
     | 'min'
     | 'max'
     | 'minLength'

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -11,7 +11,7 @@ import type {
 } from 'react-hook-form'
 
 export type MetaField = {
-  step?: number | string
+  isInteger?: number | string
   min?: number | string
   max?: number | string
   minLength?: number
@@ -30,7 +30,7 @@ export type RequiredErrors = {
 export type FormErrors = {
   [key in
     | 'required'
-    | 'step'
+    | 'isInteger'
     | 'min'
     | 'max'
     | 'minLength'

--- a/packages/form/src/validators/isInteger.ts
+++ b/packages/form/src/validators/isInteger.ts
@@ -1,0 +1,8 @@
+export const isInteger = (step?: number | string) => (value: number) => {
+  if (value === undefined || step === undefined) return true
+  if (Number.isInteger(step)) {
+    return Number.isInteger(value) && Number.isInteger(value)
+  }
+
+  return !Number.isInteger(value) && !Number.isInteger(value)
+}

--- a/packages/ui/src/__stories__/Tools/ThemeGenerator/index.tsx
+++ b/packages/ui/src/__stories__/Tools/ThemeGenerator/index.tsx
@@ -143,6 +143,7 @@ export const ThemeGenerator = () => {
               required: () => '',
               maxDate: () => '',
               minDate: () => '',
+              isInteger: () => '',
             }}
           >
             <FormContent />

--- a/utils/test/src/vitest/helpers/index.tsx
+++ b/utils/test/src/vitest/helpers/index.tsx
@@ -47,6 +47,17 @@ export const mockFormErrors: FormErrors = {
     `This field should be before ${maxDate?.toString() ?? ''}`,
   minDate: ({ minDate }) =>
     `This field should be after ${minDate?.toString() ?? ''}`,
+  isInteger: ({ isInteger }) => {
+    if (typeof isInteger === 'number') {
+      if (Number.isInteger(isInteger)) {
+        return 'This field should be a decimal number'
+      }
+
+      return 'This field should be a whole number'
+    }
+
+    return 'This field should be a number'
+  },
 }
 
 /**


### PR DESCRIPTION
## Summary

## Type


- Enhancement

### Summarise concisely:

#### What is expected?

When step is set, if step is an integer or not we do not check the value depending. We could make the thing a little more precise and block the submit if the step is not an integer and neither the value. We do not check the precision of the float but only if it's an integer or not.

## Relevant logs and/or screenshots

![Screenshot 2024-09-05 at 10 59 40](https://github.com/user-attachments/assets/5aa238f2-812e-48f4-9af7-1ac6bb02c049)
![Screenshot 2024-09-05 at 10 59 45](https://github.com/user-attachments/assets/25ea3161-78eb-410e-ae33-109a88f24316)
![Screenshot 2024-09-05 at 11 00 00](https://github.com/user-attachments/assets/b0c8f8a9-5738-41af-bfe4-328cd917ee48)
![Screenshot 2024-09-05 at 11 00 04](https://github.com/user-attachments/assets/cdc800ae-f9c6-4d9d-92f3-86d0f520550b)

