### PR TITLE
fix(Form): fix minDate and maxDate validators

### DIFF
--- a/.changeset/strong-dancers-repeat.md
+++ b/.changeset/strong-dancers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+`DateField`: fix minDate and maxDate validators

--- a/packages/form/src/components/DateField/__stories__/MinMaxDateRange.stories.tsx
+++ b/packages/form/src/components/DateField/__stories__/MinMaxDateRange.stories.tsx
@@ -1,0 +1,23 @@
+import type { StoryFn } from '@storybook/react'
+import { Stack } from '@ultraviolet/ui'
+import type { ComponentProps } from 'react'
+import { DateField } from '..'
+import { Submit } from '../../Submit'
+
+export const MinMaxDateRange: StoryFn<
+  ComponentProps<typeof DateField>
+> = args => (
+  <Stack gap={1}>
+    <DateField {...args} />
+    <Submit>Submit</Submit>
+  </Stack>
+)
+
+MinMaxDateRange.args = {
+  // A month ago
+  minDate: new Date(Date.now() - 60 * 60 * 24 * 30 * 1000),
+  maxDate: new Date(Date.now()),
+  name: 'date',
+  required: true,
+  selectsRange: true,
+}

--- a/packages/form/src/components/DateField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/DateField/__stories__/index.stories.tsx
@@ -8,7 +8,9 @@ export default {
   component: DateField,
   decorators: [
     ChildStory => {
-      const methods = useForm()
+      const methods = useForm({
+        mode: 'onChange',
+      })
       const {
         errors,
         isDirty,
@@ -79,3 +81,4 @@ export { Playground } from './Playground.stories'
 export { Required } from './Required.stories'
 export { MinMaxDate } from './MinMaxDate.stories'
 export { MinMaxDateWithTimeField } from './MinMaxWithTimeField.stories'
+export { MinMaxDateRange } from './MinMaxDateRange.stories'

--- a/packages/form/src/validators/maxDate.ts
+++ b/packages/form/src/validators/maxDate.ts
@@ -1,2 +1,5 @@
-export const maxDateValidator = (maxDate?: Date) => (value: Date) =>
-  value === undefined || maxDate === undefined || value <= maxDate
+export const maxDateValidator =
+  (maxDate?: Date) => (value: Date | [Date, Date]) =>
+    value === undefined ||
+    maxDate === undefined ||
+    (Array.isArray(value) ? value[1] <= maxDate : value <= maxDate)

--- a/packages/form/src/validators/minDate.ts
+++ b/packages/form/src/validators/minDate.ts
@@ -1,2 +1,5 @@
-export const minDateValidator = (minDate?: Date) => (value: Date) =>
-  value === undefined || minDate === undefined || value >= minDate
+export const minDateValidator =
+  (maxDate?: Date) => (value: Date | [Date, Date]) =>
+    value === undefined ||
+    maxDate === undefined ||
+    (Array.isArray(value) ? value[0] >= maxDate : value >= maxDate)


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:
`minDateValidator` and `maxDateValidator` were not supporting dates range causing a validation error each time we were using DateField with both `selectRanges` and `minDate/maxDate`