### PR TITLE
fix(TextInputFieldV2): onChangeValue call

### DIFF
--- a/.changeset/curvy-bugs-melt.md
+++ b/.changeset/curvy-bugs-melt.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+`TextInputValue`: the prop/callback `onChangeValue` is now called

--- a/.changeset/curvy-bugs-melt.md
+++ b/.changeset/curvy-bugs-melt.md
@@ -2,4 +2,4 @@
 "@ultraviolet/form": patch
 ---
 
-`TextInputValue`: the prop/callback `onChangeValue` is now called
+`<TextInputFieldV2 />`: the prop/callback `onChangeValue` is now called

--- a/packages/form/src/components/TextInputFieldV2/index.tsx
+++ b/packages/form/src/components/TextInputFieldV2/index.tsx
@@ -26,6 +26,7 @@ export const TextInputField = <
   className,
   tabIndex,
   onChange,
+  onChangeValue,
   placeholder,
   disabled = false,
   readOnly = false,
@@ -114,6 +115,7 @@ export const TextInputField = <
       onChange={event => {
         field.onChange(event)
         onChange?.(event)
+        onChangeValue?.(event.target.value)
       }}
       onFocus={event => {
         onFocus?.(event)


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

The prop `onChangeValue` was exposed by type but not use internally by the component. This MR fixes it, and the callback is now properly called