### PR TITLE
fix(SelectInputV2): group shown when empty

### DIFF
--- a/.changeset/wet-hairs-search.md
+++ b/.changeset/wet-hairs-search.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInputV2 />` regression: the gorup is being shown when empty, it shouldn't

--- a/packages/ui/src/components/SelectInputV2/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/Dropdown.tsx
@@ -441,8 +441,7 @@ const CreateDropdown = ({
           ) : null}
           {Object.keys(displayedOptions).map((group, index) => (
             <Stack key={group} gap={0.25}>
-              {displayedOptions[group].length > 0 ||
-              (!Array.isArray(options) && options[group].length === 0) ? (
+              {displayedOptions[group].length > 0 ? (
                 <DropdownGroupWrapper id={selectAllGroup ? 'items' : undefined}>
                   {group ? (
                     <DropdownGroup

--- a/packages/ui/src/components/SelectInputV2/__stories__/Multiselect.stories.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/Multiselect.stories.tsx
@@ -7,7 +7,7 @@ Multiselect.args = {
   ...Template.args,
   options: dataGrouped,
   multiselect: true,
-  value: [dataGrouped['terrestrial planets'][4].value],
+  value: '',
 }
 Multiselect.decorators = [
   StoryComponent => (

--- a/packages/ui/src/components/SelectInputV2/__stories__/resources.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/resources.tsx
@@ -72,33 +72,7 @@ export const dataUnGrouped = [
 ]
 
 export const dataGrouped = {
-  'terrestrial planets': [
-    {
-      value: 'mercury',
-      label: 'Mercury',
-    },
-    {
-      value: 'venus',
-      label: 'Venus',
-    },
-    {
-      value: 'earth',
-      label: 'Earth',
-      description: 'Our home planet',
-      searchText: 'earth',
-    },
-    {
-      value: 'mars',
-      label: 'Mars',
-      disabled: true,
-    },
-    {
-      value: 'pluto',
-      label: 'Pluto',
-      description:
-        'Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky',
-    },
-  ],
+  'terrestrial planets': [],
 
   'jovian planets': [
     {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

SelectInputV2 regression: the group name is shown while its content is empty. It shouldn't.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="2207" alt="Screenshot 2024-10-09 at 14 30 26" src="https://github.com/user-attachments/assets/a7574b09-7f90-49fa-9474-9ba41bd14fdb"> | <img width="2213" alt="Screenshot 2024-10-09 at 14 30 34" src="https://github.com/user-attachments/assets/08891f7a-7000-48d8-aa2c-24388b963f60"> |
