### PR TITLE
fix(NumberInputV2): styling when disabled

### DIFF
--- a/.changeset/thirty-glasses-rush.md
+++ b/.changeset/thirty-glasses-rush.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<NumberInputV2 />`: border color when disabled

--- a/packages/form/src/components/NumberInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/NumberInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -264,11 +264,13 @@ exports[`NumberInputFieldV2 > should render correctly 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -283,6 +285,7 @@ exports[`NumberInputFieldV2 > should render correctly 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -641,11 +644,13 @@ exports[`NumberInputFieldV2 > should render correctly disabled 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -660,6 +665,7 @@ exports[`NumberInputFieldV2 > should render correctly disabled 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {

--- a/packages/form/src/components/SliderField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SliderField/__tests__/__snapshots__/index.test.tsx.snap
@@ -2214,11 +2214,13 @@ exports[`SliderField > should trigger events correctly 1`] = `
 .emotion-19:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-19:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-19:-moz-read-only~.e1b9qdjy2 {
@@ -2233,6 +2235,7 @@ exports[`SliderField > should trigger events correctly 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-19:disabled~.e1b9qdjy2 {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -1019,11 +1019,13 @@ exports[`EstimateCost - NumberInput Item > render basic props 1`] = `
 .emotion-112:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-112:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-112:-moz-read-only~.e1b9qdjy2 {
@@ -1038,6 +1040,7 @@ exports[`EstimateCost - NumberInput Item > render basic props 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-112:disabled~.e1b9qdjy2 {
@@ -2559,11 +2562,13 @@ exports[`EstimateCost - NumberInput Item > render basic with overlay 1`] = `
 .emotion-112:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-112:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-112:-moz-read-only~.e1b9qdjy2 {
@@ -2578,6 +2583,7 @@ exports[`EstimateCost - NumberInput Item > render basic with overlay 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-112:disabled~.e1b9qdjy2 {
@@ -4099,11 +4105,13 @@ exports[`EstimateCost - NumberInput Item > render with getAmountValue 1`] = `
 .emotion-112:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-112:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-112:-moz-read-only~.e1b9qdjy2 {
@@ -4118,6 +4126,7 @@ exports[`EstimateCost - NumberInput Item > render with getAmountValue 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-112:disabled~.e1b9qdjy2 {
@@ -5653,11 +5662,13 @@ exports[`EstimateCost - NumberInput Item > render with values 1`] = `
 .emotion-115:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-115:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-115:-moz-read-only~.e1b9qdjy2 {
@@ -5672,6 +5683,7 @@ exports[`EstimateCost - NumberInput Item > render with values 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-115:disabled~.e1b9qdjy2 {

--- a/packages/ui/src/components/NumberInputV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/NumberInputV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -473,11 +473,13 @@ exports[`NumberInputV2 > should click on min button 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -492,6 +494,7 @@ exports[`NumberInputV2 > should click on min button 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -565,11 +568,13 @@ exports[`NumberInputV2 > should click on min button 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -584,6 +589,7 @@ exports[`NumberInputV2 > should click on min button 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -1157,11 +1163,13 @@ exports[`NumberInputV2 > should click on plus button with a step value 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -1176,6 +1184,7 @@ exports[`NumberInputV2 > should click on plus button with a step value 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -1249,11 +1258,13 @@ exports[`NumberInputV2 > should click on plus button with a step value 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -1268,6 +1279,7 @@ exports[`NumberInputV2 > should click on plus button with a step value 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -1840,11 +1852,13 @@ exports[`NumberInputV2 > should click on plus button with a step value and an in
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -1859,6 +1873,7 @@ exports[`NumberInputV2 > should click on plus button with a step value and an in
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -1932,11 +1947,13 @@ exports[`NumberInputV2 > should click on plus button with a step value and an in
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -1951,6 +1968,7 @@ exports[`NumberInputV2 > should click on plus button with a step value and an in
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -2523,11 +2541,13 @@ exports[`NumberInputV2 > should focus input and modify value 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -2542,6 +2562,7 @@ exports[`NumberInputV2 > should focus input and modify value 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -2615,11 +2636,13 @@ exports[`NumberInputV2 > should focus input and modify value 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -2634,6 +2657,7 @@ exports[`NumberInputV2 > should focus input and modify value 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -3207,11 +3231,13 @@ exports[`NumberInputV2 > should focus input and modify value when value > max 1`
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -3226,6 +3252,7 @@ exports[`NumberInputV2 > should focus input and modify value when value > max 1`
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -3299,11 +3326,13 @@ exports[`NumberInputV2 > should focus input and modify value when value > max 1`
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -3318,6 +3347,7 @@ exports[`NumberInputV2 > should focus input and modify value when value > max 1`
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -3682,11 +3712,13 @@ exports[`NumberInputV2 > should renders correctly 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -3701,6 +3733,7 @@ exports[`NumberInputV2 > should renders correctly 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -4063,11 +4096,13 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size large 1`
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -4082,6 +4117,7 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size large 1`
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -4444,11 +4480,13 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size large an
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.emotion-15 {
@@ -4463,6 +4501,7 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size large an
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.emotion-15 {
@@ -4853,11 +4892,13 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size medium 1
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -4872,6 +4913,7 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size medium 1
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -5234,11 +5276,13 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size medium a
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.emotion-15 {
@@ -5253,6 +5297,7 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size medium a
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.emotion-15 {
@@ -5643,11 +5688,13 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size small 1`
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -5662,6 +5709,7 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size small 1`
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -6024,11 +6072,13 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size small an
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.emotion-15 {
@@ -6043,6 +6093,7 @@ exports[`NumberInputV2 > should renders correctly all sizes > with size small an
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.emotion-15 {
@@ -6424,11 +6475,13 @@ exports[`NumberInputV2 > should renders correctly disabled 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -6443,6 +6496,7 @@ exports[`NumberInputV2 > should renders correctly disabled 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -6808,11 +6862,13 @@ exports[`NumberInputV2 > should renders correctly max value 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -6827,6 +6883,7 @@ exports[`NumberInputV2 > should renders correctly max value 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -7189,11 +7246,13 @@ exports[`NumberInputV2 > should renders correctly min value 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -7208,6 +7267,7 @@ exports[`NumberInputV2 > should renders correctly min value 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -7570,11 +7630,13 @@ exports[`NumberInputV2 > should renders correctly with error 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -7589,6 +7651,7 @@ exports[`NumberInputV2 > should renders correctly with error 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -7968,11 +8031,13 @@ exports[`NumberInputV2 > should renders correctly with placeholder 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -7987,6 +8052,7 @@ exports[`NumberInputV2 > should renders correctly with placeholder 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -8349,11 +8415,13 @@ exports[`NumberInputV2 > should renders correctly with success 1`] = `
 .emotion-13:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-13:-moz-read-only~.e1b9qdjy2 {
@@ -8368,6 +8436,7 @@ exports[`NumberInputV2 > should renders correctly with success 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-13:disabled~.e1b9qdjy2 {
@@ -8642,11 +8711,13 @@ exports[`NumberInputV2 > should renders correctly without controls 1`] = `
 .emotion-7:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-7:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-7:-moz-read-only~.e1b9qdjy2 {
@@ -8661,6 +8732,7 @@ exports[`NumberInputV2 > should renders correctly without controls 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-7:disabled~.e1b9qdjy2 {

--- a/packages/ui/src/components/NumberInputV2/index.tsx
+++ b/packages/ui/src/components/NumberInputV2/index.tsx
@@ -115,6 +115,7 @@ const Input = styled.input`
   &:read-only {
     color: ${({ theme }) => theme.colors.neutral.text};
     background: ${({ theme }) => theme.colors.neutral.backgroundWeak};
+    border-block: 1px solid ${({ theme }) => theme.colors.neutral.border};
 
     & ~ ${Unit} {
       background: ${({ theme }) => theme.colors.neutral.backgroundWeak};
@@ -125,6 +126,7 @@ const Input = styled.input`
     color: ${({ theme }) => theme.colors.neutral.textDisabled};
     background: ${({ theme }) => theme.colors.neutral.backgroundDisabled};
     cursor: not-allowed;
+    border-block: 1px solid ${({ theme }) => theme.colors.neutral.borderDisabled};
 
     & ~ ${Unit} {
       background: ${({ theme }) => theme.colors.neutral.backgroundDisabled};

--- a/packages/ui/src/components/Slider/__tests__/__snapshots__/doubleSlider.test.tsx.snap
+++ b/packages/ui/src/components/Slider/__tests__/__snapshots__/doubleSlider.test.tsx.snap
@@ -1583,11 +1583,13 @@ exports[`Double slider > handles correctly onChange double 1`] = `
 .emotion-15:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:-moz-read-only~.e1b9qdjy2 {
@@ -1602,6 +1604,7 @@ exports[`Double slider > handles correctly onChange double 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-15:disabled~.e1b9qdjy2 {
@@ -1675,11 +1678,13 @@ exports[`Double slider > handles correctly onChange double 1`] = `
 .emotion-15:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:-moz-read-only~.e1b9qdjy2 {
@@ -1694,6 +1699,7 @@ exports[`Double slider > handles correctly onChange double 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-15:disabled~.e1b9qdjy2 {
@@ -2650,11 +2656,13 @@ exports[`Double slider > handles correctly onChange with min and max double 1`] 
 .emotion-15:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:-moz-read-only~.e1b9qdjy2 {
@@ -2669,6 +2677,7 @@ exports[`Double slider > handles correctly onChange with min and max double 1`] 
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-15:disabled~.e1b9qdjy2 {
@@ -2742,11 +2751,13 @@ exports[`Double slider > handles correctly onChange with min and max double 1`] 
 .emotion-15:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-15:-moz-read-only~.e1b9qdjy2 {
@@ -2761,6 +2772,7 @@ exports[`Double slider > handles correctly onChange with min and max double 1`] 
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-15:disabled~.e1b9qdjy2 {
@@ -4342,11 +4354,13 @@ exports[`Double slider > renders correctly direction row double with input 1`] =
 .emotion-19:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-19:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-19:-moz-read-only~.e1b9qdjy2 {
@@ -4361,6 +4375,7 @@ exports[`Double slider > renders correctly direction row double with input 1`] =
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-19:disabled~.e1b9qdjy2 {
@@ -8000,11 +8015,13 @@ exports[`Double slider > renders correctly double input 1`] = `
 .emotion-21:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-21:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-21:-moz-read-only~.e1b9qdjy2 {
@@ -8019,6 +8036,7 @@ exports[`Double slider > renders correctly double input 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-21:disabled~.e1b9qdjy2 {

--- a/packages/ui/src/components/Slider/__tests__/__snapshots__/singleSlider.test.tsx.snap
+++ b/packages/ui/src/components/Slider/__tests__/__snapshots__/singleSlider.test.tsx.snap
@@ -363,11 +363,13 @@ exports[`Single slider > handles correctly onChange with min and max 1`] = `
 .emotion-11:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-11:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-11:-moz-read-only~.e1b9qdjy2 {
@@ -382,6 +384,7 @@ exports[`Single slider > handles correctly onChange with min and max 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-11:disabled~.e1b9qdjy2 {
@@ -455,11 +458,13 @@ exports[`Single slider > handles correctly onChange with min and max 1`] = `
 .emotion-11:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-11:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-11:-moz-read-only~.e1b9qdjy2 {
@@ -474,6 +479,7 @@ exports[`Single slider > handles correctly onChange with min and max 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-11:disabled~.e1b9qdjy2 {
@@ -3236,11 +3242,13 @@ exports[`Single slider > renders correctly direction row with input 1`] = `
 .emotion-21:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-21:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-21:-moz-read-only~.e1b9qdjy2 {
@@ -3255,6 +3263,7 @@ exports[`Single slider > renders correctly direction row with input 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-21:disabled~.e1b9qdjy2 {
@@ -5382,11 +5391,13 @@ exports[`Single slider > renders correctly input 1`] = `
 .emotion-17:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-17:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-17:-moz-read-only~.e1b9qdjy2 {
@@ -5401,6 +5412,7 @@ exports[`Single slider > renders correctly input 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-17:disabled~.e1b9qdjy2 {
@@ -7997,11 +8009,13 @@ exports[`Single slider > renders correctly suffix string input 1`] = `
 .emotion-17:-moz-read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-17:read-only {
   color: #3f4250;
   background: #f9f9fa;
+  border-block: 1px solid #d9dadd;
 }
 
 .emotion-17:-moz-read-only~.emotion-19 {
@@ -8016,6 +8030,7 @@ exports[`Single slider > renders correctly suffix string input 1`] = `
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
+  border-block: 1px solid #e9eaeb;
 }
 
 .emotion-17:disabled~.emotion-19 {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There was a problem with the border of `NumberInputV2` when it was disabled or read-only.
## Relevant logs and/or screenshots
Before: 
<img width="1029" alt="Capture d’écran 2025-01-15 à 17 32 23" src="https://github.com/user-attachments/assets/bcaf487c-e7bc-44ef-bf06-2a0a74760646" />

After: 
<img width="1029" alt="Capture d’écran 2025-01-15 à 17 32 37" src="https://github.com/user-attachments/assets/0934da5e-5abd-49cd-a80c-221a2b5757c1" />
