### PR TITLE
fix(textinput): onKeyUp/Down not forwarded

### DIFF
--- a/.changeset/gorgeous-plants-reflect.md
+++ b/.changeset/gorgeous-plants-reflect.md
@@ -3,4 +3,4 @@
 "@ultraviolet/ui": patch
 ---
 
-fix(textinput): onKeyUp/Down not forwarded
+Fix <TextInputV2 /> onKeyUp/Down not forwarded

--- a/.changeset/gorgeous-plants-reflect.md
+++ b/.changeset/gorgeous-plants-reflect.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+fix(textinput): onKeyUp/Down not forwarded

--- a/packages/form/src/components/TextInputFieldV2/index.tsx
+++ b/packages/form/src/components/TextInputFieldV2/index.tsx
@@ -61,6 +61,8 @@ export const TextInputField = <
   role,
   'aria-live': ariaLive,
   'aria-atomic': ariaAtomic,
+  onKeyDown,
+  onKeyUp,
 }: TextInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
 
@@ -142,6 +144,8 @@ export const TextInputField = <
       role={role}
       aria-live={ariaLive}
       aria-atomic={ariaAtomic}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
     />
   )
 }

--- a/packages/ui/src/components/TextInputV2/index.tsx
+++ b/packages/ui/src/components/TextInputV2/index.tsx
@@ -179,6 +179,7 @@ type TextInputProps = {
   | 'tabIndex'
   | 'autoComplete'
   | 'onKeyDown'
+  | 'onKeyUp'
   | 'role'
   | 'aria-live'
   | 'aria-atomic'
@@ -227,6 +228,7 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
       'aria-label': ariaLabel,
       autoComplete,
       onKeyDown,
+      onKeyUp,
       role,
       'aria-live': ariaLive,
       'aria-atomic': ariaAtomic,
@@ -354,6 +356,7 @@ export const TextInputV2 = forwardRef<HTMLInputElement, TextInputProps>(
                 autoComplete={autoComplete}
                 required={required}
                 onKeyDown={onKeyDown}
+                onKeyUp={onKeyUp}
               />
               {success || error || loading || computedClearable ? (
                 <StateStack direction="row" gap={1} alignItems="center">


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

forward onKeyUp/onKeyDown to TextInput

#### The following changes where made:

(Describe what you did)

1.

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
