### PR TITLE
docs(storybook): fix margins set by docs container

### DIFF
--- a/.storybook/components/globalStyle.ts
+++ b/.storybook/components/globalStyle.ts
@@ -22,6 +22,10 @@ export const globalStyles = css`
     margin: ${lightTheme.space['2']} 0 ${lightTheme.space['1']} 0;
   }
 
+  .sb-anchor h1, .sb-anchor h2, .sb-anchor h3, .sb-anchor h4, .sb-anchor h5, .sb-anchor h6 {
+    margin: inherit;
+  }
+
   body {
       font-family: 'Inter', sans-serif;
       font-size: 16px;

--- a/packages/ui/src/components/SelectInputV2/__stories__/resources.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/resources.tsx
@@ -72,8 +72,33 @@ export const dataUnGrouped = [
 ]
 
 export const dataGrouped = {
-  'terrestrial planets': [],
-
+  'terrestrial planets': [
+    {
+      value: 'mercury',
+      label: 'Mercury',
+    },
+    {
+      value: 'venus',
+      label: 'Venus',
+    },
+    {
+      value: 'earth',
+      label: 'Earth',
+      description: 'Our home planet',
+      searchText: 'earth',
+    },
+    {
+      value: 'mars',
+      label: 'Mars',
+      disabled: true,
+    },
+    {
+      value: 'pluto',
+      label: 'Pluto',
+      description:
+        'Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky',
+    },
+  ],
   'jovian planets': [
     {
       value: 'jupiter',


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Fix docs container not to apply global margin on stories.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="332" alt="Screenshot 2024-11-12 at 14 25 31" src="https://github.com/user-attachments/assets/618b7980-3333-4164-8f2c-750496a17101"> | <img width="353" alt="Screenshot 2024-11-12 at 14 25 35" src="https://github.com/user-attachments/assets/601d4e5c-acd2-423f-9173-f84667893951"> |
