### PR TITLE
docs: fix conversation avatar and implement real talks

### DIFF
--- a/packages/plus/src/components/Conversation/__stories__/Message.stories.tsx
+++ b/packages/plus/src/components/Conversation/__stories__/Message.stories.tsx
@@ -1,41 +1,34 @@
 import { SupportProductIcon } from '@ultraviolet/icons/product'
-import { Avatar, Text } from '@ultraviolet/ui'
+import { AvatarV2, Text } from '@ultraviolet/ui'
 import { Conversation } from '..'
 
 export const Message = () => (
   <>
     <Conversation.Message
-      avatar={<SupportProductIcon size="medium" />}
-      align="left"
-    >
-      <Text variant="body" sentiment="neutral" as="div">
-        Message left
-      </Text>
-    </Conversation.Message>
-    <Conversation.MessageInfos align="left">
-      <Conversation.Tag>tag</Conversation.Tag>
-      <Text as="p" variant="bodySmall" prominence="weak">
-        info
-      </Text>
-    </Conversation.MessageInfos>
-
-    <Conversation.Message
-      avatar={
-        <Avatar
-          size={40}
-          image="static/media/packages/ui/src/components/Avatar/__stories__/avatar.svg"
-        />
-      }
+      avatar={<AvatarV2 shape="circle" variant="text" text="MC" size="small" />}
       align="right"
     >
       <Text variant="body" sentiment="neutral" as="div">
-        Message right
+        Hi, I’m having trouble logging into my account. It keeps saying invalid
+        password, but I’m sure it’s correct.
       </Text>
     </Conversation.Message>
     <Conversation.MessageInfos align="right">
-      <Conversation.Tag>tag</Conversation.Tag>
+      <Conversation.Tag>1 day ago</Conversation.Tag>
       <Text as="p" variant="bodySmall" prominence="weak">
-        info
+        sent
+      </Text>
+    </Conversation.MessageInfos>
+    <Conversation.Message avatar={<SupportProductIcon />} align="left">
+      <Text variant="body" sentiment="neutral" as="div">
+        Hello! I recommend resetting your password using the Forgot Password
+        link. If that doesn’t work, let me know, and I’ll assist further.
+      </Text>
+    </Conversation.Message>
+    <Conversation.MessageInfos align="left">
+      <Conversation.Tag>10 minutes ago</Conversation.Tag>
+      <Text as="p" variant="bodySmall" prominence="weak">
+        read
       </Text>
     </Conversation.MessageInfos>
   </>

--- a/packages/plus/src/components/Conversation/__stories__/Playground.stories.tsx
+++ b/packages/plus/src/components/Conversation/__stories__/Playground.stories.tsx
@@ -1,4 +1,4 @@
-import { Avatar } from '@ultraviolet/ui'
+import { AvatarV2 } from '@ultraviolet/ui'
 import { Conversation } from '..'
 import { Template } from './Template.stories'
 
@@ -9,27 +9,35 @@ Playground.args = {
     <>
       <Conversation.Date>2022-03-02</Conversation.Date>
       <Conversation.Message
-        avatar={
-          <Avatar image="static/media/packages/ui/src/components/Avatar/__stories__/avatar.svg" />
-        }
-        align="left"
+        avatar={<AvatarV2 shape="circle" variant="text" text="MC" />}
+        align="right"
       >
-        Message 1
-      </Conversation.Message>
-      <Conversation.MessageInfos align="left">
-        <Conversation.Tag>tag</Conversation.Tag>
-        info message
-      </Conversation.MessageInfos>
-      <Conversation.Message
-        avatar={
-          <Avatar image="static/media/packages/ui/src/components/Avatar/__stories__/avatar.svg" />
-        }
-      >
-        Message 2
+        I finally tried that new café downtown. Their coffee is amazing!
       </Conversation.Message>
       <Conversation.MessageInfos align="right">
-        <Conversation.Tag>tag</Conversation.Tag>
-        info message
+        <Conversation.Tag>3 minutes ago</Conversation.Tag>
+        sent
+      </Conversation.MessageInfos>
+      <Conversation.Message
+        avatar={<AvatarV2 shape="circle" variant="text" text="TM" />}
+        align="left"
+      >
+        Oh really? I&#39;ve heard good things. Did you get one of those fancy
+        lattes with the art on top?
+      </Conversation.Message>
+      <Conversation.MessageInfos align="left">
+        <Conversation.Tag>2 minutes ago</Conversation.Tag>
+        read
+      </Conversation.MessageInfos>
+      <Conversation.Message
+        avatar={<AvatarV2 shape="circle" variant="text" text="TM" />}
+      >
+        Yeah, they made a leaf pattern. I almost didn’t want to drink it, but I
+        couldn’t resist!
+      </Conversation.Message>
+      <Conversation.MessageInfos align="right">
+        <Conversation.Tag>few seconds ago</Conversation.Tag>
+        sent
       </Conversation.MessageInfos>
     </>,
   ],


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Conversation documentation was a bit broken with the avatar not working. Also I improved the view by adding a "real" conversation example.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2024-10-16 at 14 36 12](https://github.com/user-attachments/assets/e5e54f70-141c-4728-905e-bd8639538756) | ![Screenshot 2024-10-16 at 14 36 17](https://github.com/user-attachments/assets/262e8844-a3b1-4b70-b22a-fe71ef51508f) |
