### PR TITLE
fix(Skeleton): due to px to rem migration skeleton is broken

### DIFF
--- a/.changeset/orange-pots-explain.md
+++ b/.changeset/orange-pots-explain.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Skeleton />` having wrong width and heigh due to px to rem migration

--- a/packages/plus/src/components/ContentCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/ContentCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -624,7 +624,8 @@ exports[`ContentCard > renders correctly with all directions > renders correctly
 }
 
 .emotion-15 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -1347,7 +1348,8 @@ exports[`ContentCard > renders correctly with all directions > renders correctly
 }
 
 .emotion-15 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;

--- a/packages/plus/src/components/ContentCardGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/ContentCardGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -1053,7 +1053,8 @@ exports[`ContentCardGroup > renders correctly with loading prop 1`] = `
 }
 
 .emotion-10 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -6102,7 +6102,8 @@ exports[`List > Should render correctly with loading 1`] = `
 }
 
 .emotion-23 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -7078,7 +7079,8 @@ exports[`List > Should render correctly with loading with selectable 1`] = `
 }
 
 .emotion-37 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;

--- a/packages/ui/src/components/Skeleton/Donut.tsx
+++ b/packages/ui/src/components/Skeleton/Donut.tsx
@@ -30,7 +30,11 @@ const LineList = styled.ul`
 export const Donut = () => (
   <StyledContainer>
     <StyledSVG>
-      <StyledCircle cx={CIRCLE_SIZE / 2} cy={CIRCLE_SIZE / 2} r="90" />
+      <StyledCircle
+        cx={`${CIRCLE_SIZE / 2}rem`}
+        cy={`${CIRCLE_SIZE / 2}rem`}
+        r="90"
+      />
     </StyledSVG>
     <LineList>
       <li>

--- a/packages/ui/src/components/Skeleton/Line.tsx
+++ b/packages/ui/src/components/Skeleton/Line.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 
-const sizes = [80, 120, 160, 200]
+const sizes = ['5rem', '7.5rem', '10rem', '12.5rem']
 
 const randomSize = () => sizes[Math.floor(Math.random() * sizes.length)]
 
 export const Line = styled.div`
-  height: ${({ theme }) => theme.sizing['150']}
-  width: ${() => randomSize()}px;
+  height: ${({ theme }) => theme.sizing['150']};
+  width: ${() => randomSize()};
   max-width: 100%;
   border-radius: ${({ theme }) => theme.radii.large};
   background-color: ${({ theme }) => theme.colors.neutral.borderWeak};

--- a/packages/ui/src/components/Skeleton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Skeleton/__tests__/__snapshots__/index.test.tsx.snap
@@ -64,7 +64,8 @@ exports[`Skeleton > renders correctly with type="block" 1`] = `
 }
 
 .emotion-8 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -207,7 +208,8 @@ exports[`Skeleton > renders correctly with type="blocks" 1`] = `
 }
 
 .emotion-8 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -406,7 +408,8 @@ exports[`Skeleton > renders correctly with type="box" 1`] = `
 }
 
 .emotion-8 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -598,7 +601,8 @@ exports[`Skeleton > renders correctly with type="donut" 1`] = `
 }
 
 .emotion-10 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -647,8 +651,8 @@ exports[`Skeleton > renders correctly with type="donut" 1`] = `
         >
           <circle
             class="emotion-6 emotion-7"
-            cx="6.4375"
-            cy="6.4375"
+            cx="6.4375rem"
+            cy="6.4375rem"
             r="90"
           />
         </svg>
@@ -714,7 +718,8 @@ exports[`Skeleton > renders correctly with type="line" 1`] = `
 }
 
 .emotion-2 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -824,7 +829,8 @@ exports[`Skeleton > renders correctly with type="list" 1`] = `
 }
 
 .emotion-8 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;
@@ -1218,7 +1224,8 @@ exports[`Skeleton > renders default variant 1`] = `
 }
 
 .emotion-8 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;

--- a/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -2339,7 +2339,8 @@ exports[`Table > Should render correctly with loading 1`] = `
 }
 
 .emotion-36 {
-  height:0.75rem width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
   border-radius: 0.5rem;
   background-color: #e9eaeb;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Due to px to rem migration the skeleton is broken, I fixed it.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1036" alt="Screenshot 2024-11-19 at 11 25 51" src="https://github.com/user-attachments/assets/96470d9e-2c38-49f6-ad2a-177bab9f8f24"> | <img width="1030" alt="Screenshot 2024-11-19 at 11 25 57" src="https://github.com/user-attachments/assets/b98f0347-2574-4833-8db3-bf5368c08295"> |