### PR TITLE
fix(Snippet): snippet height

### DIFF
--- a/.changeset/hot-rockets-watch.md
+++ b/.changeset/hot-rockets-watch.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Snippet />` height

--- a/packages/ui/src/components/Snippet/__stories__/Multiline.stories.tsx
+++ b/packages/ui/src/components/Snippet/__stories__/Multiline.stories.tsx
@@ -3,10 +3,8 @@ import { Template } from './Template.stories'
 export const Multiline = Template.bind({})
 
 Multiline.args = {
-  children: `
-# Install the package and start it
+  children: `# Install the package and start it
 pnpm add @ultraviolet/ui
 pnpm install
-pnpm start
-`,
+pnpm start`,
 }

--- a/packages/ui/src/components/Snippet/__stories__/Prefixes.stories.tsx
+++ b/packages/ui/src/components/Snippet/__stories__/Prefixes.stories.tsx
@@ -2,11 +2,9 @@ import type { Decorator } from '@storybook/react'
 import type { ComponentProps } from 'react'
 import { Snippet } from '../index'
 
-const VALUE = `
-pnpm add @ultraviolet/ui
+const VALUE = `pnpm add @ultraviolet/ui
 pnpm install
-pnpm start
-`
+pnpm start`
 
 export const Prefixes = (props: ComponentProps<typeof Snippet>) =>
   (['command', 'lines'] as const).map(suffix => (

--- a/packages/ui/src/components/Snippet/__stories__/Rows.stories.tsx
+++ b/packages/ui/src/components/Snippet/__stories__/Rows.stories.tsx
@@ -23,7 +23,7 @@ pnpm build
 
 # Test
 pnpm test:unit`,
-  rows: 20,
+  rows: 18,
 }
 
 Rows.parameters = {

--- a/packages/ui/src/components/Snippet/index.tsx
+++ b/packages/ui/src/components/Snippet/index.tsx
@@ -233,6 +233,10 @@ export const Snippet = ({
   const numberOfLines = lines.length
   const multiline = numberOfLines > 1
   const hasShowMoreButton = numberOfLines > rows && multiline && !noExpandable
+  // Height of the expandable (when needed) = number of rows * height of a line (from rem to px) + padding (from rem to px)
+  const minHeight =
+    rows * parseFloat(theme.typography.code.lineHeight) * 16 +
+    parseFloat(theme.space[4]) * 16
 
   return (
     <Container
@@ -242,14 +246,7 @@ export const Snippet = ({
     >
       <StyledStack>
         {hasShowMoreButton ? (
-          // Height = number of rows * height of a line + padding
-          <Expandable
-            minHeight={
-              rows * parseInt(theme.typography.code.lineHeight, 10) +
-              parseInt(theme.space[4], 10)
-            }
-            opened={showMore}
-          >
+          <Expandable minHeight={minHeight} opened={showMore}>
             <CodeContent
               prefix={prefix}
               multiline={multiline}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix snippet height problem due to switch from pixels to rem

| Before  |  <img width="1124" alt="Capture d’écran 2024-11-25 à 14 36 49" src="https://github.com/user-attachments/assets/40ebfea9-b92f-42f7-8bdd-3a6b1c203539"> |  
| :--- | :--------: |
| After  | <img width="1124" alt="Capture d’écran 2024-11-25 à 14 36 15" src="https://github.com/user-attachments/assets/f78ca66a-86ad-4f88-a00f-717783b0738f">  |