### PR TITLE
fix(Slider): thumb position

### DIFF
--- a/.changeset/beige-houses-own.md
+++ b/.changeset/beige-houses-own.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<Slider />`: fix thumb position (firefox)

--- a/packages/ui/src/components/Slider/__tests__/__snapshots__/doubleSlider.test.tsx.snap
+++ b/packages/ui/src/components/Slider/__tests__/__snapshots__/doubleSlider.test.tsx.snap
@@ -5819,6 +5819,10 @@ exports[`Double slider > renders correctly double custom tooltip 1`] = `
   position: absolute;
   left: calc(12% - 8px);
   top: -8px;
+  -webkit-transform: translate(0, -10px);
+  -moz-transform: translate(0, -10px);
+  -ms-transform: translate(0, -10px);
+  transform: translate(0, -10px);
 }
 
 .emotion-28::-moz-range-thumb:hover,
@@ -5945,6 +5949,10 @@ exports[`Double slider > renders correctly double custom tooltip 1`] = `
   position: absolute;
   left: calc(14% - 8px);
   top: -8px;
+  -webkit-transform: translate(0, -10px);
+  -moz-transform: translate(0, -10px);
+  -ms-transform: translate(0, -10px);
+  transform: translate(0, -10px);
 }
 
 .emotion-32::-moz-range-thumb:hover,
@@ -6576,6 +6584,10 @@ exports[`Double slider > renders correctly double default toolipt  1`] = `
   position: absolute;
   left: calc(12% - 8px);
   top: -8px;
+  -webkit-transform: translate(0, -10px);
+  -moz-transform: translate(0, -10px);
+  -ms-transform: translate(0, -10px);
+  transform: translate(0, -10px);
 }
 
 .emotion-28::-moz-range-thumb:hover,
@@ -6702,6 +6714,10 @@ exports[`Double slider > renders correctly double default toolipt  1`] = `
   position: absolute;
   left: calc(14% - 8px);
   top: -8px;
+  -webkit-transform: translate(0, -10px);
+  -moz-transform: translate(0, -10px);
+  -ms-transform: translate(0, -10px);
+  transform: translate(0, -10px);
 }
 
 .emotion-32::-moz-range-thumb:hover,
@@ -13629,6 +13645,10 @@ exports[`Double slider > renders correctly double with single tooltip 1`] = `
   position: absolute;
   left: calc(12% - 8px);
   top: -8px;
+  -webkit-transform: translate(0, -10px);
+  -moz-transform: translate(0, -10px);
+  -ms-transform: translate(0, -10px);
+  transform: translate(0, -10px);
 }
 
 .emotion-28::-moz-range-thumb:hover,
@@ -13755,6 +13775,10 @@ exports[`Double slider > renders correctly double with single tooltip 1`] = `
   position: absolute;
   left: calc(14% - 8px);
   top: -8px;
+  -webkit-transform: translate(0, -10px);
+  -moz-transform: translate(0, -10px);
+  -ms-transform: translate(0, -10px);
+  transform: translate(0, -10px);
 }
 
 .emotion-30::-moz-range-thumb:hover,

--- a/packages/ui/src/components/Slider/components/DoubleSlider.tsx
+++ b/packages/ui/src/components/Slider/components/DoubleSlider.tsx
@@ -18,8 +18,15 @@ const StyledTextValue = styled(Text, {
 `
 
 const SliderElement = styled('input', {
-  shouldForwardProp: prop => !['themeSlider', 'suffix', 'left'].includes(prop),
-})<{ themeSlider: string; disabled: boolean; suffix: boolean; left: number }>`
+  shouldForwardProp: prop =>
+    !['themeSlider', 'suffix', 'left', 'hasTooltip'].includes(prop),
+})<{
+  themeSlider: string
+  disabled: boolean
+  suffix: boolean
+  left: number
+  hasTooltip: boolean
+}>`
   position: absolute;
   width: 100%;
   pointer-events: none;
@@ -35,11 +42,11 @@ const SliderElement = styled('input', {
       box-shadow: ${({ theme, disabled }) => (disabled ? null : theme.shadows.focusPrimary)};
       }
 
-      &::-webkit-slider-thumb {
-        border: ${({ theme, disabled }) => (disabled ? null : `1.5px solid ${theme.colors.primary.border}`)};
+    &::-webkit-slider-thumb {
+      border: ${({ theme, disabled }) => (disabled ? null : `1.5px solid ${theme.colors.primary.border}`)};
       box-shadow: ${({ theme, disabled }) => (disabled ? null : theme.shadows.focusPrimary)};
 
-      }
+    }
   }
 
   /* Mozilla */
@@ -48,6 +55,10 @@ const SliderElement = styled('input', {
   }
   &::-moz-range-thumb {
     ${({ theme, themeSlider, disabled, left }) => thumbStyle(theme, themeSlider, disabled, left, true)}
+    ${({ hasTooltip }) =>
+      hasTooltip &&
+      `transform: translate(0, -10px); 
+`}
     }
 
   /* Other browsers */
@@ -400,6 +411,7 @@ export const DoubleSlider = ({
                 themeSlider={theme}
                 ref={refSlider}
                 left={((selectedIndexes[0] - min) * 100) / (max - min)}
+                hasTooltip={!!tooltip}
               />
             </StyledTooltip>
             <StyledTooltip
@@ -432,6 +444,7 @@ export const DoubleSlider = ({
                 }}
                 themeSlider={theme}
                 left={((selectedIndexes[1] - min) * 100) / (max - min)}
+                hasTooltip={!!tooltip}
               />
             </StyledTooltip>
           </StyledTooltip>


### PR DESCRIPTION
## Summary

## Type

- Bug
- 
### Summarise concisely:

#### What is expected?

The thumb of the double slider was not centered on firefox when there was a tooltip. Fixed it
Before : 
<img width="251" alt="Capture d’écran 2025-01-03 à 18 06 19" src="https://github.com/user-attachments/assets/17976198-1f3e-4c3a-ac23-3347dec676a5" />
After : 
<img width="251" alt="Capture d’écran 2025-01-03 à 18 06 26" src="https://github.com/user-attachments/assets/c4221299-d1b6-417d-a965-2b2fb0305818" />
