### PR TITLE
fix(SwitchButton): not updating local value when value prop change

### DIFF
--- a/.changeset/wicked-baboons-dream.md
+++ b/.changeset/wicked-baboons-dream.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix <SwitchButton /> not updating local value when value prop change

--- a/.changeset/wicked-baboons-dream.md
+++ b/.changeset/wicked-baboons-dream.md
@@ -2,4 +2,4 @@
 "@ultraviolet/ui": patch
 ---
 
-Fix <SwitchButton /> not updating local value when value prop change
+Fix `<SwitchButton />` not updating local value when value prop change

--- a/packages/ui/src/components/SwitchButton/index.tsx
+++ b/packages/ui/src/components/SwitchButton/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import type { ChangeEvent, ChangeEventHandler, FocusEventHandler } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { SelectableCard } from '../SelectableCard'
 import { Tooltip } from '../Tooltip'
 import { FocusOverlay } from './FocusOverlay'
@@ -106,9 +106,17 @@ export const SwitchButton = ({
   const [rightCardWidth, setRightCardWidth] = useState<number>()
   const [hasMouseDown, setHasMouseDown] = useState(false)
 
-  const [localValue, setLocalValue] = useState(
-    value === leftButton.value ? leftButton.value : rightButton.value,
+  const getValueToUse = useCallback(
+    () => (value === leftButton.value ? leftButton.value : rightButton.value),
+    [leftButton.value, rightButton.value, value],
   )
+
+  const [localValue, setLocalValue] = useState(getValueToUse())
+
+  useEffect(() => {
+    setLocalValue(getValueToUse())
+  }, [getValueToUse, value])
+
   const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange?.(event)
     setLocalValue(event.target.value)


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

fix SwitchButton not updating local value when value prop change

## Relevant logs and/or screenshots

https://github.com/user-attachments/assets/01820de3-1720-4f54-a2b1-8cd2c7460695


