### PR TITLE
fix(Alert): take full with for link case

### DIFF
--- a/.changeset/many-grapes-rule.md
+++ b/.changeset/many-grapes-rule.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Alert />` to take full width when available allowing usage of link

--- a/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.test.tsx.snap
@@ -124,6 +124,9 @@ exports[`SubmitErrorAlert > should display an alert when submitError is present 
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-8 {
@@ -161,6 +164,9 @@ exports[`SubmitErrorAlert > should display an alert when submitError is present 
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
@@ -12419,6 +12419,9 @@ exports[`EstimateCost - Regular Item > render with alert 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-41 {
@@ -12456,6 +12459,9 @@ exports[`EstimateCost - Regular Item > render with alert 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;

--- a/packages/ui/src/components/Alert/__stories__/Link.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Link.stories.tsx
@@ -1,20 +1,25 @@
+import { Link as UVLink } from '../../Link'
+import { Stack } from '../../Stack'
 import { Template } from './Template.stories'
 
-export const Button = Template.bind({})
+export const Link = Template.bind({})
 
-Button.args = {
+Link.args = {
   sentiment: 'info',
-  buttonText: 'More info',
-  onClickButton: () => alert('Button clicked'),
   title: 'Information',
-  children: 'This is an alert content.',
+  children: (
+    <Stack direction="row" justifyContent="space-between" flex="1 1 auto">
+      <p>You cannot create a ressource here</p>
+      <UVLink href="scaleway.com">Read more</UVLink>
+    </Stack>
+  ),
 }
 
-Button.parameters = {
+Link.parameters = {
   docs: {
     description: {
       story:
-        'Using `Button` prop you can add a custom Button and use `onClickButton` prop to handle the click event.',
+        'If you need you can add a link into the Alert component. You will need to add a Stack as children of the Alert component to align the link at the end.',
     },
   },
 }

--- a/packages/ui/src/components/Alert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/index.stories.tsx
@@ -9,6 +9,7 @@ export default {
 export { Playground } from './Playground.stories'
 export { Title } from './Title.stories'
 export { Button } from './Button.stories'
+export { Link } from './Link.stories'
 export { Sentiments } from './Sentiments.stories'
 export { Closable } from './Closable.stories'
 export { LongChildren } from './LongChildren.stories'

--- a/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
@@ -78,6 +78,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -115,6 +118,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -250,6 +256,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -287,6 +296,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -422,6 +434,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -459,6 +474,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -599,6 +617,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -636,6 +657,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -771,6 +795,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -808,6 +835,9 @@ exports[`Alert > renders correctly with all sentiments > renders correctly senti
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -943,6 +973,9 @@ exports[`Alert > renders correctly with buttonText and onClickButton 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -980,6 +1013,9 @@ exports[`Alert > renders correctly with buttonText and onClickButton 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -1176,6 +1212,9 @@ exports[`Alert > renders correctly with children as component 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -1213,6 +1252,9 @@ exports[`Alert > renders correctly with children as component 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -1335,6 +1377,9 @@ exports[`Alert > renders correctly with closable and onClose 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -1372,6 +1417,9 @@ exports[`Alert > renders correctly with closable and onClose 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -1593,6 +1641,9 @@ exports[`Alert > renders correctly with default values 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -1630,6 +1681,9 @@ exports[`Alert > renders correctly with default values 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -1820,6 +1874,9 @@ exports[`Alert > renders correctly with disabled 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-4 {
@@ -1843,6 +1900,9 @@ exports[`Alert > renders correctly with disabled 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -1894,6 +1954,9 @@ exports[`Alert > renders correctly with disabled 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -1922,6 +1985,9 @@ exports[`Alert > renders correctly with disabled 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
@@ -2122,6 +2188,9 @@ exports[`Alert > renders correctly with title 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 
 .emotion-6 {
@@ -2159,6 +2228,9 @@ exports[`Alert > renders correctly with title 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   color: #3f4250;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;

--- a/packages/ui/src/components/Alert/index.tsx
+++ b/packages/ui/src/components/Alert/index.tsx
@@ -130,7 +130,7 @@ export const Alert = ({
         justifyContent="space-between"
         gap={2}
       >
-        <Stack alignItems="start" direction="row" gap={2}>
+        <Stack alignItems="start" direction="row" gap={2} flex="1 1 auto">
           <Icon
             name={typesDefaultIcons[sentiment]}
             size={24}
@@ -138,7 +138,7 @@ export const Alert = ({
             prominence={sentiment === 'neutral' ? 'strong' : undefined}
             sentiment={sentiment}
           />
-          <TextStack gap={1.5} direction="row">
+          <TextStack gap={1.5} direction="row" flex="1 1 auto">
             {title ? (
               <Text variant="bodyStronger" as="span" sentiment={sentiment}>
                 {title}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Make children of alert take full width for cases like links. It will be easier to do so. I added an example in the storybook.

## Relevant logs and/or screenshots

<img width="1055" alt="Screenshot 2024-09-10 at 13 56 41" src="https://github.com/user-attachments/assets/205f061c-b7c7-4048-a64e-790ccaabb995">

