### PR TITLE
feat(Card): new prop subHeader

### DIFF
--- a/.changeset/real-walls-own.md
+++ b/.changeset/real-walls-own.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<Card />`: new prop `subHeader`, deprecated prop `isActive` (use instead prop `active`) and various enhancements

--- a/packages/ui/src/components/Card/__stories__/Active.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/Active.stories.tsx
@@ -5,11 +5,11 @@ import { Stack } from '../../Stack'
 import { Text } from '../../Text'
 import { Card } from '../index'
 
-export const IsActive: StoryFn = args => {
+export const Active: StoryFn = args => {
   const [active, setActive] = useState(true)
 
   return (
-    <Card {...args} header="Active Card" isActive={active}>
+    <Card {...args} header="Active Card" active={active}>
       <Stack gap={6} direction="row" justifyContent="space-between">
         <Text as="p" variant="body" sentiment={active ? 'primary' : 'neutral'}>
           This card is currently highlighted through isActive prop. In this
@@ -43,7 +43,7 @@ export const IsActive: StoryFn = args => {
   )
 }
 
-IsActive.parameters = {
+Active.parameters = {
   docs: {
     description: {
       story: 'You can highlight a Card by passing the `isActive` prop.',

--- a/packages/ui/src/components/Card/__stories__/AdvancedHeader.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/AdvancedHeader.stories.tsx
@@ -9,7 +9,7 @@ export const AdvancedHeader: StoryFn = args => {
   const CustomHeader = (
     <Stack gap={1}>
       <Stack gap={1} direction="row" alignItems="center">
-        <Text variant="heading" as="h2">
+        <Text variant="heading" as="h4" sentiment="neutral" prominence="strong">
           Advanced Header
         </Text>
         <Badge sentiment="success" size="small">

--- a/packages/ui/src/components/Card/__stories__/Disabled.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/Disabled.stories.tsx
@@ -7,7 +7,7 @@ import { Card } from '../index'
 export const Disabled: StoryFn = args => (
   <Card {...args} header="Disabled Card" disabled>
     <Stack gap={1}>
-      <Text as="p" variant="body" disabled>
+      <Text as="p" variant="body" disabled sentiment="neutral">
         This is a disabled card children.
       </Text>
       <Button sentiment="neutral" disabled>

--- a/packages/ui/src/components/Card/__stories__/SubHeader.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/SubHeader.stories.tsx
@@ -1,0 +1,45 @@
+import type { StoryFn } from '@storybook/react'
+import { Badge } from '../../Badge'
+import { Stack } from '../../Stack'
+import { Text } from '../../Text'
+import { Card } from '../index'
+
+export const SubHeader: StoryFn = args => (
+  <Stack>
+    <Card {...args}>
+      <Text as="p" variant="body" sentiment="neutral">
+        This is the content of a card.
+      </Text>
+    </Card>
+    <Card
+      {...args}
+      subHeader={
+        <Stack gap={1} direction="row" alignItems="center">
+          <Text as="h5" variant="headingSmallStrong" sentiment="neutral">
+            Advanced subHeader
+          </Text>
+          <Badge sentiment="success" size="small">
+            New
+          </Badge>
+        </Stack>
+      }
+    >
+      <Text as="p" variant="body" sentiment="neutral">
+        This is the content of a card with an advanced subHeader
+      </Text>
+    </Card>
+  </Stack>
+)
+
+SubHeader.args = {
+  subHeader: 'subHeader',
+}
+
+SubHeader.parameters = {
+  docs: {
+    description: {
+      story:
+        'You can pass a `string` to the `subHeader` prop to display a simple subHeader inside the card.',
+    },
+  },
+}

--- a/packages/ui/src/components/Card/__stories__/SubHeader.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/SubHeader.stories.tsx
@@ -32,6 +32,7 @@ export const SubHeader: StoryFn = args => (
 )
 
 SubHeader.args = {
+  header: 'Simple Header',
   subHeader: 'subHeader',
 }
 

--- a/packages/ui/src/components/Card/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/index.stories.tsx
@@ -8,6 +8,7 @@ export default {
 
 export { Playground } from './Playground.stories'
 export { Header } from './Header.stories'
+export { SubHeader } from './SubHeader.stories'
 export { AdvancedHeader } from './AdvancedHeader.stories'
-export { IsActive } from './IsActive.stories'
+export { Active } from './Active.stories'
 export { Disabled } from './Disabled.stories'

--- a/packages/ui/src/components/Card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Card/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,65 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Card > renders correctly with active 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+  padding: 24px;
+}
+
+.emotion-0[data-is-active='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-disabled="false"
+      data-is-active="true"
+    >
+      Hello
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Card > renders correctly with active and disabled 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+  padding: 24px;
+}
+
+.emotion-0[data-is-active='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-disabled="true"
+      data-is-active="true"
+    >
+      Hello
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Card > renders correctly with advanced header 1`] = `
 <DocumentFragment>
   .emotion-0 {
@@ -58,6 +118,161 @@ exports[`Card > renders correctly with advanced header 1`] = `
         data-disabled="false"
         data-is-active="false"
       >
