### PR TITLE
fix(SelectInputV2): display placeholder if no values match in options

### DIFF
--- a/.changeset/slimy-birds-dream.md
+++ b/.changeset/slimy-birds-dream.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+SelectInput : The component display the placeholder if no selected values are found in the options

--- a/packages/ui/src/components/SelectInputV2/SelectBar.tsx
+++ b/packages/ui/src/components/SelectInputV2/SelectBar.tsx
@@ -104,7 +104,7 @@ const StyledInputWrapper = styled(Stack)<{
       border-color: ${({ theme }) => theme.colors.success.borderHover};
       box-shadow: ${({ theme }) => theme.shadows.focusSuccess};
     }
-  
+
     &[data-dropdownvisible='true'] {
       border-color: ${({ theme }) => theme.colors.success.borderHover};
     }
@@ -117,7 +117,7 @@ const StyledInputWrapper = styled(Stack)<{
       border-color: ${({ theme }) => theme.colors.danger.borderHover};
       box-shadow: ${({ theme }) => theme.shadows.focusDanger};
     }
-  
+
     &[data-dropdownvisible='true'] {
       border-color: ${({ theme }) => theme.colors.danger.borderHover};
     }
@@ -145,7 +145,7 @@ const CustomTag = styled(Tag)`
 `
 const SelectedValues = styled(Text)`
 text-overflow: ellipsis;
-overflow: hidden; 
+overflow: hidden;
 `
 
 const isValidSelectedValue = (selectedValue: string, options: DataType) =>
@@ -367,7 +367,7 @@ export const SelectBar = ({
         tabIndex={0}
         aria-label={label}
       >
-        {selectedData.selectedValues.length > 0 ? (
+        {nonOverflowedValues.length > 0 ? (
           <DisplayValues
             refTag={refTag}
             nonOverflowedValues={nonOverflowedValues}

--- a/packages/ui/src/components/SelectInputV2/SelectBar.tsx
+++ b/packages/ui/src/components/SelectInputV2/SelectBar.tsx
@@ -328,6 +328,28 @@ export const SelectBar = ({
     setSelectedData({ type: 'update' })
   }, [setSelectedData, options])
 
+  const shouldDisplayValues = useMemo(() => {
+    if (multiselect) {
+      return (
+        nonOverflowedValues.length > 0 ||
+        selectedData.selectedValues.some(
+          selectedValue =>
+            findOptionInOptions(options, selectedValue) !== undefined,
+        )
+      )
+    }
+
+    return (
+      selectedData.selectedValues[0] !== undefined &&
+      findOptionInOptions(options, selectedData.selectedValues[0]) !== undefined
+    )
+  }, [
+    multiselect,
+    nonOverflowedValues.length,
+    options,
+    selectedData.selectedValues,
+  ])
+
   return (
     <Tooltip text={tooltip}>
       <StyledInputWrapper
@@ -367,7 +389,7 @@ export const SelectBar = ({
         tabIndex={0}
         aria-label={label}
       >
-        {nonOverflowedValues.length > 0 ? (
+        {shouldDisplayValues ? (
           <DisplayValues
             refTag={refTag}
             nonOverflowedValues={nonOverflowedValues}

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -2624,8 +2624,8 @@ exports[`UnitInput > renders with default value 1`] = `
           class="emotion-8 emotion-9 emotion-10"
         >
           <div
-            aria-controls=":r31:"
-            aria-describedby=":r31:"
+            aria-controls=":r30:"
+            aria-describedby=":r30:"
             class="emotion-11 emotion-12"
             data-container-full-width="true"
             tabindex="0"
@@ -6361,7 +6361,7 @@ exports[`UnitInput > renders with label and label information 1`] = `
       >
         <label
           class="emotion-4 emotion-5"
-          for=":r2k:"
+          for=":r2j:"
         >
           label
         </label>
@@ -6399,8 +6399,8 @@ exports[`UnitInput > renders with label and label information 1`] = `
           class="emotion-12 emotion-13 emotion-14"
         >
           <div
-            aria-controls=":r2n:"
-            aria-describedby=":r2n:"
+            aria-controls=":r2m:"
+            aria-describedby=":r2m:"
             class="emotion-15 emotion-16"
             data-container-full-width="true"
             tabindex="0"
@@ -7312,7 +7312,7 @@ exports[`UnitInput > renders with label and no label information 1`] = `
       >
         <label
           class="emotion-4 emotion-5"
-          for=":r2e:"
+          for=":r2d:"
         >
           label
         </label>
@@ -7349,8 +7349,8 @@ exports[`UnitInput > renders with label and no label information 1`] = `
           class="emotion-12 emotion-13 emotion-14"
         >
           <div
-            aria-controls=":r2h:"
-            aria-describedby=":r2h:"
+            aria-controls=":r2g:"
+            aria-describedby=":r2g:"
             class="emotion-15 emotion-16"
             data-container-full-width="true"
             tabindex="0"
@@ -8767,8 +8767,8 @@ exports[`UnitInput > renders with no label and label information 1`] = `
           class="emotion-8 emotion-9 emotion-10"
         >
           <div
-            aria-controls=":r2s:"
-            aria-describedby=":r2s:"
+            aria-controls=":r2r:"
+            aria-describedby=":r2r:"
             class="emotion-11 emotion-12"
             data-container-full-width="true"
             tabindex="0"

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -2624,8 +2624,8 @@ exports[`UnitInput > renders with default value 1`] = `
           class="emotion-8 emotion-9 emotion-10"
         >
           <div
-            aria-controls=":r30:"
-            aria-describedby=":r30:"
+            aria-controls=":r31:"
+            aria-describedby=":r31:"
             class="emotion-11 emotion-12"
             data-container-full-width="true"
             tabindex="0"
@@ -6361,7 +6361,7 @@ exports[`UnitInput > renders with label and label information 1`] = `
       >
         <label
           class="emotion-4 emotion-5"
-          for=":r2j:"
+          for=":r2k:"
         >
           label
         </label>
@@ -6399,8 +6399,8 @@ exports[`UnitInput > renders with label and label information 1`] = `
           class="emotion-12 emotion-13 emotion-14"
         >
           <div
-            aria-controls=":r2m:"
-            aria-describedby=":r2m:"
+            aria-controls=":r2n:"
+            aria-describedby=":r2n:"
             class="emotion-15 emotion-16"
             data-container-full-width="true"
             tabindex="0"
@@ -7312,7 +7312,7 @@ exports[`UnitInput > renders with label and no label information 1`] = `
       >
         <label
           class="emotion-4 emotion-5"
-          for=":r2d:"
+          for=":r2e:"
         >
           label
         </label>
@@ -7349,8 +7349,8 @@ exports[`UnitInput > renders with label and no label information 1`] = `
           class="emotion-12 emotion-13 emotion-14"
         >
           <div
-            aria-controls=":r2g:"
-            aria-describedby=":r2g:"
+            aria-controls=":r2h:"
+            aria-describedby=":r2h:"
             class="emotion-15 emotion-16"
             data-container-full-width="true"
             tabindex="0"
@@ -8767,8 +8767,8 @@ exports[`UnitInput > renders with no label and label information 1`] = `
           class="emotion-8 emotion-9 emotion-10"
         >
           <div
-            aria-controls=":r2r:"
-            aria-describedby=":r2r:"
+            aria-controls=":r2s:"
+            aria-describedby=":r2s:"
             class="emotion-11 emotion-12"
             data-container-full-width="true"
             tabindex="0"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

SelectInputV2 should display the placeholder if none of selected values match in options 

#### The following changes where made:

1. Improve the condition in SelectBar

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
