### PR TITLE
docs(storybook): add tags and fix component state

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,7 @@ export default {
     '@storybook/addon-links',
     '@storybook/addon-a11y',
     '@storybook/addon-themes',
+    'storybook-addon-tag-badges',
     {
       name: '@storybook/addon-docs',
       options: {

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,6 +1,28 @@
 import { addons } from '@storybook/manager-api'
 import { light } from './storybookThemes'
+import { consoleLightTheme } from '@ultraviolet/themes'
 
 addons.setConfig({
   theme: light,
+  tagBadges: [
+    {
+      tags: 'experimental',
+      badge: {
+        text: '🧪 Experimental',
+        bgColor: consoleLightTheme.colors.warning.background,
+        fgColor: consoleLightTheme.colors.warning.text,
+        tooltip:
+          'This component is at an unstable stage and is subject to change in future releases.',
+      },
+    },
+    {
+      tags: 'deprecated',
+      badge: {
+        text: '⛔ Deprecated',
+        bgColor: consoleLightTheme.colors.danger.background,
+        fgColor: consoleLightTheme.colors.danger.text,
+        tooltip: 'This component is deprecated please do not use it any more.',
+      },
+    },
+  ],
 })

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "shx": "0.3.4",
     "size-limit": "11.1.6",
     "storybook": "8.4.5",
+    "storybook-addon-tag-badges": "1.2.0",
     "svgo": "3.3.2",
     "timekeeper": "2.3.1",
     "tsx": "4.19.2",

--- a/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
@@ -80,6 +80,7 @@ export default {
     migrationLink: 'Migrations/NumberInput to NumberInputV2',
   },
   title: 'Form/Components/Fields/NumberInputField',
+  tags: ['deprecated'],
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/form/src/components/SelectInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectInputField/__stories__/index.stories.tsx
@@ -72,6 +72,7 @@ export default {
     },
   },
   title: 'Form/Components/Fields/SelectInputField',
+  tags: ['deprecated'],
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
@@ -76,6 +76,7 @@ export default {
     migrationLink: 'Migrations/TextInput to TextInputV2',
   },
   title: 'Form/Components/Fields/TextInputField',
+  tags: ['deprecated'],
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/__stories__/ComponentState/ComponentState.tsx
+++ b/packages/ui/src/__stories__/ComponentState/ComponentState.tsx
@@ -1,4 +1,5 @@
 import { linkTo } from '@storybook/addon-links'
+import { useEffect, useState } from 'react'
 import * as components from '../../components'
 import { Button } from '../../components/Button'
 import { Stack } from '../../components/Stack'
@@ -10,7 +11,7 @@ const findComponentState = (parameters: {
   experimental?: boolean
 }) => {
   if (parameters?.deprecated) {
-    return '⚠️ Deprecated'
+    return '⛔ Deprecated'
   }
 
   if (parameters?.experimental) {
@@ -21,155 +22,163 @@ const findComponentState = (parameters: {
 }
 
 const componentsNames = Object.keys(components)
-let modules: PromiseSettledResult<{
-  default: {
-    title: string
-    parameters: {
-      deprecated: boolean
-    }
-  }
-}>[]
 
-Promise.allSettled(
-  componentsNames?.map(
-    name => import(`../../components/${name}/__stories__/index.stories`),
-  ),
-)
-  .then(module => {
-    modules = module
-  })
-  .catch(() => {})
+const ComponentState = () => {
+  const [modules, setModules] = useState<
+    | PromiseSettledResult<{
+        default: { title: string; parameters: { deprecated: boolean } }
+      }>[]
+    | null
+  >(null)
 
-const ComponentState = () => (
-  <Stack gap={4}>
-    <Text as="p" variant="body">
-      Here you will find all our components and their states. They are updated
-      automatically based on configuration of the component story.
-    </Text>
+  useEffect(() => {
+    Promise.allSettled(
+      componentsNames.map(
+        name =>
+          import(`../../components/${name}/__stories__/index.stories.tsx`),
+      ),
+    )
+      .then(localModules => {
+        setModules(localModules)
+      })
+      .catch(error => {
+        console.error('Error loading component stories:', error)
+      })
+  }, [])
 
-    <Stack gap={3}>
-      <Text as="h2" variant="heading">
-        Definition of states
-      </Text>
-      <Stack gap={1}>
-        <Text as="h3" variant="headingSmall">
-          ✅ Stable
-        </Text>
-        <Text as="p" variant="body">
-          Stable state means the component is ready for production. If a
-          breaking change occurs it will generate a major version.
-        </Text>
-      </Stack>
-
-      <Stack gap={1}>
-        <Text as="h3" variant="headingSmall">
-          🧪 Experimental
-        </Text>
-        <Text as="p" variant="body">
-          Experimental state means the component is being tested and props might
-          change in the future. The component itself might even disappear if we
-          don&apos;t find a real purpose for it. This state is also used for new
-          version of a component (ex: Button v2) that we want to test before
-          replacing the old one. In any case{' '}
-          <Text as="span" variant="bodyStronger">
-            this state means the component is not ready for production
-          </Text>
-          .
-        </Text>
-        <Text variant="body" as="p">
-          An experimental component won&apos;t generate major version when
-          having a breaking change.
-        </Text>
-      </Stack>
-
-      <Stack gap={1}>
-        <Text as="h3" variant="headingSmall">
-          ⚠️ Deprecated
-        </Text>
-        <Text as="p" variant="body">
-          Deprecated state means the component is not recommended for use and
-          will be removed in the future. When seeing a component you use being
-          deprecated you should start migrating to another component as soon as
-          possible. To know what to use instead you can check the story of the
-          deprecated component.
-        </Text>
-      </Stack>
-    </Stack>
-    <Stack gap={3}>
-      <Text as="h2" variant="heading">
-        Components list
+  return (
+    <Stack gap={4}>
+      <Text as="p" variant="body">
+        Here you will find all our components and their states. They are updated
+        automatically based on configuration of the component story.
       </Text>
 
-      <Stack gap={1}>
-        <Text as="p" variant="body">
-          <Text as="span" variant="bodyStronger">
-            Number of components
-          </Text>
-          : {componentsNames.length}
+      <Stack gap={3}>
+        <Text as="h2" variant="heading">
+          Definition of states
         </Text>
-        <Table
-          columns={[
-            { label: 'Name' },
-            { label: 'Category' },
-            { label: 'State' },
-          ]}
-          stripped
-        >
-          <Table.Body>
-            {modules?.map(module => {
-              if (module.status === 'fulfilled') {
-                const desctructuredName: string[] =
-                  module.value.default.title
-                    .replace('Components/', '')
-                    .split('/') ?? []
+        <Stack gap={1}>
+          <Text as="h3" variant="headingSmall">
+            ✅ Stable
+          </Text>
+          <Text as="p" variant="body">
+            Stable state means the component is ready for production. If a
+            breaking change occurs it will generate a major version.
+          </Text>
+        </Stack>
 
-                const componentCategory = desctructuredName[1]
-                  ? desctructuredName[0]
-                  : 'Others'
-                const componentName = desctructuredName[1]
-                  ? desctructuredName[1]
-                  : desctructuredName[0]
+        <Stack gap={1}>
+          <Text as="h3" variant="headingSmall">
+            🧪 Experimental
+          </Text>
+          <Text as="p" variant="body">
+            Experimental state means the component is being tested and props
+            might change in the future. The component itself might even
+            disappear if we don&apos;t find a real purpose for it. This state is
+            also used for new version of a component (ex: Button v2) that we
+            want to test before replacing the old one. In any case{' '}
+            <Text as="span" variant="bodyStronger">
+              this state means the component is not ready for production
+            </Text>
+            .
+          </Text>
+          <Text variant="body" as="p">
+            An experimental component won&apos;t generate major version when
+            having a breaking change.
+          </Text>
+        </Stack>
 
-                const componentState = findComponentState(
-                  module.value.default.parameters,
-                )
+        <Stack gap={1}>
+          <Text as="h3" variant="headingSmall">
+            ⛔ Deprecated
+          </Text>
+          <Text as="p" variant="body">
+            Deprecated state means the component is not recommended for use and
+            will be removed in the future. When seeing a component you use being
+            deprecated you should start migrating to another component as soon
+            as possible. To know what to use instead you can check the story of
+            the deprecated component.
+          </Text>
+        </Stack>
+      </Stack>
+      <Stack gap={3}>
+        <Text as="h2" variant="heading">
+          Components list
+        </Text>
 
-                return (
-                  <Table.Row
-                    key={module.value.default.title}
-                    id={module.value.default.title}
-                  >
-                    <Table.Cell>
-                      <Text as="span" variant="bodyStrong">
-                        <Button
-                          onClick={linkTo(module.value.default.title)}
-                          variant="ghost"
-                        >
-                          {componentName}
-                        </Button>
-                      </Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text as="span" variant="body">
-                        {componentCategory}
-                      </Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text as="span" variant="body">
-                        {componentState}
-                      </Text>
-                    </Table.Cell>
-                  </Table.Row>
-                )
-              }
+        <Stack gap={1}>
+          <Text as="p" variant="body">
+            <Text as="span" variant="bodyStronger">
+              Number of components
+            </Text>
+            : {componentsNames.length}
+          </Text>
+          <Table
+            columns={[
+              { label: 'Name' },
+              { label: 'Category' },
+              { label: 'State' },
+            ]}
+            stripped
+            loading={!modules}
+          >
+            <Table.Body>
+              {modules?.map(module => {
+                if (module.status === 'fulfilled') {
+                  const desctructuredName: string[] =
+                    module.value.default.title
+                      .replace('Components/', '')
+                      .split('/') ?? []
 
-              return null
-            })}
-          </Table.Body>
-        </Table>
+                  const componentCategory = desctructuredName[1]
+                    ? desctructuredName[0]
+                    : 'Others'
+                  const componentName = desctructuredName[1]
+                    ? desctructuredName[1]
+                    : desctructuredName[0]
+
+                  const componentState = findComponentState(
+                    module.value.default.parameters,
+                  )
+
+                  return (
+                    <Table.Row
+                      key={module.value.default.title}
+                      id={module.value.default.title}
+                    >
+                      <Table.Cell>
+                        <Text as="span" variant="bodyStrong">
+                          <Button
+                            onClick={linkTo(module.value.default.title)}
+                            variant="ghost"
+                            size="small"
+                          >
+                            {componentName}
+                          </Button>
+                        </Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text as="span" variant="body">
+                          {componentCategory}
+                        </Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text as="span" variant="body">
+                          {componentState}
+                        </Text>
+                      </Table.Cell>
+                    </Table.Row>
+                  )
+                }
+
+                return null
+              })}
+            </Table.Body>
+          </Table>
+        </Stack>
       </Stack>
     </Stack>
-  </Stack>
-)
+  )
+}
 
 export default ComponentState

--- a/packages/ui/src/components/Avatar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/index.stories.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '..'
 export default {
   component: Avatar,
   title: 'Components/Other/Avatar',
+  tags: ['deprecated'],
   parameters: {
     deprecated: true,
     deprecatedReason: 'This component is deprecated, use AvatarV2 instead.',

--- a/packages/ui/src/components/Dialog/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Dialog/__stories__/index.stories.tsx
@@ -7,6 +7,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
 } as Meta<typeof Dialog>
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/LineChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/LineChart/__stories__/index.stories.tsx
@@ -7,6 +7,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/Menu/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Menu/__stories__/index.stories.tsx
@@ -10,6 +10,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['deprecated'],
   parameters: {
     deprecated: true,
     deprecatedReason:

--- a/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
@@ -15,6 +15,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['deprecated'],
   parameters: {
     deprecated: true,
     deprecatedReason:

--- a/packages/ui/src/components/NumberInputV2/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/NumberInputV2/__stories__/index.stories.tsx
@@ -17,6 +17,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
   title: 'Components/Data Entry/NumberInputV2',
 } as Meta<typeof NumberInputV2>
 

--- a/packages/ui/src/components/PasswordStrengthMeter/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/PasswordStrengthMeter/__stories__/index.stories.tsx
@@ -3,6 +3,7 @@ import { PasswordStrengthMeter } from '..'
 
 export default {
   component: PasswordStrengthMeter,
+  tags: ['deprecated'],
   parameters: {
     deprecated: true,
     deprecatedReason: 'This component is deprecated, please use Meter instead.',

--- a/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
@@ -7,6 +7,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
 } as Meta<typeof PieChart>
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/Row/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Row/__stories__/index.stories.tsx
@@ -3,9 +3,6 @@ import { Row } from '..'
 
 export default {
   component: Row,
-  parameters: {
-    experimental: true,
-  },
   title: 'Components/Layout/Row',
 } as Meta<typeof Row>
 

--- a/packages/ui/src/components/Row/index.tsx
+++ b/packages/ui/src/components/Row/index.tsx
@@ -51,7 +51,6 @@ type RowProps = {
 
 /**
  * Row component is a wrapper for grid layout.
- * @experimental This component is experimental and may be subject to breaking changes in the future.
  */
 export const Row = ({
   className,

--- a/packages/ui/src/components/SelectInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/index.stories.tsx
@@ -10,6 +10,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['deprecated'],
   parameters: {
     deprecated: true,
     deprecatedReason:

--- a/packages/ui/src/components/SelectInputV2/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/index.stories.tsx
@@ -6,6 +6,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
   decorators: [
     StoryComponent => (
       <div style={{ marginBottom: 400 }}>

--- a/packages/ui/src/components/Slider/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Slider/__stories__/index.stories.tsx
@@ -4,9 +4,6 @@ import { Slider } from '..'
 export default {
   component: Slider,
   title: 'Components/Data Entry/Slider',
-  parameters: {
-    experimental: true,
-  },
 } as Meta<typeof Slider>
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/StepList/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/StepList/__stories__/index.stories.tsx
@@ -10,6 +10,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
   title: 'Components/Data Display/StepList',
 } as Meta
 

--- a/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
@@ -4,6 +4,7 @@ import { TextInput } from '..'
 export default {
   component: TextInput,
   title: 'Components/Data Entry/TextInput',
+  tags: ['deprecated'],
   parameters: {
     deprecated: true,
     deprecatedReason:

--- a/packages/ui/src/components/TextInputV2/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextInputV2/__stories__/index.stories.tsx
@@ -7,6 +7,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
 } as Meta<typeof TextInputV2>
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
@@ -6,6 +6,7 @@ export default {
   parameters: {
     experimental: true,
   },
+  tags: ['experimental'],
   title: 'Components/Data Entry/TimeInput',
   decorators: [
     Story => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       storybook:
         specifier: 8.4.5
         version: 8.4.5(prettier@2.8.8)
+      storybook-addon-tag-badges:
+        specifier: 1.2.0
+        version: 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@2.8.8))
       svgo:
         specifier: 3.3.2
         version: 3.3.2
@@ -7049,6 +7052,12 @@ packages:
 
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
+
+  storybook-addon-tag-badges@1.2.0:
+    resolution: {integrity: sha512-qkpmkeY0pSBphOBUppCwpJ8+5X3IPVRlHzLaBABSOiy3jpgpt+PDaxu1kEg8qaCixBE0pDHY5wKSO6sw/RdN4w==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      storybook: ^8.4.2
 
   storybook@8.4.5:
     resolution: {integrity: sha512-9tfgabXnMibYp3SvoaJXXMD63Pw0SA9Hnf5v6TxysCYZs4DZ/04fAkK+9RW+K4C5JkV83qXMMlrsPj766R47fg==}
@@ -15461,6 +15470,14 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.8.0: {}
+
+  storybook-addon-tag-badges@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@2.8.8)):
+    dependencies:
+      '@storybook/icons': 1.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 8.4.5(prettier@2.8.8)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   storybook@8.4.5(prettier@2.8.8):
     dependencies:


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Update component state page to make it work and add tags so they are visible in the menu.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1025" alt="Screenshot 2024-11-19 at 18 18 15" src="https://github.com/user-attachments/assets/c330b18e-8746-4cdf-87d1-cf6b510184b6"> | <img width="1039" alt="Screenshot 2024-11-19 at 18 18 03" src="https://github.com/user-attachments/assets/f54c4242-b210-4ce4-b4dd-d8f84787d520"> |

<img width="276" alt="Screenshot 2024-11-19 at 18 17 37" src="https://github.com/user-attachments/assets/943bf9e1-75ca-4d1e-b2f8-9a4b40361743">
