### PR TITLE
docs(storybook): add dots in background for better visual

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -26,17 +26,17 @@ const parameters: Preview['parameters'] = {
     values: [
       {
         name: 'light',
-        value: '#ffffff',
+        value: 'linear-gradient(90deg,#ffffff 10px,transparent 1%) 50%,linear-gradient(#ffffff 10px,transparent 1%) 50%,#eceef2',
         textColor: '#3f4250',
       },
       {
         name: 'dark',
-        value: '#151a2d',
+        value: 'linear-gradient(90deg,#151a2d 10px,transparent 1%) 50%,linear-gradient(#151a2d 10px,transparent 1%) 50%,#303445',
         textColor: '#b8bac0',
       },
       {
         name: 'darker',
-        value: '#000000',
+        value: 'linear-gradient(90deg,#000000 10px,transparent 1%) 50%,linear-gradient(#000000 10px,transparent 1%) 50%,#151a2d',
         textColor: '#d8d9dc',
       },
     ],
@@ -80,22 +80,24 @@ const parameters: Preview['parameters'] = {
 }
 
 const getThemeColor = (theme: string) => {
-  const { value: backgroundColor, textColor } =
+  const { value: background, textColor } =
     parameters['backgrounds'].values.find(
       ({ name }: { name: string }) => name === theme,
     ) ?? parameters['backgrounds'].values[0]
 
-  return { backgroundColor, textColor }
+  return { background, textColor }
 }
 
-const withThemeProvider = (Story: StoryFn, context: { globals: any }) => {
+const withThemeProvider = (Story: StoryFn, context: { globals: { theme: string } }) => {
   const { theme } = context.globals
-  const { backgroundColor, textColor } = getThemeColor(theme)
+  const { background, textColor } = getThemeColor(theme)
 
   return (
     <div
       style={{
-        backgroundColor,
+        background,
+        backgroundPosition: '-4px -4px',
+        backgroundSize: '12px 12px',
         padding: '30px',
         color: textColor,
       }}
@@ -107,7 +109,14 @@ const withThemeProvider = (Story: StoryFn, context: { globals: any }) => {
 
 const decorators = [
   (Story: StoryFn) => {
-    return <>{<Story />}</> // Storybook is broken without this please refer to this issue: https://github.com/storybookjs/storybook/issues/24625
+    return (
+      <>
+        {
+          // eslint-disable-next-line react/jsx-curly-brace-presence
+          <Story />
+        }
+      </>
+    ) // Storybook is broken without this please refer to this issue: https://github.com/storybookjs/storybook/issues/24625
   },
   withThemeFromJSXProvider({
     themes: {


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

I added a real background on storybook stories. This seems only cool but it actually has a purpose: indicated whenever we have a background or not on our components. Our theme being full white in background we can never differentiate if we see the background of storybook or of the component.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1059" alt="Screenshot 2025-01-08 at 18 01 31" src="https://github.com/user-attachments/assets/8aa0e7e1-9fcb-43b8-8353-cc81798a3e7b" /> | <img width="1053" alt="Screenshot 2025-01-08 at 18 12 02" src="https://github.com/user-attachments/assets/28ec1f3a-85fe-418f-869f-e6ccd3fc36ff" /> |
| url  | <img width="1056" alt="Screenshot 2025-01-08 at 18 12 34" src="https://github.com/user-attachments/assets/fb32b950-a99e-4aac-9aed-473796f0620f" /> | <img width="1034" alt="Screenshot 2025-01-08 at 18 12 38" src="https://github.com/user-attachments/assets/8dbdd1c8-73ba-486e-9853-5bfd1e29b998" /> |
