### PR TITLE
fix(Navigation): allow better links on navigation items

### DIFF
--- a/.changeset/cyan-pants-search.md
+++ b/.changeset/cyan-pants-search.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": minor
+---
+
+Improve `<Navigation.Item />` component by adding props `rel` and `target`. Previously a `href` item meant external link, it has now changed. Take this in consideration as your links might not open in a new browser and not have the external icon anymore.

--- a/.changeset/slimy-laws-grab.md
+++ b/.changeset/slimy-laws-grab.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+New props `rel` and `target` on `<MenuV2.Item />`

--- a/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
+++ b/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
@@ -123,6 +123,7 @@ const PlaygroundContent = ({ ...props }: ComponentProps<typeof Navigation>) => {
             label="Dedibox"
             id="dedibox"
             href="https://scaleway.com"
+            target="_blank"
             active={active === 'Dedibox'}
             onClickPinUnpin={onClickPinUnpin}
             onToggle={() => setActive('Dedibox')}
@@ -305,6 +306,7 @@ const PlaygroundContent = ({ ...props }: ComponentProps<typeof Navigation>) => {
           badgeText="new"
           badgeSentiment="success"
           href="http://scaleway.com"
+          target="_blank"
           active={active === 'Documentation'}
           onClickPinUnpin={onClickPinUnpin}
           onToggle={() => setActive('Documentation')}
@@ -313,6 +315,7 @@ const PlaygroundContent = ({ ...props }: ComponentProps<typeof Navigation>) => {
           label="Feature Request"
           id="feature-request"
           href="http://scaleway.com"
+          target="_blank"
           active={active === 'Feature Request'}
           onClickPinUnpin={onClickPinUnpin}
           onToggle={() => setActive('Feature Request')}

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -300,7 +300,9 @@ type ItemProps = {
    * `@ultraviolet/ui`
    */
   badgeSentiment?: ComponentProps<typeof Badge>['sentiment']
-  href?: string
+  href?: HTMLAnchorElement['href']
+  target?: HTMLAnchorElement['target']
+  rel?: HTMLAnchorElement['rel']
   /**
    * This function will be triggered on click of the item. If the item is expandable
    * toggle will be passed with it.
@@ -362,6 +364,8 @@ export const Item = memo(
     badgeText,
     badgeSentiment,
     href,
+    target,
+    rel,
     onToggle,
     onClickPinUnpin,
     toggle,
@@ -543,7 +547,8 @@ export const Item = memo(
             onClick={triggerToggle}
             aria-expanded={ariaExpanded}
             href={href}
-            target={href ? '_blank' : undefined}
+            target={target}
+            rel={rel}
             data-is-pinnable={shouldShowPinnedButton}
             data-is-active={active}
             data-animation={shouldAnimate ? animation : undefined}
@@ -684,7 +689,7 @@ export const Item = memo(
                   ) : null}
                 </>
               ) : null}
-              {hasHrefAndNoChildren ? (
+              {hasHrefAndNoChildren && target === '_blank' ? (
                 <AnimatedIcon
                   sentiment="neutral"
                   prominence="default"
@@ -794,6 +799,8 @@ export const Item = memo(
       return (
         <StyledMenuItem
           href={href}
+          target={target}
+          rel={rel}
           borderless
           active={active}
           disabled={disabled}
@@ -823,7 +830,7 @@ export const Item = memo(
                   {badgeText}
                 </StyledBadge>
               ) : null}
-              {hasHrefAndNoChildren ? (
+              {hasHrefAndNoChildren && target === '_blank' ? (
                 <AnimatedIcon
                   sentiment="neutral"
                   prominence="weak"
@@ -892,7 +899,8 @@ export const Item = memo(
               alignItems="center"
               justifyContent="center"
               href={href}
-              target="_blank"
+              target={target}
+              rel={rel}
             >
               <AnimatedIcon sentiment="neutral" prominence="weak" />
             </Container>

--- a/packages/ui/src/components/MenuV2/components/Item.tsx
+++ b/packages/ui/src/components/MenuV2/components/Item.tsx
@@ -103,7 +103,9 @@ const StyledLinkItem = styled('a', {
 `
 
 type ItemProps = {
-  href?: string | undefined
+  href?: HTMLAnchorElement['href']
+  target?: HTMLAnchorElement['target']
+  rel?: HTMLAnchorElement['rel']
   disabled?: boolean | undefined
   tooltip?: string | undefined
   className?: string | undefined
@@ -123,6 +125,8 @@ const Item = forwardRef<HTMLElement, ItemProps>(
       onClick,
       sentiment = 'neutral',
       href,
+      target,
+      rel,
       children,
       tooltip,
       active,
@@ -154,6 +158,8 @@ const Item = forwardRef<HTMLElement, ItemProps>(
               data-active={active}
               borderless
               href={href}
+              target={target}
+              rel={rel}
               ref={ref as Ref<HTMLAnchorElement>}
               onClick={onClickHandle}
               role="menuitem"


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Improve `<Navigation.Item />` component by adding props `rel` and `target`. Previously a `href` item meant external link, it has now changed. Take this in consideration as your links might not open in a new browser and not have the external icon anymore.

New props `rel` and `target` on `<MenuV2.Item />`
