### PR TITLE
fix(DateInput): max date bug

### DIFF
--- a/.changeset/eight-pugs-share.md
+++ b/.changeset/eight-pugs-share.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<DateInput />: fix issue with min-max date

--- a/packages/ui/src/components/DateInput/components/Popup.tsx
+++ b/packages/ui/src/components/DateInput/components/Popup.tsx
@@ -104,10 +104,7 @@ const PopupContent = () => {
           sentiment="neutral"
           size="xsmall"
           onClick={() => {
-            if (
-              !maxDate ||
-              maxDate >= new Date(yearToShow, monthToShow + 1, 1)
-            ) {
+            if (!maxDate || maxDate >= new Date(yearToShow, monthToShow, 1)) {
               if (!showMonthYearPicker) {
                 const [monthNext, year] = getNextMonth(monthToShow, yearToShow)
                 setMonthToShow(monthNext)
@@ -118,7 +115,7 @@ const PopupContent = () => {
             }
           }}
           disabled={
-            !!(maxDate && maxDate < new Date(yearToShow, monthToShow + 1, 1))
+            !!(maxDate && maxDate < new Date(yearToShow, monthToShow, 1))
           }
         />
       </Stack>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?
There was an issue with max-date: since months are 0-indexed, there shouldn't be a +1 when creating a date to compute wether the "next" button is disabled or not.
## Relevant logs and/or screenshots
Before : 

https://github.com/user-attachments/assets/8de19009-fac4-4133-9354-c78415e38157

After : 

https://github.com/user-attachments/assets/e40fd5b7-7015-4d57-9367-272d85f5a28c

