### PR TITLE
fix(SelectInputV2): accessibility for selected and disabled on div with option role

### DIFF
--- a/.changeset/moody-parrots-clean.md
+++ b/.changeset/moody-parrots-clean.md
@@ -2,4 +2,4 @@
 "@ultraviolet/ui": minor
 ---
 
-SelectInputV2 : Fix accessibility by changing disabled for aria-disabled on div with option role
+SelectInputV2 : Fix accessibility by changing disabled and data-selected for aria-disabled and aria-selected on div with option role.

--- a/.changeset/moody-parrots-clean.md
+++ b/.changeset/moody-parrots-clean.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+SelectInputV2 : Fix accessibility by changing disabled for aria-disabled on div with option role

--- a/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -496,17 +496,17 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
   outline: none;
 }
 
-.emotion-36[data-selected='true'] {
+.emotion-36[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-36[disabled] {
+.emotion-36[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-36[disabled]:hover,
-.emotion-36 [disabled]:focus {
+.emotion-36[aria-disabled="true"]:hover,
+.emotion-36 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -687,9 +687,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                     id="items"
                   >
                     <div
+                      aria-disabled="false"
                       aria-label="mercury"
+                      aria-selected="true"
                       class="emotion-36 emotion-37"
-                      data-selected="true"
                       data-testid="option-mercury"
                       id="option-0"
                       role="option"
@@ -711,9 +712,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="venus"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-venus"
                       id="option-1"
                       role="option"
@@ -735,9 +737,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="earth"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-earth"
                       id="option-2"
                       role="option"
@@ -764,11 +767,11 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                       </div>
                     </div>
                     <div
+                      aria-disabled="true"
                       aria-label="mars"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-mars"
-                      disabled=""
                       id="option-3"
                       role="option"
                       tabindex="-1"
@@ -789,9 +792,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="pluto"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-pluto"
                       id="option-4"
                       role="option"
@@ -845,9 +849,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                     id="items"
                   >
                     <div
+                      aria-disabled="false"
                       aria-label="jupiter"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-jupiter"
                       id="option-0"
                       role="option"
@@ -874,9 +879,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="saturn"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-saturn"
                       id="option-1"
                       role="option"
@@ -898,9 +904,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="uranus"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-uranus"
                       id="option-2"
                       role="option"
@@ -922,9 +929,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="neptune"
+                      aria-selected="false"
                       class="emotion-36 emotion-37"
-                      data-selected="false"
                       data-testid="option-neptune"
                       id="option-3"
                       role="option"

--- a/packages/ui/src/components/SelectInputV2/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/Dropdown.tsx
@@ -112,8 +112,8 @@ const DropdownGroupWrapper = styled.div`
   top: 0px;
 `
 const DropdownItem = styled.div<{
-  'data-selected': boolean
-  disabled: boolean
+  'aria-selected': boolean
+  'aria-disabled': boolean
 }>`
   text-align:left;
   border: none;
@@ -135,16 +135,16 @@ const DropdownItem = styled.div<{
     outline: none;
   }
 
-  &[data-selected='true'] {
+  &[aria-selected='true'] {
     background-color: ${({ theme }) => theme.colors.primary.background};
   }
 
-  &[disabled] {
+  &[aria-disabled="true"] {
     background-color: ${({ theme }) => theme.colors.neutral.backgroundDisabled};
     color: ${({ theme }) => theme.colors.neutral.textDisabled};
   }
 
-  &[disabled]:hover, [disabled]:focus {
+  &[aria-disabled="true"]:hover, [aria-disabled="true"]:focus {
     background-color: ${({ theme }) =>
       theme.colors.neutral.backgroundStrongDisabled};
     color: ${({ theme }) => theme.colors.neutral.textStrongDisabled};
@@ -402,8 +402,8 @@ const CreateDropdown = ({
           {selectAll && multiselect ? (
             <Stack id="items">
               <DropdownItem
-                disabled={false}
-                data-selected={selectedData.allSelected}
+                aria-disabled={false}
+                aria-selected={selectedData.allSelected}
                 aria-label="select-all"
                 data-testid="select-all"
                 id="select-all"
@@ -491,9 +491,9 @@ const CreateDropdown = ({
                 {displayedOptions[group].map((option, indexOption) => (
                   <DropdownItem
                     key={option.value}
-                    disabled={!!option.disabled}
+                    aria-disabled={!!option.disabled}
                     tabIndex={!option.disabled ? 0 : -1}
-                    data-selected={
+                    aria-selected={
                       selectedData.selectedValues.includes(option.value) &&
                       !option.disabled
                     }
@@ -562,8 +562,8 @@ const CreateDropdown = ({
       {selectAll && multiselect ? (
         <Stack id="items" gap={0.25} tabIndex={-1}>
           <DropdownItem
-            disabled={false}
-            data-selected={selectedData.allSelected}
+            aria-disabled={false}
+            aria-selected={selectedData.allSelected}
             aria-label="select-all"
             data-testid="select-all"
             tabIndex={0}
@@ -605,8 +605,8 @@ const CreateDropdown = ({
           displayedOptions.map((option, index) => (
             <DropdownItem
               key={option.value}
-              disabled={!!option.disabled}
-              data-selected={
+              aria-disabled={!!option.disabled}
+              aria-selected={
                 selectedData.selectedValues.includes(option.value) &&
                 !option.disabled
               }

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1011,17 +1011,17 @@ exports[`UnitInput > renders click 1`] = `
   outline: none;
 }
 
-.emotion-33[data-selected='true'] {
+.emotion-33[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-33[disabled] {
+.emotion-33[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-33[disabled]:hover,
-.emotion-33 [disabled]:focus {
+.emotion-33[aria-disabled="true"]:hover,
+.emotion-33 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -1178,9 +1178,10 @@ exports[`UnitInput > renders click 1`] = `
                     id="items"
                   >
                     <div
+                      aria-disabled="false"
                       aria-label="kb"
+                      aria-selected="false"
                       class="emotion-33 emotion-34"
-                      data-selected="false"
                       data-testid="option-kb"
                       id="option-0"
                       role="option"
@@ -1202,9 +1203,10 @@ exports[`UnitInput > renders click 1`] = `
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="mb"
+                      aria-selected="false"
                       class="emotion-33 emotion-34"
-                      data-selected="false"
                       data-testid="option-mb"
                       id="option-1"
                       role="option"
@@ -1226,9 +1228,10 @@ exports[`UnitInput > renders click 1`] = `
                       </div>
                     </div>
                     <div
+                      aria-disabled="false"
                       aria-label="gb"
+                      aria-selected="false"
                       class="emotion-33 emotion-34"
-                      data-selected="false"
                       data-testid="option-gb"
                       id="option-2"
                       role="option"


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarise concisely:

#### What is expected?

(Description of the new behavior)
Div with option role should be accessible when testing but by changing for a div instead of button the prop disabled is not valid anymore.

#### The following changes where made:

(Describe what you did)
I replaced disabled for aria-disabled and the data-selected for aria-selected which is valid for multi select or single select

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
