### PR TITLE
fix(Navigation): pin button disabled still working

### DIFF
--- a/.changeset/weak-kings-taste.md
+++ b/.changeset/weak-kings-taste.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<Navigation />` disabled pin button still working when clicking on it

--- a/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
+++ b/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
@@ -339,6 +339,7 @@ export const Playground: StoryFn<ComponentProps<typeof Navigation>> = props => {
         initialWidth={navigationWidth}
         initialPinned={pinnedItems}
         animationType="complex"
+        pinLimit={2}
         pinnedFeature
       >
         <PlaygroundContent {...props} />

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -635,20 +635,22 @@ export const Item = ({
                         variant="ghost"
                         sentiment={active ? 'primary' : 'neutral'}
                         onClick={(event: MouseEvent<HTMLDivElement>) => {
-                          event.preventDefault()
-                          event.stopPropagation() // This is to avoid click spread to the parent and change the routing
-                          let newValue: string[] | undefined
-                          if (isItemPinned) {
-                            newValue = unpinItem(id)
-                          } else {
-                            newValue = pinItem(id)
-                          }
+                          if (pinnedItems.length < pinLimit || isItemPinned) {
+                            event.preventDefault()
+                            event.stopPropagation() // This is to avoid click spread to the parent and change the routing
+                            let newValue: string[] | undefined
+                            if (isItemPinned) {
+                              newValue = unpinItem(id)
+                            } else {
+                              newValue = pinItem(id)
+                            }
 
-                          onClickPinUnpin?.({
-                            state: isItemPinned ? 'unpin' : 'pin',
-                            id,
-                            totalPinned: newValue,
-                          })
+                            onClickPinUnpin?.({
+                              state: isItemPinned ? 'unpin' : 'pin',
+                              id,
+                              totalPinned: newValue,
+                            })
+                          }
                         }}
                         disabled={isItemPinned ? false : isPinDisabled}
                       >
@@ -833,20 +835,22 @@ export const Item = ({
                     variant="ghost"
                     sentiment={active ? 'primary' : 'neutral'}
                     onClick={(event: MouseEvent<HTMLDivElement>) => {
-                      event.preventDefault()
-                      event.stopPropagation() // This is to avoid click spread to the parent and change the routing
+                      if (pinnedItems.length < pinLimit || isItemPinned) {
+                        event.preventDefault()
+                        event.stopPropagation() // This is to avoid click spread to the parent and change the routing
 
-                      let newValue: string[] | undefined
-                      if (isItemPinned) {
-                        newValue = unpinItem(id)
-                      } else {
-                        newValue = pinItem(id)
+                        let newValue: string[] | undefined
+                        if (isItemPinned) {
+                          newValue = unpinItem(id)
+                        } else {
+                          newValue = pinItem(id)
+                        }
+                        onClickPinUnpin?.({
+                          state: isItemPinned ? 'unpin' : 'pin',
+                          id,
+                          totalPinned: newValue,
+                        })
                       }
-                      onClickPinUnpin?.({
-                        state: isItemPinned ? 'unpin' : 'pin',
-                        id,
-                        totalPinned: newValue,
-                      })
                     }}
                     disabled={isItemPinned ? false : isPinDisabled}
                   >


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Bug on Navigation allowing users to pin more product than the limit.

## Relevant logs and/or screenshots

Before:

https://github.com/user-attachments/assets/9307563d-6372-4026-8ea2-7c54895a06c1

After:

https://github.com/user-attachments/assets/76b485bf-7515-469d-b0d0-527d67af587c

