### PR TITLE
fix(Menuv2): min/max width

### DIFF
--- a/.changeset/orange-olives-search.md
+++ b/.changeset/orange-olives-search.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<MenuV2 />`: now have a min and max width instead of a fixed width

--- a/packages/ui/src/components/MenuV2/MenuContent.tsx
+++ b/packages/ui/src/components/MenuV2/MenuContent.tsx
@@ -22,7 +22,7 @@ import type { MenuProps } from './types'
 
 const StyledPopup = styled(Popup, {
   shouldForwardProp: prop => !['size', 'searchable'].includes(prop),
-})<{ size: keyof typeof SIZES; searchable: boolean }>`
+})<{ size?: keyof typeof SIZES; searchable: boolean }>`
   background-color: ${({ theme }) => theme.colors.other.elevation.background.raised};
   box-shadow: ${({ theme }) => `${theme.shadows.raised[0]}, ${theme.shadows.raised[1]}`};
   padding: 0;
@@ -34,8 +34,9 @@ const StyledPopup = styled(Popup, {
     }
   }
 
-  width: ${({ size }) => SIZES[size]};
-  max-width: none;
+  min-width: ${SIZES.small};
+  max-width: ${SIZES.large};
+  ${({ size }) => (size ? `width: ${SIZES[size]};` : null)}
   ${({ searchable }) => (searchable ? `min-width: 20rem` : null)};
   padding: ${({ theme }) => `${theme.space['0.25']} 0`};
 `
@@ -85,7 +86,7 @@ export const Menu = forwardRef(
       maxHeight,
       maxWidth,
       portalTarget = document.body,
-      size = 'small',
+      size,
       triggerMethod = 'click',
       dynamicDomRendering,
       align,

--- a/packages/ui/src/components/MenuV2/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/components/MenuV2/__stories__/Playground.stories.tsx
@@ -5,7 +5,10 @@ export const Playground = Template.bind({})
 
 Playground.args = {
   children: [
-    <MenuV2.Item borderless>Information with a long name</MenuV2.Item>,
+    <MenuV2.Item borderless>
+      Information with a very long name. Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit.
+    </MenuV2.Item>,
     <MenuV2.Item borderless>Power on</MenuV2.Item>,
   ],
 }

--- a/packages/ui/src/components/MenuV2/types.ts
+++ b/packages/ui/src/components/MenuV2/types.ts
@@ -44,6 +44,9 @@ export type MenuProps = {
    * behavior by setting a portalTarget prop.
    */
   portalTarget?: HTMLElement
+  /**
+   * @deprecated The size of the menu is automatic now to fit the content. Use this prop to set a fixed size.
+   */
   size?: keyof typeof SIZES
   /**
    * The behavior of the menu when it is opened. If set to `click`, the menu will open when the user clicks on the disclosure.

--- a/packages/ui/src/components/Tabs/__stories__/Showcase.stories.tsx
+++ b/packages/ui/src/components/Tabs/__stories__/Showcase.stories.tsx
@@ -1,4 +1,5 @@
 import { Tabs } from '..'
+import { Badge } from '../../Badge'
 import { Template } from './Template.stories'
 
 export const Showcase = Template.bind({})
@@ -46,6 +47,9 @@ Showcase.args = {
     </Tabs.Tab>,
     <Tabs.Tab key="9" value="9" counter={10}>
       Choice 9
+    </Tabs.Tab>,
+    <Tabs.Tab key="10" value="10">
+      Lots of info <Badge>New badge very long</Badge>
     </Tabs.Tab>,
   ],
   selected: 1,

--- a/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -2284,8 +2284,8 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   background-color: #ffffff;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
   padding: 0;
-  width: 11.25rem;
-  max-width: none;
+  min-width: 11.25rem;
+  max-width: 23.75rem;
   padding: 0.125rem 0;
 }
 
@@ -2507,8 +2507,8 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   background-color: #ffffff;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
   padding: 0;
-  width: 11.25rem;
-  max-width: none;
+  min-width: 11.25rem;
+  max-width: 23.75rem;
   padding: 0.125rem 0;
 }
 
@@ -3428,8 +3428,8 @@ exports[`Tabs > renders correctly with Tabs with prop 1`] = `
   background-color: #ffffff;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
   padding: 0;
-  width: 11.25rem;
-  max-width: none;
+  min-width: 11.25rem;
+  max-width: 23.75rem;
   padding: 0.125rem 0;
 }
 


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

- `<MenuV2 />`: now have a min and max width instead of a fixed width, `size` is deprecated
- Updated a story of Tab to show the automatic sizing of MenuV2
