### PR TITLE
refactor: remove some more legacy icons and deprecated others

### DIFF
--- a/.changeset/curvy-beers-roll.md
+++ b/.changeset/curvy-beers-roll.md
@@ -10,7 +10,7 @@ import { Badge } from '@ultraviolet/ui'
 
 <Badge icon="pencil">
   Edit
-</Button>
+</Badge>
 ```
 
 ```tsx

--- a/.changeset/curvy-beers-roll.md
+++ b/.changeset/curvy-beers-roll.md
@@ -1,0 +1,24 @@
+---
+"@ultraviolet/ui": patch
+---
+
+In `<Badge />` component, `icon` props is deprecated. You can directly use the imported icon you need in the children.
+
+```tsx
+// Before
+import { Badge } from '@ultraviolet/ui'
+
+<Badge icon="pencil">
+  Edit
+</Button>
+```
+
+```tsx
+// After
+import { Badge } from '@ultraviolet/ui'
+import { PencilOutlineIcon } from '@ultraviolet/icons'
+
+<Badge>
+  Edit <PencilOutlineIcon />
+</Badge>
+```

--- a/packages/ui/src/__stories__/migrations/MigrationIconUsages.mdx
+++ b/packages/ui/src/__stories__/migrations/MigrationIconUsages.mdx
@@ -32,3 +32,26 @@ import { PencilOutlineIcon } from '@ultraviolet/icons'
   Edit <PencilOutlineIcon />
 </Button>
 ```
+
+### Badge
+
+`icon` props is deprecated. You can directly use the imported icon you need in the children.
+
+```tsx
+// Before
+import { Badge } from '@ultraviolet/ui'
+
+<Badge icon="pencil">
+  Edit
+</Button>
+```
+
+```tsx
+// After
+import { Badge } from '@ultraviolet/ui'
+import { PencilOutlineIcon } from '@ultraviolet/icons'
+
+<Badge>
+  Edit <PencilOutlineIcon />
+</Badge>
+```

--- a/packages/ui/src/components/Badge/__stories__/Icon.stories.tsx
+++ b/packages/ui/src/components/Badge/__stories__/Icon.stories.tsx
@@ -1,9 +1,14 @@
+import { InformationOutlineIcon } from '@ultraviolet/icons'
 import { Template } from './Template'
 
 export const Icon = Template.bind({})
 
 Icon.args = {
-  children: ['Badge'],
-  icon: 'information-outline',
+  children: (
+    <>
+      <InformationOutlineIcon size="small" />
+      Badge
+    </>
+  ),
   sentiment: 'primary',
 }

--- a/packages/ui/src/components/Badge/index.tsx
+++ b/packages/ui/src/components/Badge/index.tsx
@@ -118,6 +118,7 @@ type BadgeProps = {
   size?: keyof typeof SIZES
   prominence?: keyof typeof PROMINENCES
   /**
+   * @deprecated: Use the icon directly in children
    * Defines icon to display on left side of badge. **Only available on medium and large sizes**.
    */
   icon?: IconName

--- a/packages/ui/src/components/Banner/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Banner/__tests__/__snapshots__/index.test.tsx.snap
@@ -473,6 +473,8 @@ exports[`Banner > renders correctly with a link 1`] = `
   text-case: none;
 }
 
+.emotion-12 .e1afnb7a2,
+.emotion-12 .e1afnb7a3,
 .emotion-12 .emotion-16 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
@@ -492,6 +494,10 @@ exports[`Banner > renders correctly with a link 1`] = `
   text-decoration-color: #521094;
 }
 
+.emotion-12:hover .e1afnb7a2,
+.emotion-12:focus .e1afnb7a2,
+.emotion-12:hover .e1afnb7a3,
+.emotion-12:focus .e1afnb7a3,
 .emotion-12:hover .emotion-16,
 .emotion-12:focus .emotion-16 {
   -webkit-transform: translate(-0.25rem, 0);
@@ -653,13 +659,16 @@ exports[`Banner > renders correctly with a link 1`] = `
               <svg
                 class="emotion-16 emotion-17 emotion-18"
                 viewBox="0 0 20 20"
-                xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69z"
+                  clip-rule="evenodd"
+                  d="M4.25 6.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 18h-8.5A2.25 2.25 0 0 1 2 15.75v-8.5A2.25 2.25 0 0 1 4.25 5h5a.75.75 0 0 1 0 1.5z"
+                  fill-rule="evenodd"
                 />
                 <path
-                  d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25z"
+                  clip-rule="evenodd"
+                  d="M6.194 13.753a.75.75 0 0 0 1.06.053L16.5 5.44v2.81a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75h-4.5a.75.75 0 0 0 0 1.5h2.553l-9.056 8.194a.75.75 0 0 0-.053 1.06"
+                  fill-rule="evenodd"
                 />
               </svg>
             </span>
