### PR TITLE
fix(SelectableCard): illustration not aligned on the right when small content

### DIFF
--- a/.changeset/sixty-ladybugs-know.md
+++ b/.changeset/sixty-ladybugs-know.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectableCard />` when using illustration

--- a/packages/ui/src/components/SelectableCard/__stories__/Illustration.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/Illustration.stories.tsx
@@ -65,8 +65,7 @@ export const Illustration: StoryFn = args => {
           productIcon="macMiniM2"
           showTick
         >
-          Offer the best experience to your Mac, iPhone and iPad users with VNC,
-          the remote desktop-sharing protocol.
+          Offer the best experience to your Mac
           <Link target="_blank" href="scaleway.com">
             Learn more
           </Link>
@@ -120,8 +119,7 @@ export const Illustration: StoryFn = args => {
           illustration={appleSiliconM2Wire as string}
           showTick
         >
-          Offer the best experience to your Mac, iPhone and iPad users with VNC,
-          the remote desktop-sharing protocol.
+          Offer the best experience to your Mac
           <Link target="_blank" href="scaleway.com">
             Learn more
           </Link>

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -3972,20 +3972,26 @@ exports[`SelectableCard > renders correctly with illustration 1`] = `
 }
 
 .emotion-27 {
-  -webkit-flex: 1 1 220px;
-  -ms-flex: 1 1 220px;
-  flex: 1 1 220px;
-  height: auto;
-  overflow: hidden;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  gap: 0px;
+  -webkit-box-flex-flow: column;
+  -webkit-flex-flow: column;
+  -ms-flex-flow: column;
+  flex-flow: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  min-width: 180px;
   position: relative;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  overflow: hidden;
 }
 
 .emotion-29 {

--- a/packages/ui/src/components/SelectableCard/index.tsx
+++ b/packages/ui/src/components/SelectableCard/index.tsx
@@ -58,7 +58,7 @@ const Container = styled(Stack)`
 
   &[data-image="illustration"] {
     padding: ${({ theme }) => theme.space[0]};
-  } 
+  }
 
   &[data-image="icon"] {
     padding: ${({ theme }) => theme.space[0]};
@@ -80,34 +80,36 @@ const Container = styled(Stack)`
   }
 `
 const StyledDiv = styled.div`
-flex:1 1 220px;
-height: auto;
-overflow: hidden;
-display: flex;
-position: relative;
-align-items: center;
+  display: flex;
+  gap: 0px;
+  flex-flow: column;
+  align-items: normal;
+  justify-content: center;
+  min-width: 180px;
+  position: relative;
+  overflow: hidden;
 `
 
 const StyledImg = styled.img`
-object-fit: cover;
-position: absolute;
-min-width:220px;
-height: auto;
-left: ${({ theme }) => theme.space[1]};
+  object-fit: cover;
+  position: absolute;
+  min-width: 220px;
+  height: auto;
+  left: ${({ theme }) => theme.space[1]};
 `
 
 const StyledSVG = styled.div`
-object-fit: cover;
-position: absolute;
-min-width:220px;
-height: auto;
-left: ${({ theme }) => theme.space[1]};
+  object-fit: cover;
+  position: absolute;
+  min-width:220px;
+  height: auto;
+  left: ${({ theme }) => theme.space[1]};
 `
 
 const IllustrationStack = styled(Stack)`
-padding: ${({ theme }) => theme.space[2]};
-max-width:  calc(100% - 160px);
-flex: 0 1 auto;
+  padding: ${({ theme }) => theme.space[2]};
+  max-width:  calc(100% - 160px);
+  flex: 0 1 auto;
 `
 
 const StyledStack = styled(Stack)`


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Bug on selectable card when illustration is set and content is too small the alignement is wrong.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="956" alt="Screenshot 2024-10-09 at 11 21 04" src="https://github.com/user-attachments/assets/f75a5100-12ba-47ab-ab9d-588d66edfb35"> |  <img width="978" alt="Screenshot 2024-10-09 at 11 20 49" src="https://github.com/user-attachments/assets/5c9070f3-c787-4d1f-85fd-f4bf9157417f"> |
