### PR TITLE
fix(Navigation): wrong icons and wrong size

### DIFF
--- a/.changeset/nervous-rings-add.md
+++ b/.changeset/nervous-rings-add.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<Navigation />` icons

--- a/packages/plus/src/components/Navigation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/Navigation/__tests__/__snapshots__/index.test.tsx.snap
@@ -1357,10 +1357,10 @@ exports[`Navigation > click on expand / collapse button 1`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -1381,10 +1381,10 @@ exports[`Navigation > click on expand / collapse button 1`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -4395,10 +4395,10 @@ exports[`Navigation > pin and unpin an item 1`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -4419,10 +4419,10 @@ exports[`Navigation > pin and unpin an item 1`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -6360,10 +6360,10 @@ exports[`Navigation > pin and unpin an item 2`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -6384,10 +6384,10 @@ exports[`Navigation > pin and unpin an item 2`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -8141,10 +8141,10 @@ exports[`Navigation > pin and unpin an item 3`] = `
 .emotion-60 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -8699,7 +8699,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                           viewBox="0 0 20 20"
                         >
                           <path
-                            d="m22.67 12-4.49 4.5-2.51-2.5 1.98-2-1.98-1.96 2.51-2.51zM12 1.33l4.47 4.49-2.51 2.51L12 6.35l-2 1.98-2.5-2.51zm0 21.34-4.47-4.49 2.51-2.51L12 17.65l2-1.98 2.5 2.51zM1.33 12l4.49-4.5L8.33 10l-1.98 2 1.98 1.96-2.51 2.51zM12 10a2 2 0 0 1 2 2 2 2 0 0 1-2 2 2 2 0 0 1-2-2 2 2 0 0 1 2-2"
+                            d="M9 20q-.825 0-1.412-.587A1.93 1.93 0 0 1 7 18q0-.824.588-1.413A1.93 1.93 0 0 1 9 16q.825 0 1.412.587Q11 17.176 11 18t-.588 1.413A1.93 1.93 0 0 1 9 20m6 0q-.825 0-1.412-.587A1.93 1.93 0 0 1 13 18q0-.824.588-1.413A1.93 1.93 0 0 1 15 16q.824 0 1.413.587Q17 17.176 17 18t-.587 1.413A1.93 1.93 0 0 1 15 20m-6-6q-.825 0-1.412-.588A1.93 1.93 0 0 1 7 12q0-.825.588-1.412A1.93 1.93 0 0 1 9 10q.825 0 1.412.588Q11 11.175 11 12t-.588 1.412A1.93 1.93 0 0 1 9 14m6 0q-.825 0-1.412-.588A1.93 1.93 0 0 1 13 12q0-.825.588-1.412A1.93 1.93 0 0 1 15 10q.824 0 1.413.588Q17 11.175 17 12t-.587 1.412A1.93 1.93 0 0 1 15 14M9 8q-.825 0-1.412-.588A1.93 1.93 0 0 1 7 6q0-.824.588-1.412A1.93 1.93 0 0 1 9 4q.825 0 1.412.588Q11 5.175 11 6q0 .824-.588 1.412A1.93 1.93 0 0 1 9 8m6 0q-.825 0-1.412-.588A1.93 1.93 0 0 1 13 6q0-.824.588-1.412A1.93 1.93 0 0 1 15 4q.824 0 1.413.588Q17 5.175 17 6q0 .824-.587 1.412A1.93 1.93 0 0 1 15 8"
                           />
                         </svg>
                         <div
@@ -9643,10 +9643,10 @@ exports[`Navigation > render with basic content 1`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -12361,10 +12361,10 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -12385,10 +12385,10 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
 .emotion-90 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
+  height: 1.25rem;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
   position: absolute;
   top: 0;
   bottom: 0;

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import {
   ArrowDownIcon,
   ArrowRightIcon,
-  DragVariantIcon,
+  DragIcon,
   OpenInNewIcon,
   PinOutlineIcon,
   UnpinIcon,
@@ -92,7 +92,7 @@ const LocalExpandButton = styled(Button)`
 
 const PinnedButton = LocalExpandButton.withComponent('div')
 
-const GrabIcon = styled(DragVariantIcon)`
+const GrabIcon = styled(DragIcon)`
   opacity: 0;
   margin: 0 ${({ theme }) => theme.space['0.25']};
   cursor: grab;
@@ -673,7 +673,7 @@ export const Item = memo(
                           disabled={isItemPinned ? false : isPinDisabled}
                         >
                           <PinUnpinIcon
-                            size="large"
+                            size="medium"
                             disabled={isItemPinned ? false : isPinDisabled}
                             sentiment={active ? 'primary' : 'neutral'}
                             active={active}
@@ -867,7 +867,7 @@ export const Item = memo(
                       disabled={isItemPinned ? false : isPinDisabled}
                     >
                       <PinUnpinIcon
-                        size="large"
+                        size="medium"
                         disabled={isItemPinned ? false : isPinDisabled}
                         sentiment={active ? 'primary' : 'neutral'}
                         active={active}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<Navigation />` icons

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="266" alt="Screenshot 2025-02-11 at 16 12 11" src="https://github.com/user-attachments/assets/828e22a3-3760-4fe3-b6e8-9c78ee0a412b" /> | <img width="267" alt="Screenshot 2025-02-11 at 16 12 20" src="https://github.com/user-attachments/assets/7eb4333f-ec0f-4020-8597-6ed07ce6a843" /> |
