### PR TITLE
fix: all group inputs

### DIFF
--- a/.changeset/thick-pandas-hunt.md
+++ b/.changeset/thick-pandas-hunt.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<RadioGroup />`, `<CheckboxGroup />` and `<ToggleGroup />` not to show empty div when legend is empty

--- a/packages/ui/src/components/CheckboxGroup/index.tsx
+++ b/packages/ui/src/components/CheckboxGroup/index.tsx
@@ -95,7 +95,7 @@ const StyledRequiredIcon = styled(AsteriskIcon)`
 `
 
 type CheckboxGroupProps = {
-  legend: ReactNode
+  legend?: ReactNode
   value?: string[]
   className?: string
   helper?: ReactNode
@@ -139,29 +139,33 @@ export const CheckboxGroup = ({
       <Stack gap={1}>
         <FieldSet className={className}>
           <Stack gap={1.5}>
-            <Stack gap={0.5}>
-              <Text
-                as="legend"
-                variant="bodyStrong"
-                sentiment="neutral"
-                prominence="strong"
-              >
-                {legend}&nbsp;
-                {required ? (
-                  <StyledRequiredIcon sentiment="danger" size={8} />
+            {legend || description ? (
+              <Stack gap={0.5}>
+                {legend ? (
+                  <Text
+                    as="legend"
+                    variant="bodyStrong"
+                    sentiment="neutral"
+                    prominence="strong"
+                  >
+                    {legend}&nbsp;
+                    {required ? (
+                      <StyledRequiredIcon sentiment="danger" size={8} />
+                    ) : null}
+                  </Text>
                 ) : null}
-              </Text>
-              {description ? (
-                <Text
-                  variant="bodySmall"
-                  as={typeof description === 'string' ? 'p' : 'div'}
-                  prominence="weak"
-                  sentiment="neutral"
-                >
-                  {description}
-                </Text>
-              ) : null}
-            </Stack>
+                {description ? (
+                  <Text
+                    variant="bodySmall"
+                    as={typeof description === 'string' ? 'p' : 'div'}
+                    prominence="weak"
+                    sentiment="neutral"
+                  >
+                    {description}
+                  </Text>
+                ) : null}
+              </Stack>
+            ) : null}
             <Stack gap={direction === 'column' ? 1 : 2} direction={direction}>
               {children}
             </Stack>

--- a/packages/ui/src/components/RadioGroup/index.tsx
+++ b/packages/ui/src/components/RadioGroup/index.tsx
@@ -88,7 +88,7 @@ const StyledRequiredIcon = styled(AsteriskIcon)`
 `
 
 type RadioGroupProps = {
-  legend: ReactNode
+  legend?: ReactNode
   value: string | number
   className?: string
   helper?: ReactNode
@@ -131,29 +131,33 @@ export const RadioGroup = ({
       <Stack gap={1}>
         <FieldSet className={className}>
           <Stack gap={1.5}>
-            <Stack gap={0.5}>
-              <Text
-                as="legend"
-                variant="bodyStrong"
-                sentiment="neutral"
-                prominence="strong"
-              >
-                {legend}&nbsp;
-                {required ? (
-                  <StyledRequiredIcon sentiment="danger" size={8} />
+            {legend || description ? (
+              <Stack gap={0.5}>
+                {legend ? (
+                  <Text
+                    as="legend"
+                    variant="bodyStrong"
+                    sentiment="neutral"
+                    prominence="strong"
+                  >
+                    {legend}&nbsp;
+                    {required ? (
+                      <StyledRequiredIcon sentiment="danger" size={8} />
+                    ) : null}
+                  </Text>
                 ) : null}
-              </Text>
-              {description ? (
-                <Text
-                  variant="bodySmall"
-                  as={typeof description === 'string' ? 'p' : 'div'}
-                  prominence="weak"
-                  sentiment="neutral"
-                >
-                  {description}
-                </Text>
-              ) : null}
-            </Stack>
+                {description ? (
+                  <Text
+                    variant="bodySmall"
+                    as={typeof description === 'string' ? 'p' : 'div'}
+                    prominence="weak"
+                    sentiment="neutral"
+                  >
+                    {description}
+                  </Text>
+                ) : null}
+              </Stack>
+            ) : null}
             <Stack
               gap={direction === 'column' ? 1 : 2}
               direction={direction}

--- a/packages/ui/src/components/ToggleGroup/index.tsx
+++ b/packages/ui/src/components/ToggleGroup/index.tsx
@@ -81,7 +81,7 @@ const StyledRequiredIcon = styled(AsteriskIcon)`
 `
 
 type ToggleGroupProps = {
-  legend: ReactNode
+  legend?: ReactNode
   value?: string[]
   className?: string
   helper?: ReactNode
@@ -121,29 +121,33 @@ export const ToggleGroup = ({
       <Stack gap={1}>
         <FieldSet className={className}>
           <Stack gap={1.5}>
-            <Stack gap={0.5}>
-              <Text
-                as="legend"
-                variant="bodyStrong"
-                sentiment="neutral"
-                prominence="strong"
-              >
-                {legend}&nbsp;
-                {required ? (
-                  <StyledRequiredIcon color="danger" size={8} />
+            {legend || description ? (
+              <Stack gap={0.5}>
+                {legend ? (
+                  <Text
+                    as="legend"
+                    variant="bodyStrong"
+                    sentiment="neutral"
+                    prominence="strong"
+                  >
+                    {legend}&nbsp;
+                    {required ? (
+                      <StyledRequiredIcon color="danger" size={8} />
+                    ) : null}
+                  </Text>
                 ) : null}
-              </Text>
-              {description ? (
-                <Text
-                  variant="bodySmall"
-                  as={typeof description === 'string' ? 'p' : 'div'}
-                  prominence="weak"
-                  sentiment="neutral"
-                >
-                  {description}
-                </Text>
-              ) : null}
-            </Stack>
+                {description ? (
+                  <Text
+                    variant="bodySmall"
+                    as={typeof description === 'string' ? 'p' : 'div'}
+                    prominence="weak"
+                    sentiment="neutral"
+                  >
+                    {description}
+                  </Text>
+                ) : null}
+              </Stack>
+            ) : null}
             <Stack gap={2} direction={direction}>
               {children}
             </Stack>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

When no legend is set there is a blank space

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1043" alt="Screenshot 2025-02-20 at 16 07 29" src="https://github.com/user-attachments/assets/19d50724-7040-4251-81d2-6e6d84d59f48" /> | <img width="1043" alt="Screenshot 2025-02-20 at 16 07 09" src="https://github.com/user-attachments/assets/070e67c5-a7d0-4ae8-8350-14e3014b390d" /> |