+        Hello
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Card > renders correctly with advanced header and subHeader 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-0[data-disabled='true'] {
+  cursor: not-allowed;
+}
+
+.emotion-2 {
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+  padding: 24px;
+}
+
+.emotion-2[data-is-active='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-2[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-disabled="false"
+    >
+      <h2>
+        Advanced Title
+      </h2>
+      <div
+        class="emotion-2 emotion-3"
+        data-disabled="false"
+        data-is-active="false"
+      >
+        <div
+          class="emotion-4 emotion-5"
+        >
+          <h2>
+            Advanced subHeader
+          </h2>
+          Hello
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Card > renders correctly with advanced subHeader 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+  padding: 24px;
+}
+
+.emotion-0[data-is-active='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-disabled="false"
+      data-is-active="false"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <h2>
+          Advanced subHeader
+        </h2>
         Hello
       </div>
     </div>
@@ -186,6 +401,7 @@ exports[`Card > renders correctly with disabled and header 1`] = `
 }
 
 .emotion-2 {
+  color: #b5b7bd;
   font-size: 25px;
   font-family: Space Grotesk,Inter,Asap,sans-serif;
   font-weight: 400;
@@ -217,11 +433,11 @@ exports[`Card > renders correctly with disabled and header 1`] = `
       class="emotion-0 emotion-1"
       data-disabled="true"
     >
-      <h2
+      <h4
         class="emotion-2 emotion-3"
       >
         Title
-      </h2>
+      </h4>
       <div
         class="emotion-4 emotion-5"
         data-disabled="true"
@@ -264,6 +480,7 @@ exports[`Card > renders correctly with header 1`] = `
 }
 
 .emotion-2 {
+  color: #222638;
   font-size: 25px;
   font-family: Space Grotesk,Inter,Asap,sans-serif;
   font-weight: 400;
@@ -295,11 +512,11 @@ exports[`Card > renders correctly with header 1`] = `
       class="emotion-0 emotion-1"
       data-disabled="false"
     >
-      <h2
+      <h4
         class="emotion-2 emotion-3"
       >
         Title
-      </h2>
+      </h4>
       <div
         class="emotion-4 emotion-5"
         data-disabled="false"
@@ -312,7 +529,130 @@ exports[`Card > renders correctly with header 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Card > renders correctly with isActive 1`] = `
+exports[`Card > renders correctly with header and subHeader 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-0[data-disabled='true'] {
+  cursor: not-allowed;
+}
+
+.emotion-2 {
+  color: #222638;
+  font-size: 25px;
+  font-family: Space Grotesk,Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 32px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-4 {
+  border: 1px solid #d9dadd;
+  border-radius: 4px;
+  padding: 24px;
+}
+
+.emotion-4[data-is-active='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-4[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-8 {
+  color: #3f4250;
+  font-size: 21px;
+  font-family: Space Grotesk,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 32px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-disabled="false"
+    >
+      <h4
+        class="emotion-2 emotion-3"
+      >
+        Main title
+      </h4>
+      <div
+        class="emotion-4 emotion-5"
+        data-disabled="false"
+        data-is-active="false"
+      >
+        <div
+          class="emotion-6 emotion-7"
+        >
+          <h5
+            class="emotion-8 emotion-3"
+          >
+            Title
+          </h5>
+          Hello
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Card > renders correctly with subHeader 1`] = `
 <DocumentFragment>
   .emotion-0 {
   border: 1px solid #d9dadd;
@@ -328,15 +668,59 @@ exports[`Card > renders correctly with isActive 1`] = `
   border: 1px solid #e9eaeb;
 }
 
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-4 {
+  color: #3f4250;
+  font-size: 21px;
+  font-family: Space Grotesk,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 32px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <div
     data-testid="testing"
   >
     <div
       class="emotion-0 emotion-1"
       data-disabled="false"
-      data-is-active="true"
+      data-is-active="false"
     >
-      Hello
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <h5
+          class="emotion-4 emotion-5"
+        >
+          Title
+        </h5>
+        Hello
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/packages/ui/src/components/Card/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Card/__tests__/__snapshots__/index.test.tsx.snap
@@ -433,11 +433,11 @@ exports[`Card > renders correctly with disabled and header 1`] = `
       class="emotion-0 emotion-1"
       data-disabled="true"
     >
-      <h4
+      <h2
         class="emotion-2 emotion-3"
       >
         Title
-      </h4>
+      </h2>
       <div
         class="emotion-4 emotion-5"
         data-disabled="true"
@@ -512,11 +512,11 @@ exports[`Card > renders correctly with header 1`] = `
       class="emotion-0 emotion-1"
       data-disabled="false"
     >
-      <h4
+      <h2
         class="emotion-2 emotion-3"
       >
         Title
-      </h4>
+      </h2>
       <div
         class="emotion-4 emotion-5"
         data-disabled="false"
@@ -626,11 +626,11 @@ exports[`Card > renders correctly with header and subHeader 1`] = `
       class="emotion-0 emotion-1"
       data-disabled="false"
     >
-      <h4
+      <h2
         class="emotion-2 emotion-3"
       >
         Main title
-      </h4>
+      </h2>
       <div
         class="emotion-4 emotion-5"
         data-disabled="false"
@@ -639,11 +639,11 @@ exports[`Card > renders correctly with header and subHeader 1`] = `
         <div
           class="emotion-6 emotion-7"
         >
-          <h5
+          <h3
             class="emotion-8 emotion-3"
           >
             Title
-          </h5>
+          </h3>
           Hello
         </div>
       </div>
@@ -714,11 +714,11 @@ exports[`Card > renders correctly with subHeader 1`] = `
       <div
         class="emotion-2 emotion-3"
       >
-        <h5
+        <h3
           class="emotion-4 emotion-5"
         >
           Title
-        </h5>
+        </h3>
         Hello
       </div>
     </div>

--- a/packages/ui/src/components/Card/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Card/__tests__/index.test.tsx
@@ -10,6 +10,29 @@ describe('Card', () => {
     shouldMatchEmotionSnapshot(
       <Card header={<h2>Advanced Title</h2>}>Hello</Card>,
     ))
+  test('renders correctly with advanced subHeader', () =>
+    shouldMatchEmotionSnapshot(
+      <Card subHeader={<h2>Advanced subHeader</h2>}>Hello</Card>,
+    ))
+  test('renders correctly with subHeader', () =>
+    shouldMatchEmotionSnapshot(<Card subHeader="Title">Hello</Card>))
+
+  test('renders correctly with header and subHeader', () =>
+    shouldMatchEmotionSnapshot(
+      <Card subHeader="Title" header="Main title">
+        Hello
+      </Card>,
+    ))
+
+  test('renders correctly with advanced header and subHeader', () =>
+    shouldMatchEmotionSnapshot(
+      <Card
+        subHeader={<h2>Advanced subHeader</h2>}
+        header={<h2>Advanced Title</h2>}
+      >
+        Hello
+      </Card>,
+    ))
 
   test('renders correctly without header', () =>
     shouldMatchEmotionSnapshot(<Card>Hello</Card>))
@@ -24,8 +47,15 @@ describe('Card', () => {
       </Card>,
     ))
 
-  test('renders correctly with isActive', () =>
-    shouldMatchEmotionSnapshot(<Card isActive>Hello</Card>))
+  test('renders correctly with active', () =>
+    shouldMatchEmotionSnapshot(<Card active>Hello</Card>))
+
+  test('renders correctly with active and disabled', () =>
+    shouldMatchEmotionSnapshot(
+      <Card active disabled>
+        Hello
+      </Card>,
+    ))
 
   test('renders correctly with className', () =>
     shouldMatchEmotionSnapshot(<Card className="test">Hello</Card>))

--- a/packages/ui/src/components/Card/index.tsx
+++ b/packages/ui/src/components/Card/index.tsx
@@ -10,10 +10,15 @@ type CardProps = {
    * Header can be a string but also a component if you need more complex header.
    */
   header?: ReactNode
+  subHeader?: ReactNode
   /**
-   * isActive enable a primary style on Card component for when you need to highlight it.
+   * @deprecated use `active` property instead
    */
   isActive?: boolean
+  /**
+   * active enable a primary style on Card component for when you need to highlight it.
+   */
+  active?: boolean
   disabled?: boolean
   className?: string
   'data-testid'?: string
@@ -46,8 +51,10 @@ export const Card = forwardRef(
   (
     {
       header,
+      subHeader,
       disabled = false,
       isActive = false,
+      active = false,
       children,
       className,
       'data-testid': dataTestId,
@@ -63,25 +70,70 @@ export const Card = forwardRef(
         ref={ref}
       >
         {typeof header === 'string' ? (
-          <Text variant="heading" as="h2" disabled={disabled}>
+          <Text
+            variant="heading"
+            as="h4"
+            disabled={disabled}
+            sentiment="neutral"
+            prominence="strong"
+          >
             {header}
           </Text>
         ) : (
           header
         )}
-        <BorderedBox data-is-active={isActive} data-disabled={disabled}>
-          {children}
+        <BorderedBox
+          data-is-active={isActive || active}
+          data-disabled={disabled}
+        >
+          {subHeader ? (
+            <Stack gap={2}>
+              {typeof subHeader === 'string' ? (
+                <Text
+                  as="h5"
+                  variant="headingSmallStrong"
+                  sentiment="neutral"
+                  disabled={disabled}
+                >
+                  {subHeader}
+                </Text>
+              ) : (
+                subHeader
+              )}
+              {children}
+            </Stack>
+          ) : (
+            children
+          )}
         </BorderedBox>
       </StyledStack>
     ) : (
       <BorderedBox
-        data-is-active={isActive}
+        data-is-active={active || isActive}
         data-disabled={disabled}
         className={className}
         data-testid={dataTestId}
         ref={ref}
       >
-        {children}
+        {subHeader ? (
+          <Stack gap={2}>
+            {typeof subHeader === 'string' ? (
+              <Text
+                as="h5"
+                variant="headingSmallStrong"
+                sentiment="neutral"
+                disabled={disabled}
+              >
+                {subHeader}
+              </Text>
+            ) : (
+              subHeader
+            )}
+            {children}
+          </Stack>
+        ) : (
+          children
+        )}
       </BorderedBox>
     ),
 )

--- a/packages/ui/src/components/Card/index.tsx
+++ b/packages/ui/src/components/Card/index.tsx
@@ -72,7 +72,7 @@ export const Card = forwardRef(
         {typeof header === 'string' ? (
           <Text
             variant="heading"
-            as="h4"
+            as="h2"
             disabled={disabled}
             sentiment="neutral"
             prominence="strong"
@@ -90,7 +90,7 @@ export const Card = forwardRef(
             <Stack gap={2}>
               {typeof subHeader === 'string' ? (
                 <Text
-                  as="h5"
+                  as="h3"
                   variant="headingSmallStrong"
                   sentiment="neutral"
                   disabled={disabled}
@@ -119,7 +119,7 @@ export const Card = forwardRef(
           <Stack gap={2}>
             {typeof subHeader === 'string' ? (
               <Text
-                as="h5"
+                as="h3"
                 variant="headingSmallStrong"
                 sentiment="neutral"
                 disabled={disabled}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

`<Card />`: new prop `subHeader`, deprecated prop `isActive` (use instead prop `active`) and various enhancements
 /!\ **Please note that the styling of the header and subHeaders are incorrect in storybook due to global styling. Please see advanced header/subHeaders for an accurate styling** /!\
#### The following changes were made:

Card:
1. Added prop `subHeader` (ReactNode)

2. `isActive` (deprecated) => `active` 

3. Color fixes (header, disabled state)

