### PR TITLE
fix(SelectInputV2): resize issue in a modal

### DIFF
--- a/.changeset/dirty-planes-breathe.md
+++ b/.changeset/dirty-planes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInputV2 />` resize issue in a modal

--- a/packages/ui/src/components/SelectInputV2/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/Dropdown.tsx
@@ -678,10 +678,13 @@ export const Dropdown = ({
   const [defaultSearchValue, setDefaultSearch] = useState<string | null>(null)
   const ref = useRef<HTMLDivElement>(null)
   const [search, setSearch] = useState<string>('')
-  const [maxWidth, setWidth] = useState(refSelect.current?.offsetWidth)
+  const [maxWidth, setWidth] = useState<string | number>()
 
   const resizeDropdown = useCallback(() => {
-    if (refSelect.current) {
+    if (
+      refSelect.current &&
+      refSelect.current.getBoundingClientRect().width > 0
+    ) {
       setWidth(refSelect.current.getBoundingClientRect().width)
     }
   }, [refSelect])
@@ -808,7 +811,7 @@ export const Dropdown = ({
       }
       placement="bottom"
       disableAnimation
-      maxWidth={maxWidth}
+      maxWidth={maxWidth ?? refSelect.current?.offsetWidth}
       hasArrow={false}
       ref={ref}
       tabIndex={0}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<SelectInputV2 />` resize issue in a modal

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2024-09-30 at 09 04 17](https://github.com/user-attachments/assets/4fde431a-ae66-4db7-b4f6-b44a0a801d59) | ![Screenshot 2024-09-30 at 09 13 36](https://github.com/user-attachments/assets/8dcbb003-bd9d-4054-90e4-0b7e3e2dffa8) |
