### PR TITLE
fix: table and list to hide scroll bar is no overflow

### DIFF
--- a/.changeset/dry-cats-hope.md
+++ b/.changeset/dry-cats-hope.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Hide scroll bar on `Table` and `List` if there is no overflow on x

--- a/packages/ui/src/components/List/HeaderRow.tsx
+++ b/packages/ui/src/components/List/HeaderRow.tsx
@@ -1,10 +1,9 @@
-import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { ReactNode } from 'react'
 import { Checkbox } from '../Checkbox'
 import { HeaderCell } from './HeaderCell'
 import { useListContext } from './ListContext'
-import { EXPANDABLE_COLUMN_SIZE, SELECTABLE_CHECKBOX_SIZE } from './constants'
+import { SELECTABLE_CHECKBOX_SIZE } from './constants'
 
 const StyledHeaderRow = styled.tr`
   /* List itself also apply style about common templating between HeaderRow and other Rows */
@@ -34,6 +33,8 @@ const NoPaddingHeaderCell = styled(HeaderCell)`
   &:first-of-type {
     padding-left: ${({ theme }) => theme.space['2']};
   }
+
+  max-width: ${({ theme }) => theme.sizing[SELECTABLE_CHECKBOX_SIZE]}
 `
 
 type RowProps = {
@@ -50,17 +51,13 @@ export const HeaderRow = ({ children, hasSelectAllColumn }: RowProps) => {
     expandButton,
   } = useListContext()
 
-  const theme = useTheme()
-
   const selectableRowCount = Object.keys(selectedRowIds).length
 
   return (
     <thead>
       <StyledHeaderRow>
         {hasSelectAllColumn ? (
-          <NoPaddingHeaderCell
-            maxWidth={theme.sizing[SELECTABLE_CHECKBOX_SIZE]}
-          >
+          <NoPaddingHeaderCell>
             <Checkbox
               name="list-select-checkbox"
               value="all"
@@ -72,9 +69,7 @@ export const HeaderRow = ({ children, hasSelectAllColumn }: RowProps) => {
           </NoPaddingHeaderCell>
         ) : null}
         {expandButton ? (
-          <NoPaddingHeaderCell maxWidth={theme.sizing[EXPANDABLE_COLUMN_SIZE]}>
-            {null}
-          </NoPaddingHeaderCell>
+          <NoPaddingHeaderCell>{null}</NoPaddingHeaderCell>
         ) : null}
         {children}
       </StyledHeaderRow>

--- a/packages/ui/src/components/List/HeaderRow.tsx
+++ b/packages/ui/src/components/List/HeaderRow.tsx
@@ -2,12 +2,9 @@ import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { ReactNode } from 'react'
 import { Checkbox } from '../Checkbox'
-import {
-  EXPANDABLE_COLUMN_SIZE,
-  SELECTABLE_CHECKBOX_SIZE,
-} from '../Table/constants'
 import { HeaderCell } from './HeaderCell'
 import { useListContext } from './ListContext'
+import { EXPANDABLE_COLUMN_SIZE, SELECTABLE_CHECKBOX_SIZE } from './constants'
 
 const StyledHeaderRow = styled.tr`
   /* List itself also apply style about common templating between HeaderRow and other Rows */