@@ -672,7 +681,7 @@ exports[`Banner > renders correctly with a link 1`] = `
         type="button"
       >
         <svg
-          class="emotion-21 emotion-18"
+          class="emotion-21 emotion-22"
           viewBox="0 0 16 16"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.test.tsx.snap
@@ -158,7 +158,9 @@ exports[`Breadcrumbs > click on middle item 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-5 .e1afnb7a2 {
+.emotion-5 .e1afnb7a2,
+.emotion-5 .e1afnb7a3,
+.emotion-5 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -178,7 +180,11 @@ exports[`Breadcrumbs > click on middle item 1`] = `
 }
 
 .emotion-5:hover .e1afnb7a2,
-.emotion-5:focus .e1afnb7a2 {
+.emotion-5:focus .e1afnb7a2,
+.emotion-5:hover .e1afnb7a3,
+.emotion-5:focus .e1afnb7a3,
+.emotion-5:hover .e1afnb7a4,
+.emotion-5:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -228,7 +234,9 @@ exports[`Breadcrumbs > click on middle item 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-5 .e1afnb7a2 {
+.emotion-5 .e1afnb7a2,
+.emotion-5 .e1afnb7a3,
+.emotion-5 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -248,7 +256,11 @@ exports[`Breadcrumbs > click on middle item 1`] = `
 }
 
 .emotion-5:hover .e1afnb7a2,
-.emotion-5:focus .e1afnb7a2 {
+.emotion-5:focus .e1afnb7a2,
+.emotion-5:hover .e1afnb7a3,
+.emotion-5:focus .e1afnb7a3,
+.emotion-5:hover .e1afnb7a4,
+.emotion-5:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -617,7 +629,9 @@ exports[`Breadcrumbs > last item should no be clickable 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-5 .e1afnb7a2 {
+.emotion-5 .e1afnb7a2,
+.emotion-5 .e1afnb7a3,
+.emotion-5 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -637,7 +651,11 @@ exports[`Breadcrumbs > last item should no be clickable 1`] = `
 }
 
 .emotion-5:hover .e1afnb7a2,
-.emotion-5:focus .e1afnb7a2 {
+.emotion-5:focus .e1afnb7a2,
+.emotion-5:hover .e1afnb7a3,
+.emotion-5:focus .e1afnb7a3,
+.emotion-5:hover .e1afnb7a4,
+.emotion-5:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -687,7 +705,9 @@ exports[`Breadcrumbs > last item should no be clickable 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-5 .e1afnb7a2 {
+.emotion-5 .e1afnb7a2,
+.emotion-5 .e1afnb7a3,
+.emotion-5 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -707,7 +727,11 @@ exports[`Breadcrumbs > last item should no be clickable 1`] = `
 }
 
 .emotion-5:hover .e1afnb7a2,
-.emotion-5:focus .e1afnb7a2 {
+.emotion-5:focus .e1afnb7a2,
+.emotion-5:hover .e1afnb7a3,
+.emotion-5:focus .e1afnb7a3,
+.emotion-5:hover .e1afnb7a4,
+.emotion-5:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1014,7 +1038,9 @@ exports[`Breadcrumbs > renders correctly with default values 1`] = `
   padding-right: 0.5rem;
 }
 
-.emotion-5 .e1afnb7a2 {
+.emotion-5 .e1afnb7a2,
+.emotion-5 .e1afnb7a3,
+.emotion-5 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1034,7 +1060,11 @@ exports[`Breadcrumbs > renders correctly with default values 1`] = `
 }
 
 .emotion-5:hover .e1afnb7a2,
-.emotion-5:focus .e1afnb7a2 {
+.emotion-5:focus .e1afnb7a2,
+.emotion-5:hover .e1afnb7a3,
+.emotion-5:focus .e1afnb7a3,
+.emotion-5:hover .e1afnb7a4,
+.emotion-5:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);

--- a/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.test.tsx.snap
@@ -685,7 +685,9 @@ exports[`EmptySpace > should work with learn more 1`] = `
   text-case: none;
 }
 
-.emotion-15 .emotion-17 {
+.emotion-15 .e1afnb7a2,
+.emotion-15 .emotion-17,
+.emotion-15 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -704,8 +706,12 @@ exports[`EmptySpace > should work with learn more 1`] = `
   text-decoration-color: #004c85;
 }
 
+.emotion-15:hover .e1afnb7a2,
+.emotion-15:focus .e1afnb7a2,
 .emotion-15:hover .emotion-17,
-.emotion-15:focus .emotion-17 {
+.emotion-15:focus .emotion-17,
+.emotion-15:hover .e1afnb7a4,
+.emotion-15:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -779,12 +785,11 @@ exports[`EmptySpace > should work with learn more 1`] = `
             Learn more
             <svg
               class="emotion-17 emotion-18 emotion-19"
-              viewBox="0 0 16 16"
-              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
             >
               <path
                 clip-rule="evenodd"
-                d="M6.22 4.22a.75.75 0 0 1 1.06 0l3.25 3.25a.75.75 0 0 1 0 1.06l-3.25 3.25a.75.75 0 0 1-1.06-1.06L8.94 8 6.22 5.28a.75.75 0 0 1 0-1.06"
+                d="M7.47 5.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06l3.72-3.72-3.72-3.72a.75.75 0 0 1 0-1.06"
                 fill-rule="evenodd"
               />
             </svg>

--- a/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/GlobalAlert/__tests__/__snapshots__/index.test.tsx.snap
@@ -1544,7 +1544,9 @@ exports[`GlobalAlert > renders correctly with link 1`] = `
   text-case: none;
 }
 
-.emotion-6 .e1afnb7a2 {
+.emotion-6 .e1afnb7a2,
+.emotion-6 .e1afnb7a3,
+.emotion-6 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1564,7 +1566,11 @@ exports[`GlobalAlert > renders correctly with link 1`] = `
 }
 
 .emotion-6:hover .e1afnb7a2,
-.emotion-6:focus .e1afnb7a2 {
+.emotion-6:focus .e1afnb7a2,
+.emotion-6:hover .e1afnb7a3,
+.emotion-6:focus .e1afnb7a3,
+.emotion-6:hover .e1afnb7a4,
+.emotion-6:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);

--- a/packages/ui/src/components/Link/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Link/__tests__/__snapshots__/index.test.tsx.snap
@@ -29,7 +29,9 @@ exports[`Link > prominence > render prominence default 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -49,7 +51,11 @@ exports[`Link > prominence > render prominence default 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -116,7 +122,9 @@ exports[`Link > prominence > render prominence strong 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -136,7 +144,11 @@ exports[`Link > prominence > render prominence strong 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -203,7 +215,9 @@ exports[`Link > prominence > render prominence stronger 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -223,7 +237,11 @@ exports[`Link > prominence > render prominence stronger 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -290,7 +308,9 @@ exports[`Link > prominence > render prominence weak 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -310,7 +330,11 @@ exports[`Link > prominence > render prominence weak 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -377,7 +401,9 @@ exports[`Link > render correctly with bad sentiment 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -397,7 +423,11 @@ exports[`Link > render correctly with bad sentiment 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -463,7 +493,9 @@ exports[`Link > render correctly with href props 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -483,7 +515,11 @@ exports[`Link > render correctly with href props 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -549,7 +585,9 @@ exports[`Link > render correctly with href props 2`] = `
   text-case: none;
 }
 
-.emotion-0 .emotion-2 {
+.emotion-0 .emotion-2,
+.emotion-0 .emotion-7,
+.emotion-0 .emotion-14 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -569,7 +607,11 @@ exports[`Link > render correctly with href props 2`] = `
 }
 
 .emotion-0:hover .emotion-2,
-.emotion-0:focus .emotion-2 {
+.emotion-0:focus .emotion-2,
+.emotion-0:hover .emotion-7,
+.emotion-0:focus .emotion-7,
+.emotion-0:hover .emotion-14,
+.emotion-0:focus .emotion-14 {
   -webkit-transform: translate(0.25rem, 0);
   -moz-transform: translate(0.25rem, 0);
   -ms-transform: translate(0.25rem, 0);
@@ -633,7 +675,9 @@ exports[`Link > render correctly with href props 2`] = `
   text-case: none;
 }
 
-.emotion-5 .emotion-2 {
+.emotion-5 .emotion-2,
+.emotion-5 .emotion-7,
+.emotion-5 .emotion-14 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -653,7 +697,11 @@ exports[`Link > render correctly with href props 2`] = `
 }
 
 .emotion-5:hover .emotion-2,
-.emotion-5:focus .emotion-2 {
+.emotion-5:focus .emotion-2,
+.emotion-5:hover .emotion-7,
+.emotion-5:focus .emotion-7,
+.emotion-5:hover .emotion-14,
+.emotion-5:focus .emotion-14 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -673,6 +721,21 @@ exports[`Link > render correctly with href props 2`] = `
 
 .emotion-5:active {
   text-decoration-thickness: 2px;
+}
+
+.emotion-8 {
+  vertical-align: middle;
+  fill: currentColor;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  margin-left: 0.5rem;
+}
+
+.emotion-8 .fillStroke {
+  stroke: currentColor;
+  fill: none;
 }
 
 .emotion-12 {
@@ -709,12 +772,11 @@ exports[`Link > render correctly with href props 2`] = `
     >
       <svg
         class="emotion-2 emotion-3 emotion-4"
-        viewBox="0 0 16 16"
-        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
       >
         <path
           clip-rule="evenodd"
-          d="M10.53 4.22a.75.75 0 0 1 0 1.06L7.81 8l2.72 2.72a.75.75 0 1 1-1.06 1.06L6.22 8.53a.75.75 0 0 1 0-1.06l3.25-3.25a.75.75 0 0 1 1.06 0"
+          d="M12.78 5.47a.75.75 0 0 1 0 1.06l-3.72 3.72 3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0"
           fill-rule="evenodd"
         />
       </svg>
@@ -728,13 +790,12 @@ exports[`Link > render correctly with href props 2`] = `
     >
       Hello
       <svg
-        class="emotion-2 emotion-3 emotion-4"
-        viewBox="0 0 16 16"
-        xmlns="http://www.w3.org/2000/svg"
+        class="emotion-7 emotion-8 emotion-4"
+        viewBox="0 0 20 20"
       >
         <path
           clip-rule="evenodd"
-          d="M6.22 4.22a.75.75 0 0 1 1.06 0l3.25 3.25a.75.75 0 0 1 0 1.06l-3.25 3.25a.75.75 0 0 1-1.06-1.06L8.94 8 6.22 5.28a.75.75 0 0 1 0-1.06"
+          d="M7.47 5.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06l3.72-3.72-3.72-3.72a.75.75 0 0 1 0-1.06"
           fill-rule="evenodd"
         />
       </svg>
@@ -752,15 +813,18 @@ exports[`Link > render correctly with href props 2`] = `
         class="emotion-12 emotion-13"
       >
         <svg
-          class="emotion-2 emotion-15 emotion-4"
+          class="emotion-14 emotion-15 emotion-4"
           viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69z"
+            clip-rule="evenodd"
+            d="M4.25 6.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 18h-8.5A2.25 2.25 0 0 1 2 15.75v-8.5A2.25 2.25 0 0 1 4.25 5h5a.75.75 0 0 1 0 1.5z"
+            fill-rule="evenodd"
           />
           <path
-            d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25z"
+            clip-rule="evenodd"
+            d="M6.194 13.753a.75.75 0 0 0 1.06.053L16.5 5.44v2.81a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75h-4.5a.75.75 0 0 0 0 1.5h2.553l-9.056 8.194a.75.75 0 0 0-.053 1.06"
+            fill-rule="evenodd"
           />
         </svg>
       </span>
@@ -778,15 +842,18 @@ exports[`Link > render correctly with href props 2`] = `
         class="emotion-12 emotion-13"
       >
         <svg
-          class="emotion-2 emotion-15 emotion-4"
+          class="emotion-14 emotion-15 emotion-4"
           viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69z"
+            clip-rule="evenodd"
+            d="M4.25 6.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 18h-8.5A2.25 2.25 0 0 1 2 15.75v-8.5A2.25 2.25 0 0 1 4.25 5h5a.75.75 0 0 1 0 1.5z"
+            fill-rule="evenodd"
           />
           <path
-            d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25z"
+            clip-rule="evenodd"
+            d="M6.194 13.753a.75.75 0 0 0 1.06.053L16.5 5.44v2.81a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75h-4.5a.75.75 0 0 0 0 1.5h2.553l-9.056 8.194a.75.75 0 0 0-.053 1.06"
+            fill-rule="evenodd"
           />
         </svg>
       </span>
@@ -824,7 +891,9 @@ exports[`Link > render correctly with no sentiment 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -844,7 +913,11 @@ exports[`Link > render correctly with no sentiment 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -911,7 +984,9 @@ exports[`Link > render correctly with oneLine 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -931,7 +1006,11 @@ exports[`Link > render correctly with oneLine 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1001,7 +1080,9 @@ exports[`Link > render correctly with sizes 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1021,7 +1102,11 @@ exports[`Link > render correctly with sizes 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1070,7 +1155,9 @@ exports[`Link > render correctly with sizes 1`] = `
   text-case: none;
 }
 
-.emotion-2 .e1afnb7a2 {
+.emotion-2 .e1afnb7a2,
+.emotion-2 .e1afnb7a3,
+.emotion-2 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1090,7 +1177,11 @@ exports[`Link > render correctly with sizes 1`] = `
 }
 
 .emotion-2:hover .e1afnb7a2,
-.emotion-2:focus .e1afnb7a2 {
+.emotion-2:focus .e1afnb7a2,
+.emotion-2:hover .e1afnb7a3,
+.emotion-2:focus .e1afnb7a3,
+.emotion-2:hover .e1afnb7a4,
+.emotion-2:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1139,7 +1230,9 @@ exports[`Link > render correctly with sizes 1`] = `
   text-case: none;
 }
 
-.emotion-4 .e1afnb7a2 {
+.emotion-4 .e1afnb7a2,
+.emotion-4 .e1afnb7a3,
+.emotion-4 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1159,7 +1252,11 @@ exports[`Link > render correctly with sizes 1`] = `
 }
 
 .emotion-4:hover .e1afnb7a2,
-.emotion-4:focus .e1afnb7a2 {
+.emotion-4:focus .e1afnb7a2,
+.emotion-4:hover .e1afnb7a3,
+.emotion-4:focus .e1afnb7a3,
+.emotion-4:hover .e1afnb7a4,
+.emotion-4:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1243,6 +1340,8 @@ exports[`Link > render correctly with target blank 1`] = `
   text-case: none;
 }
 
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
 .emotion-0 .emotion-4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
@@ -1262,6 +1361,10 @@ exports[`Link > render correctly with target blank 1`] = `
   text-decoration-color: #521094;
 }
 
+.emotion-0:hover .e1afnb7a2,
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
 .emotion-0:hover .emotion-4,
 .emotion-0:focus .emotion-4 {
   -webkit-transform: translate(-0.25rem, 0);
@@ -1326,13 +1429,16 @@ exports[`Link > render correctly with target blank 1`] = `
         <svg
           class="emotion-4 emotion-5 emotion-6"
           viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69z"
+            clip-rule="evenodd"
+            d="M4.25 6.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 18h-8.5A2.25 2.25 0 0 1 2 15.75v-8.5A2.25 2.25 0 0 1 4.25 5h5a.75.75 0 0 1 0 1.5z"
+            fill-rule="evenodd"
           />
           <path
-            d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25z"
+            clip-rule="evenodd"
+            d="M6.194 13.753a.75.75 0 0 0 1.06.053L16.5 5.44v2.81a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75h-4.5a.75.75 0 0 0 0 1.5h2.553l-9.056 8.194a.75.75 0 0 0-.053 1.06"
+            fill-rule="evenodd"
           />
         </svg>
       </span>
@@ -1370,7 +1476,9 @@ exports[`Link > render correctly with variants props 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1390,7 +1498,11 @@ exports[`Link > render correctly with variants props 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1464,7 +1576,9 @@ exports[`Link > sentiment > render danger 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1484,7 +1598,11 @@ exports[`Link > sentiment > render danger 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1550,7 +1668,9 @@ exports[`Link > sentiment > render info 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1570,7 +1690,11 @@ exports[`Link > sentiment > render info 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1636,7 +1760,9 @@ exports[`Link > sentiment > render neutral 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1656,7 +1782,11 @@ exports[`Link > sentiment > render neutral 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1722,7 +1852,9 @@ exports[`Link > sentiment > render primary 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1742,7 +1874,11 @@ exports[`Link > sentiment > render primary 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1808,7 +1944,9 @@ exports[`Link > sentiment > render secondary 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1828,7 +1966,11 @@ exports[`Link > sentiment > render secondary 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1894,7 +2036,9 @@ exports[`Link > sentiment > render success 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -1914,7 +2058,11 @@ exports[`Link > sentiment > render success 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);
@@ -1980,7 +2128,9 @@ exports[`Link > sentiment > render warning 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -2000,7 +2150,11 @@ exports[`Link > sentiment > render warning 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);

--- a/packages/ui/src/components/Link/index.tsx
+++ b/packages/ui/src/components/Link/index.tsx
@@ -1,5 +1,9 @@
 import styled from '@emotion/styled'
-import { Icon } from '@ultraviolet/icons/legacy'
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  OpenInNewIcon,
+} from '@ultraviolet/icons'
 import type {
   AnchorHTMLAttributes,
   ForwardedRef,
@@ -14,9 +18,12 @@ import type { ExtendedColor } from '../../theme'
 import capitalize from '../../utils/capitalize'
 import { Tooltip } from '../Tooltip'
 
-const StyledIcon = styled(Icon)`
+const StyledArrowLeftIcon = styled(ArrowLeftIcon)`
   margin-left: ${({ theme }) => theme.space['1']};
 `
+
+const StyledArrowRightIcon = StyledArrowLeftIcon.withComponent(ArrowRightIcon)
+const StyledOpenInNewIcon = StyledArrowLeftIcon.withComponent(OpenInNewIcon)
 
 export const PROMINENCES = {
   default: '',
@@ -89,7 +96,7 @@ const StyledLink = styled('a', {
   text-decoration-color: transparent;
   transition: text-decoration-color ${TRANSITION_DURATION}ms ease-out;
 
-  ${StyledIcon} {
+  ${StyledArrowLeftIcon}, ${StyledArrowRightIcon}, ${StyledOpenInNewIcon} {
     transition: transform ${TRANSITION_DURATION}ms ease-out;
   }
 
@@ -121,7 +128,7 @@ const StyledLink = styled('a', {
     `}
   &:hover,
   &:focus {
-    ${StyledIcon} {
+    ${StyledArrowLeftIcon}, ${StyledArrowRightIcon}, ${StyledOpenInNewIcon} {
       transform: ${({ theme, iconPosition }) =>
         iconPosition === 'left'
           ? `translate(${theme.space['0.5']}, 0)`
@@ -247,18 +254,18 @@ export const Link = forwardRef(
           data-variant={variant}
         >
           {!isBlank && iconPosition === 'left' ? (
-            <StyledIcon name="arrow-left" size={ICON_SIZE} />
+            <StyledArrowLeftIcon size={ICON_SIZE} />
           ) : null}
           {children}
 
           {isBlank ? (
             <StyledExternalIconContainer>
-              <StyledIcon name="open-in-new" size={BLANK_TARGET_ICON_SIZE} />
+              <StyledOpenInNewIcon size={BLANK_TARGET_ICON_SIZE} />
             </StyledExternalIconContainer>
           ) : null}
 
           {!isBlank && iconPosition === 'right' ? (
-            <StyledIcon name="arrow-right" size={ICON_SIZE} />
+            <StyledArrowRightIcon size={ICON_SIZE} />
           ) : null}
         </StyledLink>
       </Tooltip>

--- a/packages/ui/src/components/Separator/__stories__/Icon.stories.tsx
+++ b/packages/ui/src/components/Separator/__stories__/Icon.stories.tsx
@@ -7,14 +7,14 @@ export const Icon: StoryFn<typeof Separator> = () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <div>horizontal start</div>
       <Separator>
-        <RayTopArrowIcon />
+        <RayTopArrowIcon size="medium" />
       </Separator>
       <div>horizontal end</div>
     </div>
     <div style={{ alignItems: 'center', display: 'flex', gap: 2 }}>
       <div>vertical start</div>
       <Separator direction="vertical">
-        <RayTopArrowIcon />
+        <RayTopArrowIcon size="medium" />
       </Separator>
       <div>vertical end</div>
     </div>

--- a/packages/ui/src/components/Separator/__stories__/Icon.stories.tsx
+++ b/packages/ui/src/components/Separator/__stories__/Icon.stories.tsx
@@ -1,24 +1,25 @@
 import type { StoryFn } from '@storybook/react'
+import { RayTopArrowIcon } from '@ultraviolet/icons'
 import { Separator } from '..'
 
-export const Icon: StoryFn<typeof Separator> = ({ icon }) => (
+export const Icon: StoryFn<typeof Separator> = () => (
   <>
     <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <div>horizontal start</div>
-      <Separator icon={icon} />
+      <Separator>
+        <RayTopArrowIcon />
+      </Separator>
       <div>horizontal end</div>
     </div>
     <div style={{ alignItems: 'center', display: 'flex', gap: 2 }}>
       <div>vertical start</div>
-      <Separator direction="vertical" icon={icon} />
+      <Separator direction="vertical">
+        <RayTopArrowIcon />
+      </Separator>
       <div>vertical end</div>
     </div>
   </>
 )
-
-Icon.args = {
-  icon: 'ray-top-arrow',
-}
 
 Icon.decorators = [
   Story => (

--- a/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
@@ -75,27 +75,9 @@ exports[`Separator > renders correctly with custom color 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Separator > renders correctly with custom color and icon 1`] = `
+exports[`Separator > renders correctly with custom color 2`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-0 svg {
-  fill: #e9eaeb;
-}
-
-.emotion-2 {
   margin: 0;
   border: 0;
   width: auto;
@@ -104,54 +86,16 @@ exports[`Separator > renders correctly with custom color and icon 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   background-color: #e9eaeb;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-4 {
-  vertical-align: middle;
-  fill: #641cb3;
-  height: 24px;
-  width: 24px;
-  min-width: 24px;
-  min-height: 24px;
-}
-
-.emotion-4 .fillStroke {
-  stroke: #641cb3;
-  fill: none;
 }
 
 <div
     data-testid="testing"
   >
-    <div
+    <hr
       aria-orientation="horizontal"
       class="emotion-0 emotion-1"
       role="separator"
-    >
-      <hr
-        class="emotion-2 emotion-3"
-      />
-      <svg
-        class="emotion-4 emotion-5"
-        viewBox="0 0 20 20"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clip-rule="evenodd"
-          d="M8.25 2a.75.75 0 0 1 .75.75v8.69l1.22-1.22a.75.75 0 1 1 1.06 1.06l-2.5 2.5a.75.75 0 0 1-1.06 0l-2.5-2.5a.75.75 0 1 1 1.06-1.06l1.22 1.22V2.75A.75.75 0 0 1 8.25 2"
-          fill-rule="evenodd"
-        />
-        <path
-          d="M10.25 4a2 2 0 1 1-4 0 2 2 0 0 1 4 0"
-        />
-      </svg>
-      <hr
-        class="emotion-2 emotion-3"
-      />
-    </div>
+    />
   </div>
 </DocumentFragment>
 `;
@@ -371,6 +315,87 @@ exports[`Separator > renders correctly with custom icon vertically 1`] = `
   >
     <div
       aria-orientation="vertical"
+      class="emotion-0 emotion-1"
+      role="separator"
+    >
+      <hr
+        class="emotion-2 emotion-3"
+      />
+      <svg
+        class="emotion-4 emotion-5"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M8.25 2a.75.75 0 0 1 .75.75v8.69l1.22-1.22a.75.75 0 1 1 1.06 1.06l-2.5 2.5a.75.75 0 0 1-1.06 0l-2.5-2.5a.75.75 0 1 1 1.06-1.06l1.22 1.22V2.75A.75.75 0 0 1 8.25 2"
+          fill-rule="evenodd"
+        />
+        <path
+          d="M10.25 4a2 2 0 1 1-4 0 2 2 0 0 1 4 0"
+        />
+      </svg>
+      <hr
+        class="emotion-2 emotion-3"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Separator > renders correctly with custom sentiment and icon 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0 svg {
+  fill: #521094;
+}
+
+.emotion-2 {
+  margin: 0;
+  border: 0;
+  width: auto;
+  height: 1px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  background-color: #521094;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: #3f4250;
+  height: 24px;
+  width: 24px;
+  min-width: 24px;
+  min-height: 24px;
+}
+
+.emotion-4 .fillStroke {
+  stroke: #3f4250;
+  fill: none;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      aria-orientation="horizontal"
       class="emotion-0 emotion-1"
       role="separator"
     >

--- a/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
@@ -91,6 +91,10 @@ exports[`Separator > renders correctly with custom color and icon 1`] = `
   align-items: center;
 }
 
+.emotion-0 svg {
+  fill: #e9eaeb;
+}
+
 .emotion-2 {
   margin: 0;
   border: 0;
@@ -99,23 +103,22 @@ exports[`Separator > renders correctly with custom color and icon 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  background-color: #521094;
+  background-color: #e9eaeb;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.emotion-5 {
+.emotion-4 {
   vertical-align: middle;
   fill: #641cb3;
   height: 24px;
   width: 24px;
   min-width: 24px;
   min-height: 24px;
-  fill: #521094;
 }
 
-.emotion-5 .fillStroke {
+.emotion-4 .fillStroke {
   stroke: #641cb3;
   fill: none;
 }
@@ -132,7 +135,7 @@ exports[`Separator > renders correctly with custom color and icon 1`] = `
         class="emotion-2 emotion-3"
       />
       <svg
-        class="emotion-4 emotion-5 emotion-6"
+        class="emotion-4 emotion-5"
         viewBox="0 0 20 20"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -169,6 +172,10 @@ exports[`Separator > renders correctly with custom icon 1`] = `
   align-items: center;
 }
 
+.emotion-0 svg {
+  fill: #e9eaeb;
+}
+
 .emotion-2 {
   margin: 0;
   border: 0;
@@ -183,17 +190,16 @@ exports[`Separator > renders correctly with custom icon 1`] = `
   flex: 1;
 }
 
-.emotion-5 {
+.emotion-4 {
   vertical-align: middle;
   fill: #3f4250;
   height: 24px;
   width: 24px;
   min-width: 24px;
   min-height: 24px;
-  fill: #e9eaeb;
 }
 
-.emotion-5 .fillStroke {
+.emotion-4 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
@@ -210,7 +216,7 @@ exports[`Separator > renders correctly with custom icon 1`] = `
         class="emotion-2 emotion-3"
       />
       <svg
-        class="emotion-4 emotion-5 emotion-6"
+        class="emotion-4 emotion-5"
         viewBox="0 0 20 20"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -247,6 +253,10 @@ exports[`Separator > renders correctly with custom icon horizontally 1`] = `
   align-items: center;
 }
 
+.emotion-0 svg {
+  fill: #e9eaeb;
+}
+
 .emotion-2 {
   margin: 0;
   border: 0;
@@ -261,17 +271,16 @@ exports[`Separator > renders correctly with custom icon horizontally 1`] = `
   flex: 1;
 }
 
-.emotion-5 {
+.emotion-4 {
   vertical-align: middle;
   fill: #3f4250;
   height: 24px;
   width: 24px;
   min-width: 24px;
   min-height: 24px;
-  fill: #e9eaeb;
 }
 
-.emotion-5 .fillStroke {
+.emotion-4 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
@@ -288,7 +297,7 @@ exports[`Separator > renders correctly with custom icon horizontally 1`] = `
         class="emotion-2 emotion-3"
       />
       <svg
-        class="emotion-4 emotion-5 emotion-6"
+        class="emotion-4 emotion-5"
         viewBox="0 0 20 20"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -325,6 +334,10 @@ exports[`Separator > renders correctly with custom icon vertically 1`] = `
   align-items: center;
 }
 
+.emotion-0 svg {
+  fill: #e9eaeb;
+}
+
 .emotion-2 {
   margin: 0;
   border: 0;
@@ -339,17 +352,16 @@ exports[`Separator > renders correctly with custom icon vertically 1`] = `
   flex: 1;
 }
 
-.emotion-5 {
+.emotion-4 {
   vertical-align: middle;
   fill: #3f4250;
   height: 24px;
   width: 24px;
   min-width: 24px;
   min-height: 24px;
-  fill: #e9eaeb;
 }
 
-.emotion-5 .fillStroke {
+.emotion-4 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
@@ -366,7 +378,7 @@ exports[`Separator > renders correctly with custom icon vertically 1`] = `
         class="emotion-2 emotion-3"
       />
       <svg
-        class="emotion-4 emotion-5 emotion-6"
+        class="emotion-4 emotion-5"
         viewBox="0 0 20 20"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/packages/ui/src/components/Separator/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Separator/__tests__/index.test.tsx
@@ -15,12 +15,15 @@ describe('Separator', () => {
   test(`renders correctly with custom color`, () =>
     shouldMatchEmotionSnapshot(<Separator color="primary" />))
 
+  test(`renders correctly with custom color`, () =>
+    shouldMatchEmotionSnapshot(<Separator sentiment="primary" />))
+
   test(`renders correctly with custom icon`, () =>
     shouldMatchEmotionSnapshot(<Separator icon="ray-top-arrow" />))
 
-  test(`renders correctly with custom color and icon`, () =>
+  test(`renders correctly with custom sentiment and icon`, () =>
     shouldMatchEmotionSnapshot(
-      <Separator color="primary" icon="ray-top-arrow" />,
+      <Separator sentiment="primary" icon="ray-top-arrow" />,
     ))
   test(`renders correctly with custom icon vertically`, () =>
     shouldMatchEmotionSnapshot(

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { Icon } from '@ultraviolet/icons/legacy'
-import type { ComponentProps } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import type { Color } from '../../theme'
 
 type Direction = 'horizontal' | 'vertical'
@@ -43,12 +43,16 @@ const StyledHr = styled('hr', {
 `
 
 type SeparatorProps = {
+  /**
+   * @deprecated: Use the icon directly in children
+   */
   icon?: ComponentProps<typeof Icon>['name']
   direction?: Direction
   thickness?: number
   color?: Color
   className?: string
   'data-testid'?: string
+  children?: ReactNode
 }
 
 /**
@@ -61,6 +65,7 @@ export const Separator = ({
   icon,
   className,
   'data-testid': dataTestId,
+  children,
 }: SeparatorProps) =>
   icon ? (
     <StyledIconWrapper
@@ -76,6 +81,7 @@ export const Separator = ({
         color={color}
         hasIcon
       />
+      {children}
       <StyledIcon name={icon} size={24} color={color} />
       <StyledHr
         direction={direction}

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -71,7 +71,7 @@ export const Separator = ({
   direction = 'horizontal',
   thickness = 1,
   color = 'neutral',
-  sentiment = 'neutral',
+  sentiment,
   icon,
   className,
   'data-testid': dataTestId,

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -7,19 +7,22 @@ type Direction = 'horizontal' | 'vertical'
 
 type StyledIconProps = {
   direction: Direction
+  color: Color
+  sentiment: Color
 }
 
 const StyledIconWrapper = styled('div', {
-  shouldForwardProp: prop => !['direction'].includes(prop),
+  shouldForwardProp: prop =>
+    !['direction', 'color', 'sentiment'].includes(prop),
 })<StyledIconProps>`
   display: flex;
   flex-direction: ${({ direction }) =>
     direction === 'vertical' ? 'column' : 'row'};
   align-items: center;
-`
 
-const StyledIcon = styled(Icon)<{ color: Color }>`
-  fill: ${({ color, theme }) => theme.colors[color].borderWeak};
+  svg {
+    fill: ${({ sentiment, color, theme }) => (sentiment ? theme.colors[sentiment].borderWeak : theme.colors[color].borderWeak)};
+  }
 `
 
 type HorizontalSeparatorProps = SeparatorProps & {
@@ -28,7 +31,7 @@ type HorizontalSeparatorProps = SeparatorProps & {
 
 const StyledHr = styled('hr', {
   shouldForwardProp: prop =>
-    !['direction', 'thickness', 'color', 'hasIcon'].includes(prop),
+    !['direction', 'thickness', 'color', 'hasIcon', 'sentiment'].includes(prop),
 })<HorizontalSeparatorProps>`
   margin: 0;
   border: 0;
@@ -37,19 +40,25 @@ const StyledHr = styled('hr', {
   height: ${({ direction, thickness = 1 }) =>
     direction === 'horizontal' ? `${thickness}px` : 'auto'};
   flex-shrink: 0;
-  background-color: ${({ theme, color }) =>
-    theme.colors[color as Color].borderWeak};
+  background-color: ${({ theme, color, sentiment }) =>
+    sentiment
+      ? theme.colors[sentiment].borderWeak
+      : theme.colors[color as Color].borderWeak};
   ${({ hasIcon }) => hasIcon && `flex: 1;`}
 `
 
 type SeparatorProps = {
   /**
-   * @deprecated: Use the icon directly in children
+   * @deprecated Use the icon directly in children
    */
   icon?: ComponentProps<typeof Icon>['name']
   direction?: Direction
   thickness?: number
+  /**
+   * @deprecated Use `sentiment` instead
+   */
   color?: Color
+  sentiment?: Color
   className?: string
   'data-testid'?: string
   children?: ReactNode
@@ -62,31 +71,36 @@ export const Separator = ({
   direction = 'horizontal',
   thickness = 1,
   color = 'neutral',
+  sentiment = 'neutral',
   icon,
   className,
   'data-testid': dataTestId,
   children,
 }: SeparatorProps) =>
-  icon ? (
+  icon || children ? (
     <StyledIconWrapper
       role="separator"
       aria-orientation={direction}
       direction={direction}
       className={className}
       data-testid={dataTestId}
+      sentiment={sentiment}
+      color={color}
     >
       <StyledHr
         direction={direction}
         thickness={thickness}
         color={color}
+        sentiment={sentiment}
         hasIcon
       />
       {children}
-      <StyledIcon name={icon} size={24} color={color} />
+      {icon ? <Icon name={icon} size={24} color={color} /> : null}
       <StyledHr
         direction={direction}
         thickness={thickness}
         color={color}
+        sentiment={sentiment}
         hasIcon
       />
     </StyledIconWrapper>

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -8,7 +8,7 @@ type Direction = 'horizontal' | 'vertical'
 type StyledIconProps = {
   direction: Direction
   color: Color
-  sentiment: Color
+  sentiment?: Color
 }
 
 const StyledIconWrapper = styled('div', {

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -4018,7 +4018,9 @@ exports[`Tabs > renders correctly with custom Tabs component 1`] = `
   line-height: 1.5rem;
 }
 
-.emotion-15 .e1afnb7a2 {
+.emotion-15 .e1afnb7a2,
+.emotion-15 .e1afnb7a3,
+.emotion-15 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -4038,7 +4040,11 @@ exports[`Tabs > renders correctly with custom Tabs component 1`] = `
 }
 
 .emotion-15:hover .e1afnb7a2,
-.emotion-15:focus .e1afnb7a2 {
+.emotion-15:focus .e1afnb7a2,
+.emotion-15:hover .e1afnb7a3,
+.emotion-15:focus .e1afnb7a3,
+.emotion-15:hover .e1afnb7a4,
+.emotion-15:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);

--- a/packages/ui/src/components/Toaster/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Toaster/__tests__/__snapshots__/index.test.tsx.snap
@@ -168,7 +168,9 @@ exports[`Toaster > components > renders correctly Toast.Link 1`] = `
   text-case: none;
 }
 
-.emotion-0 .e1afnb7a2 {
+.emotion-0 .e1afnb7a2,
+.emotion-0 .e1afnb7a3,
+.emotion-0 .e1afnb7a4 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
@@ -188,7 +190,11 @@ exports[`Toaster > components > renders correctly Toast.Link 1`] = `
 }
 
 .emotion-0:hover .e1afnb7a2,
-.emotion-0:focus .e1afnb7a2 {
+.emotion-0:focus .e1afnb7a2,
+.emotion-0:hover .e1afnb7a3,
+.emotion-0:focus .e1afnb7a3,
+.emotion-0:hover .e1afnb7a4,
+.emotion-0:focus .e1afnb7a4 {
   -webkit-transform: translate(-0.25rem, 0);
   -moz-transform: translate(-0.25rem, 0);
   -ms-transform: translate(-0.25rem, 0);


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

In `<Badge />` component, `icon` props is deprecated. You can directly use the imported icon you need in the children.

```tsx
// Before
import { Badge } from '@ultraviolet/ui'

<Badge icon="pencil">
  Edit
</Badge>
```

```tsx
// After
import { Badge } from '@ultraviolet/ui'
import { PencilOutlineIcon } from '@ultraviolet/icons'

<Badge>
  Edit <PencilOutlineIcon />
</Badge>
```
