### PR TITLE
fix(Snippet): to respect carriage return

### DIFF
--- a/.changeset/fuzzy-jokes-press.md
+++ b/.changeset/fuzzy-jokes-press.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Snippet />` component to respect carriage return

--- a/packages/ui/src/components/Snippet/__stories__/LongMultiline.stories.tsx
+++ b/packages/ui/src/components/Snippet/__stories__/LongMultiline.stories.tsx
@@ -3,8 +3,7 @@ import { Template } from './Template.stories'
 export const LongMultiline = Template.bind({})
 
 LongMultiline.args = {
-  children: `
-# Install the package and start it
+  children: `# Install the package and start it
 pnpm add @ultraviolet/ui
 pnpm install
 pnpm start
@@ -23,6 +22,5 @@ pnpm start
 pnpm build
 
 # Test
-pnpm test:unit
-`,
+pnpm test:unit`,
 }

--- a/packages/ui/src/components/Snippet/__stories__/LongMultilineExpanded.stories.tsx
+++ b/packages/ui/src/components/Snippet/__stories__/LongMultilineExpanded.stories.tsx
@@ -3,8 +3,7 @@ import { Template } from './Template.stories'
 export const LongMultilineExpanded = Template.bind({})
 
 LongMultilineExpanded.args = {
-  children: `
-# Install the package and start it
+  children: `# Install the package and start it
 pnpm add @ultraviolet/ui
 pnpm install
 pnpm start
@@ -23,8 +22,7 @@ pnpm start
 pnpm build
 
 # Test
-pnpm test:unit
-`,
+pnpm test:unit`,
   initiallyExpanded: true,
 }
 

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`Snippet > renders correctly in multiline  1`] = `
   padding: 32px;
 }
 