@@ -61,7 +58,9 @@ export const HeaderRow = ({ children, hasSelectAllColumn }: RowProps) => {
     <thead>
       <StyledHeaderRow>
         {hasSelectAllColumn ? (
-          <NoPaddingHeaderCell width={theme.sizing[SELECTABLE_CHECKBOX_SIZE]}>
+          <NoPaddingHeaderCell
+            maxWidth={theme.sizing[SELECTABLE_CHECKBOX_SIZE]}
+          >
             <Checkbox
               name="list-select-checkbox"
               value="all"
@@ -73,7 +72,7 @@ export const HeaderRow = ({ children, hasSelectAllColumn }: RowProps) => {
           </NoPaddingHeaderCell>
         ) : null}
         {expandButton ? (
-          <NoPaddingHeaderCell width={theme.sizing[EXPANDABLE_COLUMN_SIZE]}>
+          <NoPaddingHeaderCell maxWidth={theme.sizing[EXPANDABLE_COLUMN_SIZE]}>
             {null}
           </NoPaddingHeaderCell>
         ) : null}

--- a/packages/ui/src/components/List/Row.tsx
+++ b/packages/ui/src/components/List/Row.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { ForwardedRef, ReactNode } from 'react'
 import {
@@ -14,6 +15,7 @@ import { Checkbox } from '../Checkbox'
 import { Tooltip } from '../Tooltip'
 import { Cell } from './Cell'
 import { useListContext } from './ListContext'
+import { SELECTABLE_CHECKBOX_SIZE } from './constants'
 import type { ColumnProps } from './types'
 
 const ExpandableWrapper = styled.tr`
@@ -151,12 +153,18 @@ const StyledCheckboxContainer = styled.div`
   display: flex;
 `
 
-const NoPaddingCell = styled(Cell)`
+const NoPaddingCell = styled(Cell, {
+  shouldForwardProp: prop => !['maxWidth'].includes(prop),
+})<{
+  maxWidth: string
+}>`
   padding: 0;
 
   &:first-of-type {
     padding-left: ${({ theme }) => theme.space['2']};
   }
+
+  max-width: ${({ maxWidth }) => maxWidth};
 `
 
 const ExpandableCell = styled(Cell, {
@@ -215,6 +223,8 @@ export const Row = forwardRef(
       inRange,
       columns,
     } = useListContext()
+
+    const theme = useTheme()
 
     const expandedRowId = useId()
 
@@ -296,7 +306,10 @@ export const Row = forwardRef(
           columnsStartAt={(selectable ? 1 : 0) + (expandButton ? 1 : 0)}
         >
           {selectable ? (
-            <NoPaddingCell preventClick={canClickRowToExpand}>
+            <NoPaddingCell
+              preventClick={canClickRowToExpand}
+              maxWidth={theme.sizing[SELECTABLE_CHECKBOX_SIZE]}
+            >
               <StyledCheckboxContainer>
                 <Tooltip
                   text={
@@ -326,7 +339,7 @@ export const Row = forwardRef(
             </NoPaddingCell>
           ) : null}
           {expandButton ? (
-            <NoPaddingCell>
+            <NoPaddingCell maxWidth={theme.sizing[SELECTABLE_CHECKBOX_SIZE]}>
               <Button
                 disabled={disabled || !expandable}
                 icon={expandedRowIds[id] ? 'arrow-up' : 'arrow-down'}

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,12 +4,12 @@ exports[`List > Should expand a row by pressing Space 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -708,12 +708,12 @@ exports[`List > Should not collapse a row by clicking on expandable content 1`] 
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -1462,7 +1462,7 @@ exports[`List > Should render correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -2001,12 +2001,12 @@ exports[`List > Should render correctly with bad sort value 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -2694,7 +2694,7 @@ exports[`List > Should render correctly with disabled rows 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -3243,7 +3243,7 @@ exports[`List > Should render correctly with expandable rows 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -3802,12 +3802,12 @@ exports[`List > Should render correctly with info 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -4602,12 +4602,12 @@ exports[`List > Should render correctly with isExpandable and autoClose rows the
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -5356,12 +5356,12 @@ exports[`List > Should render correctly with isExpandable rows then click 1`] = 
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -6079,7 +6079,7 @@ exports[`List > Should render correctly with loading 1`] = `
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -6810,7 +6810,7 @@ exports[`List > Should render correctly with loading with selectable 1`] = `
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -7901,12 +7901,12 @@ exports[`List > Should render correctly with preventClick cell then click but ev
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -8594,7 +8594,7 @@ exports[`List > Should render correctly with row expanded 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -9133,7 +9133,7 @@ exports[`List > Should render correctly with selectable 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -10783,12 +10783,12 @@ exports[`List > Should render correctly with selectable then click on first row 
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -13048,12 +13048,12 @@ exports[`List > Should render correctly with selectable with shift click for mul
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -15311,7 +15311,7 @@ exports[`List > Should render correctly with sentiment rows 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -15865,7 +15865,7 @@ exports[`List > Should render correctly with sort 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -16404,12 +16404,12 @@ exports[`List > Should render correctly with sort then click 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -6852,8 +6852,8 @@ exports[`List > Should render correctly with loading with selectable 1`] = `
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  max-width: 2.5rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-7[role*='button'] {
@@ -9175,8 +9175,8 @@ exports[`List > Should render correctly with selectable 1`] = `
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  max-width: 2.5rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-7[role*='button'] {
@@ -10860,8 +10860,8 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  max-width: 2.5rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-7[role*='button'] {
@@ -10890,8 +10890,8 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  max-width: 2.5rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-7[role*='button'] {
@@ -13127,8 +13127,8 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  max-width: 2.5rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-7[role*='button'] {
@@ -13157,8 +13157,8 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  max-width: 2.5rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-7[role*='button'] {

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -6852,7 +6852,7 @@ exports[`List > Should render correctly with loading with selectable 1`] = `
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  width: 2.5rem;
+  max-width: 2.5rem;
   padding: 0;
 }
 
@@ -9175,7 +9175,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  width: 2.5rem;
+  max-width: 2.5rem;
   padding: 0;
 }
 
@@ -9588,6 +9588,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   height: 3.75rem;
   padding: 0 1rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-46:first-of-type {
@@ -10859,7 +10860,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  width: 2.5rem;
+  max-width: 2.5rem;
   padding: 0;
 }
 
@@ -10889,7 +10890,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  width: 2.5rem;
+  max-width: 2.5rem;
   padding: 0;
 }
 
@@ -11689,6 +11690,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   height: 3.75rem;
   padding: 0 1rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-46:first-of-type {
@@ -11701,6 +11703,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   height: 3.75rem;
   padding: 0 1rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-46:first-of-type {
@@ -13124,7 +13127,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  width: 2.5rem;
+  max-width: 2.5rem;
   padding: 0;
 }
 
@@ -13154,7 +13157,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #3f4250;
   gap: 0.5rem;
   padding: 0 1rem;
-  width: 2.5rem;
+  max-width: 2.5rem;
   padding: 0;
 }
 
@@ -13954,6 +13957,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   height: 3.75rem;
   padding: 0 1rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-48:first-of-type {
@@ -13966,6 +13970,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   height: 3.75rem;
   padding: 0 1rem;
   padding: 0;
+  max-width: 2.5rem;
 }
 
 .emotion-48:first-of-type {

--- a/packages/ui/src/components/List/constants.tsx
+++ b/packages/ui/src/components/List/constants.tsx
@@ -1,2 +1,2 @@
-export const SELECTABLE_CHECKBOX_SIZE = 24
-export const EXPANDABLE_COLUMN_SIZE = 32
+export const SELECTABLE_CHECKBOX_SIZE = '500' // sizing token from theme
+export const EXPANDABLE_COLUMN_SIZE = '500'

--- a/packages/ui/src/components/List/index.tsx
+++ b/packages/ui/src/components/List/index.tsx
@@ -12,7 +12,7 @@ import type { ColumnProps } from './types'
 
 const TableContainer = styled.div`
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 `
 
 const StyledTable = styled.table`

--- a/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Table > Should render correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -491,12 +491,12 @@ exports[`Table > Should render correctly with bad sort value 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -1098,12 +1098,12 @@ exports[`Table > Should render correctly with highlight animation on Table.Row 1
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -1679,12 +1679,12 @@ exports[`Table > Should render correctly with info 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -2265,7 +2265,7 @@ exports[`Table > Should render correctly with loading 1`] = `
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -2904,12 +2904,12 @@ exports[`Table > Should render correctly with selectDisabled as a string 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -3501,12 +3501,12 @@ exports[`Table > Should render correctly with selectable and shift click 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -5164,12 +5164,12 @@ exports[`Table > Should render correctly with selectable then click on first row
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -6829,12 +6829,12 @@ exports[`Table > Should render correctly with sort then click 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {
@@ -7561,12 +7561,12 @@ exports[`Table > Should render correctly with stipped 1`] = `
 <DocumentFragment>
   .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-0 {
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .emotion-2 {

--- a/packages/ui/src/components/Table/index.tsx
+++ b/packages/ui/src/components/Table/index.tsx
@@ -16,7 +16,7 @@ import type { ColumnProps } from './types'
 
 const TableContainer = styled.div`
   min-width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 `
 
 type StyledTableProps = {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Hide scroll bar on overflow x if there is no overflow.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2024-12-16 at 08 55 32](https://github.com/user-attachments/assets/3f86c8f4-4886-449a-b1db-5ad81d648fbd) | ![Screenshot 2024-12-16 at 08 55 39](https://github.com/user-attachments/assets/64be13e4-fcd6-4113-8dcf-d8d67fb54447) |
| url | ![Screenshot 2024-12-16 at 11 19 17](https://github.com/user-attachments/assets/7cba74ea-7414-4b79-8560-db6382508604) | ![Screenshot 2024-12-16 at 11 19 25](https://github.com/user-attachments/assets/68f76d53-3204-4195-9353-49277a0eeba2) |
