### PR TITLE
docs(ProductIcon): display all sizes on storybook

### DIFF
--- a/packages/icons/src/components/ProductIcon/Icon.tsx
+++ b/packages/icons/src/components/ProductIcon/Icon.tsx
@@ -3,13 +3,13 @@ import type { ReactNode } from 'react'
 
 type Variants = 'primary' | 'danger' | 'warning' | 'original'
 
-const SIZES = {
+export const SIZES = {
   xsmall: 24,
   small: 32,
   medium: 40,
   large: 48,
   xlarge: 64,
-}
+} as const
 
 const StyledIcon = styled('svg', {
   shouldForwardProp: prop => !['variant', 'disabled'].includes(prop),

--- a/packages/icons/src/components/ProductIcon/__stories__/Sizes.stories.tsx
+++ b/packages/icons/src/components/ProductIcon/__stories__/Sizes.stories.tsx
@@ -1,12 +1,13 @@
 import type { StoryFn } from '@storybook/react'
 import { Stack, Text } from '@ultraviolet/ui'
 import { ConsoleProductIcon } from '..'
+import { SIZES } from '../Icon'
 
 export const Sizes: StoryFn<typeof ConsoleProductIcon> = props => (
   <Stack gap={1}>
-    {(['small', 'medium', 'large', 'xlarge'] as const).map(size => (
+    {Object.keys(SIZES).map(size => (
       <Stack direction="row" gap={1} alignItems="center">
-        <ConsoleProductIcon {...props} size={size} />
+        <ConsoleProductIcon {...props} size={size as keyof typeof SIZES} />
         <Text as="span" variant="bodyStrong">
           {size}
         </Text>


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Display all available sizes on storybook for ProductIcon components.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2024-09-30 at 09 25 45](https://github.com/user-attachments/assets/f082d949-f575-4155-9781-f89de2a7c5c7) | ![Screenshot 2024-09-30 at 09 25 48](https://github.com/user-attachments/assets/487cdd6d-a553-420f-a1b5-0b5016005003) |
