### PR TITLE
fix(Dialog): to have correct icon with sentiment danger and warning

### DIFF
--- a/.changeset/seven-insects-look.md
+++ b/.changeset/seven-insects-look.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Dialog />` component to have correct icon when having warning and danger sentiment

--- a/packages/ui/src/components/Dialog/index.tsx
+++ b/packages/ui/src/components/Dialog/index.tsx
@@ -67,9 +67,7 @@ export const BaseDialog = ({
       <Bullet
         sentiment={sentiment}
         icon={
-          sentiment === 'warning' || sentiment === 'danger'
-            ? 'information-outline'
-            : 'check'
+          sentiment === 'warning' || sentiment === 'danger' ? 'alert' : 'check'
         }
       />
       <StyledTextTitle


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<Dialog />` component to have correct icon when sentiment is warning or danger