### PR TITLE
fix(TextArea): make label or aria label required

### DIFF
--- a/.changeset/nasty-stingrays-retire.md
+++ b/.changeset/nasty-stingrays-retire.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<TextArea />` to have either label or aria-label as required prop

--- a/packages/form/src/components/TextAreaField/index.tsx
+++ b/packages/form/src/components/TextAreaField/index.tsx
@@ -51,6 +51,7 @@ export const TextAreaField = <
   regex: regexes,
   submitOnEnter,
   validate,
+  'aria-label': ariaLabel,
 }: TextAreaFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
 
@@ -104,13 +105,12 @@ export const TextAreaField = <
           regex: regexes,
           minLength,
           maxLength,
-          label,
+          label: label ?? (ariaLabel as string),
           value: field.value,
         },
         error,
       )}
       helper={helper}
-      label={label}
       labelDescription={labelDescription}
       minLength={minLength}
       maxLength={maxLength}
@@ -133,6 +133,7 @@ export const TextAreaField = <
       tabIndex={tabIndex}
       tooltip={tooltip}
       value={field.value}
+      {...(label ? { label } : { 'aria-label': ariaLabel as string })}
     />
   )
 }

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -86,12 +86,21 @@ const StyledTextArea = styled('textarea', {
   }
 `
 
+type LabelProps =
+  | {
+      label: string
+      'aria-label'?: never
+    }
+  | {
+      label?: never
+      'aria-label': string
+    }
+
 type TextAreaProps = {
   id?: string
   className?: string
   tabIndex?: number
   autoFocus?: boolean
-  label: string
   value?: string
   onChange: (newValue: string) => void
   placeholder?: string
@@ -130,7 +139,7 @@ type TextAreaProps = {
   onKeyDown?: DOMAttributes<HTMLTextAreaElement>['onKeyDown']
   clearable?: boolean
   labelDescription?: ReactNode
-}
+} & LabelProps
 
 /**
  * This component offers an extended textarea HTML
@@ -163,6 +172,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       onKeyDown,
       clearable = false,
       labelDescription,
+      'aria-label': ariaLabel,
     },
     ref,
   ) => {
@@ -232,6 +242,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
               onFocus={onFocus}
               onBlur={onBlur}
               onKeyDown={onKeyDown}
+              aria-label={ariaLabel}
             />
             <StyledTextAreaAbsoluteStack
               direction="row"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<TextArea />` to have either label or aria-label as required prop