-.emotion-21 {
+.emotion-23 {
   position: absolute;
   top: 0;
   right: 0;
@@ -302,15 +302,15 @@ exports[`Snippet > renders correctly in multiline  1`] = `
   border: 2px solid transparent;
 }
 
-.emotion-23 {
+.emotion-25 {
   display: inherit;
 }
 
-.emotion-23[data-container-full-width="true"] {
+.emotion-25[data-container-full-width="true"] {
   width: 100%;
 }
 
-.emotion-25 {
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -349,22 +349,22 @@ exports[`Snippet > renders correctly in multiline  1`] = `
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -373,17 +373,17 @@ exports[`Snippet > renders correctly in multiline  1`] = `
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
-.emotion-29 {
+.emotion-31 {
   width: 100%;
   box-shadow: 0px -22px 19px -6px #f9f9fa;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -392,7 +392,7 @@ exports[`Snippet > renders correctly in multiline  1`] = `
   cursor: pointer;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -415,7 +415,7 @@ exports[`Snippet > renders correctly in multiline  1`] = `
   align-items: center;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -431,7 +431,7 @@ exports[`Snippet > renders correctly in multiline  1`] = `
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
@@ -482,25 +482,28 @@ exports[`Snippet > renders correctly in multiline  1`] = `
             >
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             </span>
+            <span
+              class="emotion-9 emotion-10"
+            />
           </pre>
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-23 emotion-24"
         >
           <div
             aria-controls=":r3:"
             aria-describedby=":r3:"
-            class="emotion-23 emotion-24"
+            class="emotion-25 emotion-26"
             data-container-full-width="false"
             tabindex="0"
           >
             <button
               aria-label="Copy"
-              class="emotion-25 emotion-26"
+              class="emotion-27 emotion-28"
               type="button"
             >
               <svg
-                class="emotion-27 emotion-28"
+                class="emotion-29 emotion-30"
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -519,19 +522,19 @@ exports[`Snippet > renders correctly in multiline  1`] = `
           </div>
         </div>
         <div
-          class="emotion-29 emotion-30"
+          class="emotion-31 emotion-32"
         >
           <button
             aria-expanded="false"
-            class="emotion-31 emotion-32"
+            class="emotion-33 emotion-34"
             type="button"
           >
             <span
-              class="emotion-33 emotion-34 emotion-8"
+              class="emotion-35 emotion-36 emotion-8"
             >
               Show 
               <svg
-                class="emotion-36 emotion-37 emotion-28"
+                class="emotion-38 emotion-39 emotion-30"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -643,7 +646,7 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
   padding-right: 8px;
 }
 
-.emotion-21 {
+.emotion-23 {
   position: absolute;
   top: 0;
   right: 0;
@@ -653,15 +656,15 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
   border: 2px solid transparent;
 }
 
-.emotion-23 {
+.emotion-25 {
   display: inherit;
 }
 
-.emotion-23[data-container-full-width="true"] {
+.emotion-25[data-container-full-width="true"] {
   width: 100%;
 }
 
-.emotion-25 {
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -700,22 +703,22 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -724,17 +727,17 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
-.emotion-29 {
+.emotion-31 {
   width: 100%;
   box-shadow: 0px -22px 19px -6px #f9f9fa;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -743,7 +746,7 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
   cursor: pointer;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -766,7 +769,7 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
   align-items: center;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -782,7 +785,7 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
@@ -833,25 +836,28 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
             >
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             </span>
+            <span
+              class="emotion-9 emotion-10"
+            />
           </pre>
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-23 emotion-24"
         >
           <div
             aria-controls=":r9:"
             aria-describedby=":r9:"
-            class="emotion-23 emotion-24"
+            class="emotion-25 emotion-26"
             data-container-full-width="false"
             tabindex="0"
           >
             <button
               aria-label="Copy"
-              class="emotion-25 emotion-26"
+              class="emotion-27 emotion-28"
               type="button"
             >
               <svg
-                class="emotion-27 emotion-28"
+                class="emotion-29 emotion-30"
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -870,19 +876,19 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
           </div>
         </div>
         <div
-          class="emotion-29 emotion-30"
+          class="emotion-31 emotion-32"
         >
           <button
             aria-expanded="false"
-            class="emotion-31 emotion-32"
+            class="emotion-33 emotion-34"
             type="button"
           >
             <span
-              class="emotion-33 emotion-34 emotion-8"
+              class="emotion-35 emotion-36 emotion-8"
             >
               Show 
               <svg
-                class="emotion-36 emotion-37 emotion-28"
+                class="emotion-38 emotion-39 emotion-30"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -995,7 +1001,7 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
   padding-right: 8px;
 }
 
-.emotion-21 {
+.emotion-23 {
   position: absolute;
   top: 0;
   right: 0;
@@ -1005,15 +1011,15 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
   border: 2px solid transparent;
 }
 
-.emotion-23 {
+.emotion-25 {
   display: inherit;
 }
 
-.emotion-23[data-container-full-width="true"] {
+.emotion-25[data-container-full-width="true"] {
   width: 100%;
 }
 
-.emotion-25 {
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1052,22 +1058,22 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -1076,17 +1082,17 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
-.emotion-29 {
+.emotion-31 {
   width: 100%;
   box-shadow: 0px -22px 19px -6px #f9f9fa;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -1095,7 +1101,7 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
   cursor: pointer;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -1118,7 +1124,7 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
   align-items: center;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -1134,7 +1140,7 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
@@ -1185,25 +1191,28 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
             >
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             </span>
+            <span
+              class="emotion-9 emotion-10"
+            />
           </pre>
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-23 emotion-24"
         >
           <div
             aria-controls=":r6:"
             aria-describedby=":r6:"
-            class="emotion-23 emotion-24"
+            class="emotion-25 emotion-26"
             data-container-full-width="false"
             tabindex="0"
           >
             <button
               aria-label="Copy"
-              class="emotion-25 emotion-26"
+              class="emotion-27 emotion-28"
               type="button"
             >
               <svg
-                class="emotion-27 emotion-28"
+                class="emotion-29 emotion-30"
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1222,19 +1231,19 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
           </div>
         </div>
         <div
-          class="emotion-29 emotion-30"
+          class="emotion-31 emotion-32"
         >
           <button
             aria-expanded="false"
-            class="emotion-31 emotion-32"
+            class="emotion-33 emotion-34"
             type="button"
           >
             <span
-              class="emotion-33 emotion-34 emotion-8"
+              class="emotion-35 emotion-36 emotion-8"
             >
               Show 
               <svg
-                class="emotion-36 emotion-37 emotion-28"
+                class="emotion-38 emotion-39 emotion-30"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1759,7 +1768,7 @@ exports[`Snippet > renders correctly with hideText 1`] = `
   padding: 32px;
 }
 
-.emotion-21 {
+.emotion-23 {
   position: absolute;
   top: 0;
   right: 0;
@@ -1769,15 +1778,15 @@ exports[`Snippet > renders correctly with hideText 1`] = `
   border: 2px solid transparent;
 }
 
-.emotion-23 {
+.emotion-25 {
   display: inherit;
 }
 
-.emotion-23[data-container-full-width="true"] {
+.emotion-25[data-container-full-width="true"] {
   width: 100%;
 }
 
-.emotion-25 {
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1816,22 +1825,22 @@ exports[`Snippet > renders correctly with hideText 1`] = `
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -1840,17 +1849,17 @@ exports[`Snippet > renders correctly with hideText 1`] = `
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
-.emotion-29 {
+.emotion-31 {
   width: 100%;
   box-shadow: 0px -22px 19px -6px #f9f9fa;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -1859,7 +1868,7 @@ exports[`Snippet > renders correctly with hideText 1`] = `
   cursor: pointer;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -1882,7 +1891,7 @@ exports[`Snippet > renders correctly with hideText 1`] = `
   align-items: center;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -1898,7 +1907,7 @@ exports[`Snippet > renders correctly with hideText 1`] = `
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
@@ -1949,25 +1958,28 @@ exports[`Snippet > renders correctly with hideText 1`] = `
             >
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             </span>
+            <span
+              class="emotion-9 emotion-10"
+            />
           </pre>
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-23 emotion-24"
         >
           <div
             aria-controls=":rk:"
             aria-describedby=":rk:"
-            class="emotion-23 emotion-24"
+            class="emotion-25 emotion-26"
             data-container-full-width="false"
             tabindex="0"
           >
             <button
               aria-label="Copy"
-              class="emotion-25 emotion-26"
+              class="emotion-27 emotion-28"
               type="button"
             >
               <svg
-                class="emotion-27 emotion-28"
+                class="emotion-29 emotion-30"
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -1986,19 +1998,19 @@ exports[`Snippet > renders correctly with hideText 1`] = `
           </div>
         </div>
         <div
-          class="emotion-29 emotion-30"
+          class="emotion-31 emotion-32"
         >
           <button
             aria-expanded="false"
-            class="emotion-31 emotion-32"
+            class="emotion-33 emotion-34"
             type="button"
           >
             <span
-              class="emotion-33 emotion-34 emotion-8"
+              class="emotion-35 emotion-36 emotion-8"
             >
               Show 
               <svg
-                class="emotion-36 emotion-37 emotion-28"
+                class="emotion-38 emotion-39 emotion-30"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2171,17 +2183,7 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   padding: 32px;
 }
 
-.emotion-21 {
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 16px 16px 0 0;
-  background: #f9f9fa;
-  border-radius: 4px;
-  border: 2px solid transparent;
-}
-
-.emotion-21 {
+.emotion-23 {
   position: absolute;
   top: 0;
   right: 0;
@@ -2192,22 +2194,32 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
 }
 
 .emotion-23 {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 16px 16px 0 0;
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 2px solid transparent;
+}
+
+.emotion-25 {
   display: inherit;
 }
 
-.emotion-23[data-container-full-width="true"] {
-  width: 100%;
-}
-
-.emotion-23 {
-  display: inherit;
-}
-
-.emotion-23[data-container-full-width="true"] {
+.emotion-25[data-container-full-width="true"] {
   width: 100%;
 }
 
 .emotion-25 {
+  display: inherit;
+}
+
+.emotion-25[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2246,22 +2258,22 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-25 {
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2300,22 +2312,22 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -2324,31 +2336,31 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
-  stroke: currentColor;
-  fill: none;
-}
-
-.emotion-27 {
-  vertical-align: middle;
-  fill: currentColor;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
-}
-
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
 .emotion-29 {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.emotion-29 .fillStroke {
+  stroke: currentColor;
+  fill: none;
+}
+
+.emotion-31 {
   width: 100%;
   box-shadow: none;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -2357,7 +2369,7 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   cursor: pointer;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -2366,7 +2378,7 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   cursor: pointer;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -2389,7 +2401,7 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   align-items: center;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -2412,7 +2424,7 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   align-items: center;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -2428,7 +2440,7 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
@@ -2479,25 +2491,28 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
             >
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             </span>
+            <span
+              class="emotion-9 emotion-10"
+            />
           </pre>
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-23 emotion-24"
         >
           <div
             aria-controls=":rq:"
             aria-describedby=":rq:"
-            class="emotion-23 emotion-24"
+            class="emotion-25 emotion-26"
             data-container-full-width="false"
             tabindex="0"
           >
             <button
               aria-label="Copy"
-              class="emotion-25 emotion-26"
+              class="emotion-27 emotion-28"
               type="button"
             >
               <svg
-                class="emotion-27 emotion-28"
+                class="emotion-29 emotion-30"
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2516,19 +2531,19 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
           </div>
         </div>
         <div
-          class="emotion-29 emotion-30"
+          class="emotion-31 emotion-32"
         >
           <button
             aria-expanded="true"
-            class="emotion-31 emotion-32"
+            class="emotion-33 emotion-34"
             type="button"
           >
             <span
-              class="emotion-33 emotion-34 emotion-8"
+              class="emotion-35 emotion-36 emotion-8"
             >
               Hide 
               <svg
-                class="emotion-36 emotion-37 emotion-28"
+                class="emotion-38 emotion-39 emotion-30"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -2701,17 +2716,7 @@ exports[`Snippet > renders correctly with showText 1`] = `
   padding: 32px;
 }
 
-.emotion-21 {
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 16px 16px 0 0;
-  background: #f9f9fa;
-  border-radius: 4px;
-  border: 2px solid transparent;
-}
-
-.emotion-21 {
+.emotion-23 {
   position: absolute;
   top: 0;
   right: 0;
@@ -2722,22 +2727,32 @@ exports[`Snippet > renders correctly with showText 1`] = `
 }
 
 .emotion-23 {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 16px 16px 0 0;
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 2px solid transparent;
+}
+
+.emotion-25 {
   display: inherit;
 }
 
-.emotion-23[data-container-full-width="true"] {
-  width: 100%;
-}
-
-.emotion-23 {
-  display: inherit;
-}
-
-.emotion-23[data-container-full-width="true"] {
+.emotion-25[data-container-full-width="true"] {
   width: 100%;
 }
 
 .emotion-25 {
+  display: inherit;
+}
+
+.emotion-25[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2776,22 +2791,22 @@ exports[`Snippet > renders correctly with showText 1`] = `
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-25 {
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2830,22 +2845,22 @@ exports[`Snippet > renders correctly with showText 1`] = `
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -2854,12 +2869,12 @@ exports[`Snippet > renders correctly with showText 1`] = `
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -2868,22 +2883,22 @@ exports[`Snippet > renders correctly with showText 1`] = `
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
-.emotion-29 {
-  width: 100%;
-  box-shadow: 0px -22px 19px -6px #f9f9fa;
-}
-
-.emotion-29 {
+.emotion-31 {
   width: 100%;
   box-shadow: 0px -22px 19px -6px #f9f9fa;
 }
 
 .emotion-31 {
+  width: 100%;
+  box-shadow: 0px -22px 19px -6px #f9f9fa;
+}
+
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -2892,7 +2907,7 @@ exports[`Snippet > renders correctly with showText 1`] = `
   cursor: pointer;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -2901,7 +2916,7 @@ exports[`Snippet > renders correctly with showText 1`] = `
   cursor: pointer;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -2924,7 +2939,7 @@ exports[`Snippet > renders correctly with showText 1`] = `
   align-items: center;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -2947,7 +2962,7 @@ exports[`Snippet > renders correctly with showText 1`] = `
   align-items: center;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -2963,12 +2978,12 @@ exports[`Snippet > renders correctly with showText 1`] = `
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -2984,7 +2999,7 @@ exports[`Snippet > renders correctly with showText 1`] = `
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
@@ -3035,25 +3050,28 @@ exports[`Snippet > renders correctly with showText 1`] = `
             >
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             </span>
+            <span
+              class="emotion-9 emotion-10"
+            />
           </pre>
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-23 emotion-24"
         >
           <div
             aria-controls=":rn:"
             aria-describedby=":rn:"
-            class="emotion-23 emotion-24"
+            class="emotion-25 emotion-26"
             data-container-full-width="false"
             tabindex="0"
           >
             <button
               aria-label="Copy"
-              class="emotion-25 emotion-26"
+              class="emotion-27 emotion-28"
               type="button"
             >
               <svg
-                class="emotion-27 emotion-28"
+                class="emotion-29 emotion-30"
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -3072,19 +3090,19 @@ exports[`Snippet > renders correctly with showText 1`] = `
           </div>
         </div>
         <div
-          class="emotion-29 emotion-30"
+          class="emotion-31 emotion-32"
         >
           <button
             aria-expanded="false"
-            class="emotion-31 emotion-32"
+            class="emotion-33 emotion-34"
             type="button"
           >
             <span
-              class="emotion-33 emotion-34 emotion-8"
+              class="emotion-35 emotion-36 emotion-8"
             >
               Test 
               <svg
-                class="emotion-36 emotion-37 emotion-28"
+                class="emotion-38 emotion-39 emotion-30"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -3716,17 +3734,7 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   padding: 32px;
 }
 
-.emotion-21 {
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 16px 16px 0 0;
-  background: #f9f9fa;
-  border-radius: 4px;
-  border: 2px solid transparent;
-}
-
-.emotion-21 {
+.emotion-23 {
   position: absolute;
   top: 0;
   right: 0;
@@ -3737,22 +3745,32 @@ exports[`Snippet > should click on extend button to display full content on  1`]
 }
 
 .emotion-23 {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 16px 16px 0 0;
+  background: #f9f9fa;
+  border-radius: 4px;
+  border: 2px solid transparent;
+}
+
+.emotion-25 {
   display: inherit;
 }
 
-.emotion-23[data-container-full-width="true"] {
-  width: 100%;
-}
-
-.emotion-23 {
-  display: inherit;
-}
-
-.emotion-23[data-container-full-width="true"] {
+.emotion-25[data-container-full-width="true"] {
   width: 100%;
 }
 
 .emotion-25 {
+  display: inherit;
+}
+
+.emotion-25[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3791,22 +3809,22 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-25 {
+.emotion-27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3845,22 +3863,22 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   color: #3f4250;
 }
 
-.emotion-25:hover {
+.emotion-27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-25:active {
+.emotion-27:active {
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
-.emotion-25:hover,
-.emotion-25:active {
+.emotion-27:hover,
+.emotion-27:active {
   background: #e9eaeb;
   color: #222638;
 }
 
-.emotion-27 {
+.emotion-29 {
   vertical-align: middle;
   fill: currentColor;
   height: 16px;
@@ -3869,31 +3887,31 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   min-height: 16px;
 }
 
-.emotion-27 .fillStroke {
-  stroke: currentColor;
-  fill: none;
-}
-
-.emotion-27 {
-  vertical-align: middle;
-  fill: currentColor;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
-}
-
-.emotion-27 .fillStroke {
+.emotion-29 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
 
 .emotion-29 {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.emotion-29 .fillStroke {
+  stroke: currentColor;
+  fill: none;
+}
+
+.emotion-31 {
   width: 100%;
   box-shadow: none;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -3902,7 +3920,7 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   cursor: pointer;
 }
 
-.emotion-31 {
+.emotion-33 {
   width: 100%;
   background: none;
   border: none;
@@ -3911,7 +3929,7 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   cursor: pointer;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -3934,7 +3952,7 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   align-items: center;
 }
 
-.emotion-34 {
+.emotion-36 {
   font-size: 14px;
   font-family: Inter,Asap,sans-serif;
   font-weight: 500;
@@ -3957,7 +3975,7 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   align-items: center;
 }
 
-.emotion-37 {
+.emotion-39 {
   vertical-align: middle;
   fill: currentColor;
   height: 1em;
@@ -3973,7 +3991,7 @@ exports[`Snippet > should click on extend button to display full content on  1`]
   transition: transform 300ms ease-in-out;
 }
 
-.emotion-37 .fillStroke {
+.emotion-39 .fillStroke {
   stroke: currentColor;
   fill: none;
 }
@@ -4024,25 +4042,28 @@ exports[`Snippet > should click on extend button to display full content on  1`]
             >
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             </span>
+            <span
+              class="emotion-9 emotion-10"
+            />
           </pre>
         </div>
         <div
-          class="emotion-21 emotion-22"
+          class="emotion-23 emotion-24"
         >
           <div
             aria-controls=":rt:"
             aria-describedby=":rt:"
-            class="emotion-23 emotion-24"
+            class="emotion-25 emotion-26"
             data-container-full-width="false"
             tabindex="0"
           >
             <button
               aria-label="Copy"
-              class="emotion-25 emotion-26"
+              class="emotion-27 emotion-28"
               type="button"
             >
               <svg
-                class="emotion-27 emotion-28"
+                class="emotion-29 emotion-30"
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -4061,19 +4082,19 @@ exports[`Snippet > should click on extend button to display full content on  1`]
           </div>
         </div>
         <div
-          class="emotion-29 emotion-30"
+          class="emotion-31 emotion-32"
         >
           <button
             aria-expanded="true"
-            class="emotion-31 emotion-32"
+            class="emotion-33 emotion-34"
             type="button"
           >
             <span
-              class="emotion-33 emotion-34 emotion-8"
+              class="emotion-35 emotion-36 emotion-8"
             >
               Hide 
               <svg
-                class="emotion-36 emotion-37 emotion-28"
+                class="emotion-38 emotion-39 emotion-30"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >

--- a/packages/ui/src/components/Snippet/index.tsx
+++ b/packages/ui/src/components/Snippet/index.tsx
@@ -198,7 +198,8 @@ export const Snippet = ({
     initiallyExpanded ?? false,
   )
 
-  const lines = children.split(LINES_BREAK_REGEX).filter(Boolean)
+  const lines = children.split(LINES_BREAK_REGEX)
+
   const numberOfLines = lines.length
   const multiline = numberOfLines > 1
   const hasShowMoreButton = numberOfLines > 4 && multiline


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Snippet didn't take in account new lines in it's children.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1049" alt="Screenshot 2024-09-11 at 16 21 49" src="https://github.com/user-attachments/assets/90517e8f-df43-47b6-8bdb-a6dc43cff6dd"> | <img width="1092" alt="Screenshot 2024-09-11 at 16 21 57" src="https://github.com/user-attachments/assets/5718cfbc-9bbd-4223-ba47-5cd85652fd8c"> |
