### PR TITLE
fix(Slider): disable input on disabled sliders

### DIFF
--- a/.changeset/weak-peas-marry.md
+++ b/.changeset/weak-peas-marry.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<Slider />: when the component is disabled, the input is disabled too

--- a/packages/ui/src/components/Slider/components/DoubleSlider.tsx
+++ b/packages/ui/src/components/Slider/components/DoubleSlider.tsx
@@ -257,6 +257,7 @@ export const DoubleSlider = ({
         step={step}
         aria-label={`input-${side}`}
         controls={false}
+        disabled={disabled}
         data-testid={side ? `slider-input-${side}` : 'slider-input'}
         unit={typeof suffix === 'string' ? suffix : unit}
         onChange={newVal => {

--- a/packages/ui/src/components/Slider/components/SingleSlider.tsx
+++ b/packages/ui/src/components/Slider/components/SingleSlider.tsx
@@ -178,6 +178,7 @@ export const SingleSlider = ({
         max={max}
         step={step}
         controls={false}
+        disabled={disabled}
         data-testid={dataTestId ? `${dataTestId}-input` : 'slider-input'}
         unit={typeof suffix === 'string' ? suffix : unit}
         onChange={newVal => {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Now, when a slider is disabled, its related input(s) is(are) in a disabled state : it is still not possible to edit the slider value(s) anymore.