### PR TITLE
fix: all groups input to accept react node as legend

### DIFF
--- a/.changeset/strong-trains-rule.md
+++ b/.changeset/strong-trains-rule.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<RadioGroup />`, `<SelectableCardGroup />`, `<CheckboxGroup />` and `<ToggleGroup />` to accept `ReactNode` as `legend` type

--- a/packages/ui/src/components/CheckboxGroup/index.tsx
+++ b/packages/ui/src/components/CheckboxGroup/index.tsx
@@ -95,7 +95,7 @@ const StyledRequiredIcon = styled(AsteriskIcon)`
 `
 
 type CheckboxGroupProps = {
-  legend: string
+  legend: ReactNode
   value?: string[]
   className?: string
   helper?: ReactNode

--- a/packages/ui/src/components/RadioGroup/index.tsx
+++ b/packages/ui/src/components/RadioGroup/index.tsx
@@ -88,7 +88,7 @@ const StyledRequiredIcon = styled(AsteriskIcon)`
 `
 
 type RadioGroupProps = {
-  legend: string
+  legend: ReactNode
   value: string | number
   className?: string
   helper?: ReactNode

--- a/packages/ui/src/components/SelectableCardGroup/index.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/index.tsx
@@ -92,7 +92,7 @@ const StyledRequiredIcon = styled(AsteriskIcon)`
 `
 
 type SelectableCardGroupProps = {
-  legend?: string
+  legend?: ReactNode
   value: string | number | (string | number)[]
   className?: string
   helper?: ReactNode

--- a/packages/ui/src/components/ToggleGroup/index.tsx
+++ b/packages/ui/src/components/ToggleGroup/index.tsx
@@ -81,7 +81,7 @@ const StyledRequiredIcon = styled(AsteriskIcon)`
 `
 
 type ToggleGroupProps = {
-  legend: string
+  legend: ReactNode
   value?: string[]
   className?: string
   helper?: ReactNode


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

`<RadioGroup />`, `<SelectableCardGroup />`, `<CheckboxGroup />` and `<ToggleGroup />` to accept `ReactNode` as `legend` type.