### PR TITLE
fix: taglist not adding ellipsis to single long tag

### DIFF
--- a/.changeset/quick-elephants-retire.md
+++ b/.changeset/quick-elephants-retire.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix <TagList/> not adding ellipsis to single long tag

--- a/packages/ui/src/components/TagList/__stories__/ParentWithWidth.stories.tsx
+++ b/packages/ui/src/components/TagList/__stories__/ParentWithWidth.stories.tsx
@@ -11,6 +11,10 @@ export const ParentWithDefinedWidth: StoryFn<typeof TagList> = args => (
     <div style={{ width: '100px', border: '1px solid gray', padding: '10px' }}>
       <TagList {...args} />
     </div>
+
+    <div style={{ width: '100px', border: '1px solid gray', padding: '10px' }}>
+      <TagList {...args} tags={['Looooooooooooong']} />
+    </div>
   </Stack>
 )
 

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -163,6 +163,21 @@ exports[`TagList > renders correctly and add ellipsis to the first tag as it too
   gap: 8px;
 }
 
+.emotion-2:has(.ellipsed) {
+  width: calc(100% - 0px);
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.emotion-2 span,
+.emotion-2 div {
+  width: 100%;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
 .emotion-4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/ui/src/components/TagList/index.tsx
+++ b/packages/ui/src/components/TagList/index.tsx
@@ -30,6 +30,7 @@ const StyledTagContainer = styled.div<{
   gap: string
   multiline?: boolean
   popoverTriggerWidth?: number
+  haveOnlySingleLongTag?: boolean
 }>`
   display: flex;
   align-items: center;
@@ -37,12 +38,12 @@ const StyledTagContainer = styled.div<{
   gap: ${({ gap }) => gap};
   ${({ multiline }) => multiline && `flex-wrap: wrap;`};
 
-  // to handle the case where we have one tag and we need to ellipsis it
-  ${({ popoverTriggerWidth }) =>
-    popoverTriggerWidth &&
+  // Handle the case where we have one tag and we need to ellipsis it
+  ${({ popoverTriggerWidth, haveOnlySingleLongTag }) =>
+    (popoverTriggerWidth || haveOnlySingleLongTag) &&
     `
       &:has(.ellipsed) {
-        width: calc(100% - ${popoverTriggerWidth}px); // to let space for the +X button
+        width: calc(100% - ${popoverTriggerWidth || 0}px); // to let space for the +X button
         max-width: fit-content;
       }
 
@@ -299,6 +300,9 @@ export const TagList = ({
         multiline={multiline}
         popoverTriggerWidth={popoverTriggerWidth}
         ref={containerRef}
+        haveOnlySingleLongTag={
+          visibleTags.length === 1 && hiddenTags.length === 0
+        }
       >
         {visibleTags.map((tag, index) =>
           renderTag(


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

fix TagList not adding ellipsis to single long tag

## Relevant logs and/or screenshots

![Screenshot 2024-10-29 at 00 35 49](https://github.com/user-attachments/assets/b198db94-9653-4721-8373-4c6a724b586d)

| Before | After |
| ----- | ----- |
| ![Screenshot 2024-10-29 at 00 19 40](https://github.com/user-attachments/assets/1c292a8e-8426-4739-831e-ba2a536cf646) | ![Screenshot 2024-10-29 at 00 16 36](https://github.com/user-attachments/assets/b6dd3063-4c0a-416b-942a-9e968927af31) |

