### PR TITLE
fix: onchange and border

### DIFF
--- a/.changeset/thick-olives-refuse.md
+++ b/.changeset/thick-olives-refuse.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<SelectInputV2 />`: 
+- onChange handle on checkboxes fix
+- visual indication of focused item for keyboard users

--- a/.changeset/thick-olives-refuse.md
+++ b/.changeset/thick-olives-refuse.md
@@ -5,3 +5,4 @@
 `<SelectInputV2 />`: 
 - onChange handle on checkboxes fix
 - visual indication of focused item for keyboard users
+- no scroll when opening the dropdown with "Enter"

--- a/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -209,10 +209,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  min-height: 1rem;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 .emotion-13 .fillStroke {
@@ -419,6 +419,7 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
   margin-right: 0.25rem;
   color: #3f4250;
   border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-32:hover,
@@ -427,6 +428,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
   color: #641cb3;
   cursor: pointer;
   outline: none;
+}
+
+.emotion-32:focus-visible {
+  border: #d8c5fc 1px solid;
 }
 
 .emotion-32[aria-selected='true'] {
@@ -1075,10 +1080,10 @@ exports[`SelectInputField > should render correctly 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  min-height: 1rem;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 .emotion-13 .fillStroke {
@@ -1343,10 +1348,10 @@ exports[`SelectInputField > should render correctly disabled 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #b5b7bd;
-  height: 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  min-height: 1rem;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 .emotion-13 .fillStroke {
@@ -1611,10 +1616,10 @@ exports[`SelectInputField > should render correctly grouped 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  min-height: 1rem;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 .emotion-13 .fillStroke {
@@ -1879,10 +1884,10 @@ exports[`SelectInputField > should render correctly multiselect 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  min-height: 1rem;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 .emotion-13 .fillStroke {
@@ -2145,10 +2150,10 @@ exports[`SelectInputField > should trigger events 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  min-height: 1rem;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
 }
 
 .emotion-13 .fillStroke {

--- a/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -427,11 +427,6 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
-}
-
-.emotion-32:focus-visible {
-  border: #d8c5fc 1px solid;
 }
 
 .emotion-32[aria-selected='true'] {

--- a/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -209,10 +209,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -1080,10 +1080,10 @@ exports[`SelectInputField > should render correctly 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -1348,10 +1348,10 @@ exports[`SelectInputField > should render correctly disabled 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #b5b7bd;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -1616,10 +1616,10 @@ exports[`SelectInputField > should render correctly grouped 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -1884,10 +1884,10 @@ exports[`SelectInputField > should render correctly multiselect 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -2150,10 +2150,10 @@ exports[`SelectInputField > should trigger events 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {

--- a/packages/ui/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -4467,6 +4467,7 @@ exports[`Pagination > should work correctly with perPage 1`] = `
   margin-right: 0.25rem;
   color: #3f4250;
   border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-31:hover,
@@ -4474,7 +4475,6 @@ exports[`Pagination > should work correctly with perPage 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
 .emotion-31[aria-selected='true'] {
@@ -4888,7 +4888,6 @@ exports[`Pagination > should work correctly with perPage 1`] = `
                   data-grouped="false"
                   id="select-dropdown"
                   role="listbox"
-                  tabindex="-1"
                 >
                   <div
                     class="emotion-29 emotion-1"

--- a/packages/ui/src/components/SelectInputV2/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/Dropdown.tsx
@@ -134,13 +134,7 @@ const DropdownItem = styled.div<{
     background-color: ${({ theme }) => theme.colors.primary.background};
     color: ${({ theme }) => theme.colors.primary.text};
     cursor: pointer;
-    outline: none;
   }
-
-
-  &:focus-visible {
-      border: ${({ theme }) => theme.colors.primary.borderWeakDisabled} 1px solid;
-    }
 
   &[aria-selected='true'] {
     background-color: ${({ theme }) => theme.colors.primary.background};
@@ -562,7 +556,6 @@ const CreateDropdown = ({
   ) : (
     <DropdownContainer
       role="listbox"
-      tabIndex={-1}
       id="select-dropdown"
       onKeyDown={handleKeyDownSelect}
       gap={0.25}

--- a/packages/ui/src/components/SelectInputV2/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/Dropdown.tsx
@@ -128,6 +128,7 @@ const DropdownItem = styled.div<{
 
   color:  ${({ theme }) => theme.colors.neutral.text};
   border-radius: ${({ theme }) => theme.radii.default};
+  border: 1px transparent solid;
 
   &:hover, :focus {
     background-color: ${({ theme }) => theme.colors.primary.background};
@@ -135,6 +136,11 @@ const DropdownItem = styled.div<{
     cursor: pointer;
     outline: none;
   }
+
+
+  &:focus-visible {
+      border: ${({ theme }) => theme.colors.primary.borderWeakDisabled} 1px solid;
+    }
 
   &[aria-selected='true'] {
     background-color: ${({ theme }) => theme.colors.primary.background};
@@ -212,6 +218,11 @@ const handleKeyDownSelect = (event: KeyboardEvent<HTMLDivElement>) => {
   if (event.key === 'ArrowUp') {
     event.preventDefault()
     moveFocusUp()
+  }
+
+  if (event.key === ' ') {
+    // No scroll
+    event.preventDefault()
   }
 }
 
@@ -404,6 +415,7 @@ const CreateDropdown = ({
                   value="select-all"
                   data-testid="select-all-checkbox"
                   tabIndex={-1}
+                  onChange={selectAllOptions}
                 >
                   <Stack direction="column">
                     <Text as="span" variant="body" placement="left">
@@ -452,8 +464,16 @@ const CreateDropdown = ({
                           value={group}
                           data-testid="select-group"
                           tabIndex={-1}
+                          onChange={() =>
+                            selectAllGroup ? handleSelectGroup(group) : null
+                          }
                         >
-                          <Text variant="caption" as="span" placement="left">
+                          <Text
+                            variant="caption"
+                            as="span"
+                            placement="left"
+                            sentiment="neutral"
+                          >
                             {group.toUpperCase()}
                           </Text>
                         </StyledCheckbox>
@@ -511,6 +531,11 @@ const CreateDropdown = ({
                         disabled={option.disabled}
                         value={option.value}
                         tabIndex={-1}
+                        onChange={() => {
+                          if (!option.disabled) {
+                            handleClick(option, group)
+                          }
+                        }}
                       >
                         <DisplayOption
                           option={option}
@@ -563,6 +588,7 @@ const CreateDropdown = ({
               value="select-all"
               data-testid="select-all-checkbox"
               tabIndex={-1}
+              onChange={selectAllOptions}
             >
               <Stack direction="column">
                 <Text as="span" variant="body" placement="left">
@@ -623,6 +649,11 @@ const CreateDropdown = ({
                   disabled={option.disabled}
                   value={option.value}
                   tabIndex={-1}
+                  onChange={() => {
+                    if (!option.disabled) {
+                      handleClick(option)
+                    }
+                  }}
                 >
                   <DisplayOption
                     option={option}

--- a/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
@@ -129,6 +129,8 @@ export const SearchBarDropdown = ({
           onChange?.(selectedData.selectedValues[0] ?? '')
         }
       }
+    } else if (key === 'Tab') {
+      searchInputRef.current?.blur()
     }
   }
 

--- a/packages/ui/src/components/SelectInputV2/SelectBar.tsx
+++ b/packages/ui/src/components/SelectInputV2/SelectBar.tsx
@@ -371,6 +371,9 @@ export const SelectBar = ({
               document.getElementById(`option-0`)?.focus()
             }
           }
+          if (event.key === ' ') {
+            event.preventDefault()
+          }
 
           return ['Enter', ' '].includes(event.key) && openable
             ? setIsDropdownVisible(!isDropdownVisible)

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1002,6 +1002,7 @@ exports[`UnitInput > renders click 1`] = `
   margin-right: 0.25rem;
   color: #3f4250;
   border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-33:hover,
@@ -1010,6 +1011,10 @@ exports[`UnitInput > renders click 1`] = `
   color: #641cb3;
   cursor: pointer;
   outline: none;
+}
+
+.emotion-33:focus-visible {
+  border: #d8c5fc 1px solid;
 }
 
 .emotion-33[aria-selected='true'] {

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1010,11 +1010,6 @@ exports[`UnitInput > renders click 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
-}
-
-.emotion-33:focus-visible {
-  border: #d8c5fc 1px solid;
 }
 
 .emotion-33[aria-selected='true'] {
@@ -1176,7 +1171,6 @@ exports[`UnitInput > renders click 1`] = `
                   data-grouped="false"
                   id="select-dropdown"
                   role="listbox"
-                  tabindex="-1"
                 >
                   <div
                     class="emotion-31 emotion-1"


### PR DESCRIPTION
## Summary

## Type

- Bug
- Enhancement

### Summarise concisely:

#### What is expected?
`<SelectInputV2 />`: 
- onChange handle on checkboxes fix
- visual indication of focused item for keyboard users (if the element was already selected, it was not possible to see that the element had focus)
- no automatic scroll when using "enter" to select an item
## Relevant logs and/or screenshots
Before ("Venus" has focus) : 
<img width="783" alt="Capture d’écran 2025-01-09 à 15 41 29" src="https://github.com/user-attachments/assets/5f03da55-3f1a-4d74-a4d2-7100de90df9a" />

After (when navigating with keyboard) : 
<img width="783" alt="Capture d’écran 2025-01-09 à 15 40 30" src="https://github.com/user-attachments/assets/29ef3693-b27c-4e7e-b241-693a3e0d0d6e" />
