### PR TITLE
fix(SelectInput): wrong arrow size

### DIFF
--- a/.changeset/sixty-nights-grab.md
+++ b/.changeset/sixty-nights-grab.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/plus": patch
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInput />` wrong arrow size

--- a/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -245,10 +245,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -610,10 +610,10 @@ exports[`SelectInputField > should render correctly 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -971,10 +971,10 @@ exports[`SelectInputField > should render correctly disabled 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -1334,10 +1334,10 @@ exports[`SelectInputField > should render correctly multiple 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -1703,10 +1703,10 @@ exports[`SelectInputField > should render correctly with a disabled option 1`] =
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -2085,10 +2085,10 @@ exports[`SelectInputField > should trigger events 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/CustomUnitInput.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/CustomUnitInput.test.tsx.snap
@@ -395,10 +395,10 @@ exports[`EstimateCost - CustomUnitInput > render default values 1`] = `
 .emotion-29 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-29 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Item.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Item.test.tsx.snap
@@ -1460,10 +1460,10 @@ exports[`EstimateCost - Item > render with labelTextVariant 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -1474,10 +1474,10 @@ exports[`EstimateCost - Item > render with labelTextVariant 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -2811,10 +2811,10 @@ exports[`EstimateCost - Item > render with noPrice and noBorder 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -4744,10 +4744,10 @@ exports[`EstimateCost - Item > render with notice 1`] = `
 .emotion-81 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-81 .fillStroke {
@@ -4758,10 +4758,10 @@ exports[`EstimateCost - Item > render with notice 1`] = `
 .emotion-81 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-81 .fillStroke {
@@ -6827,10 +6827,10 @@ exports[`EstimateCost - Item > render with priceText 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -6841,10 +6841,10 @@ exports[`EstimateCost - Item > render with priceText 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -8892,10 +8892,10 @@ exports[`EstimateCost - Item > render with tabulation 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -8906,10 +8906,10 @@ exports[`EstimateCost - Item > render with tabulation 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -10987,10 +10987,10 @@ exports[`EstimateCost - Item > render with tooltipInfo 1`] = `
 .emotion-84 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-84 .fillStroke {
@@ -11001,10 +11001,10 @@ exports[`EstimateCost - Item > render with tooltipInfo 1`] = `
 .emotion-84 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-84 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Region.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Region.test.tsx.snap
@@ -732,10 +732,10 @@ exports[`EstimateCost - Region > render region component 1`] = `
 .emotion-80 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-80 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
@@ -715,10 +715,10 @@ exports[`EstimateCost - Regular Item > render basic props 1`] = `
 .emotion-77 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-77 .fillStroke {
@@ -1894,10 +1894,10 @@ exports[`EstimateCost - Regular Item > render basic props with is not defined 1`
 .emotion-75 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-75 .fillStroke {
@@ -3065,10 +3065,10 @@ exports[`EstimateCost - Regular Item > render basic props with long fractions di
 .emotion-77 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-77 .fillStroke {
@@ -4259,10 +4259,10 @@ exports[`EstimateCost - Regular Item > render basic props with maxPrice 1`] = `
 .emotion-77 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-77 .fillStroke {
@@ -5470,10 +5470,10 @@ exports[`EstimateCost - Regular Item > render basic props with maxPrice and long
 .emotion-77 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-77 .fillStroke {
@@ -6723,10 +6723,10 @@ exports[`EstimateCost - Regular Item > render basic props with overlay 1`] = `
 .emotion-98 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-98 .fillStroke {
@@ -8148,10 +8148,10 @@ exports[`EstimateCost - Regular Item > render basic props with overlay beta 1`] 
 .emotion-88 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-88 .fillStroke {
@@ -9455,10 +9455,10 @@ exports[`EstimateCost - Regular Item > render basic props with sublabel 1`] = `
 .emotion-77 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-77 .fillStroke {
@@ -10668,10 +10668,10 @@ exports[`EstimateCost - Regular Item > render basic props with textNotDefined 1`
 .emotion-77 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-77 .fillStroke {
@@ -11877,10 +11877,10 @@ exports[`EstimateCost - Regular Item > render basic with ellipsis 1`] = `
 .emotion-80 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-80 .fillStroke {
@@ -13238,10 +13238,10 @@ exports[`EstimateCost - Regular Item > render with alert 1`] = `
 .emotion-91 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-91 .fillStroke {
@@ -14453,10 +14453,10 @@ exports[`EstimateCost - Regular Item > render with isDisabledOnOverlay 1`] = `
 .emotion-75 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-75 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -715,10 +715,10 @@ exports[`EstimateCost - NumberInput Item > render basic props 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -2273,10 +2273,10 @@ exports[`EstimateCost - NumberInput Item > render basic with overlay 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -3831,10 +3831,10 @@ exports[`EstimateCost - NumberInput Item > render with getAmountValue 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -5389,10 +5389,10 @@ exports[`EstimateCost - NumberInput Item > render with values 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Strong.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Strong.test.tsx.snap
@@ -727,10 +727,10 @@ exports[`EstimateCost - Strong Item > render basic props 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -1918,10 +1918,10 @@ exports[`EstimateCost - Strong Item > render with isDisabledOnOverlay 1`] = `
 .emotion-75 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-75 .fillStroke {
@@ -3130,10 +3130,10 @@ exports[`EstimateCost - Strong Item > render with small variant 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.test.tsx.snap
@@ -715,10 +715,10 @@ exports[`EstimateCost - Unit Item > render basic props 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -2813,10 +2813,10 @@ exports[`EstimateCost - Unit Item > render basic props with monthly price 1`] = 
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -2827,10 +2827,10 @@ exports[`EstimateCost - Unit Item > render basic props with monthly price 1`] = 
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -5181,10 +5181,10 @@ exports[`EstimateCost - Unit Item > render basic props with overlay 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -5195,10 +5195,10 @@ exports[`EstimateCost - Unit Item > render basic props with overlay 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -7549,10 +7549,10 @@ exports[`EstimateCost - Unit Item > render basic props with values 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -7563,10 +7563,10 @@ exports[`EstimateCost - Unit Item > render basic props with values 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -9953,10 +9953,10 @@ exports[`EstimateCost - Unit Item > render basic props with values and no iterat
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -9967,10 +9967,10 @@ exports[`EstimateCost - Unit Item > render basic props with values and no iterat
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -12358,10 +12358,10 @@ exports[`EstimateCost - Unit Item > render test 1`] = `
 .emotion-95 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-95 .fillStroke {
@@ -12372,10 +12372,10 @@ exports[`EstimateCost - Unit Item > render test 1`] = `
 .emotion-95 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-95 .fillStroke {
@@ -14859,10 +14859,10 @@ exports[`EstimateCost - Unit Item > render with 0 amount 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -14873,10 +14873,10 @@ exports[`EstimateCost - Unit Item > render with 0 amount 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -17237,10 +17237,10 @@ exports[`EstimateCost - Unit Item > render with 10 amount 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -17251,10 +17251,10 @@ exports[`EstimateCost - Unit Item > render with 10 amount 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -19622,10 +19622,10 @@ exports[`EstimateCost - Unit Item > render with getAmountValue 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {
@@ -19636,10 +19636,10 @@ exports[`EstimateCost - Unit Item > render with getAmountValue 1`] = `
 .emotion-79 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-79 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Zone.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Zone.test.tsx.snap
@@ -750,10 +750,10 @@ exports[`EstimateCost - Zone > render region component, with animation 1`] = `
 .emotion-80 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-80 .fillStroke {
@@ -1983,10 +1983,10 @@ exports[`EstimateCost - Zone > render zone component 1`] = `
 .emotion-80 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-80 .fillStroke {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/index.test.tsx.snap
@@ -767,10 +767,10 @@ exports[`EstimateCost - index > render isBeta with discount 1`] = `
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -2075,10 +2075,10 @@ exports[`EstimateCost - index > render isBeta with discount equal to 100% 1`] = 
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -3388,10 +3388,10 @@ exports[`EstimateCost - index > render isBeta with discount more than 100% 1`] =
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -4706,10 +4706,10 @@ exports[`EstimateCost - index > render isBeta without discount 1`] = `
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -5974,10 +5974,10 @@ exports[`EstimateCost - index > render with all timeUnits values 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -7900,10 +7900,10 @@ exports[`EstimateCost - index > render with commitmentFees 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -7914,10 +7914,10 @@ exports[`EstimateCost - index > render with commitmentFees 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -9933,10 +9933,10 @@ exports[`EstimateCost - index > render with commitmentFees and iscommitmentFeesC
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -9947,10 +9947,10 @@ exports[`EstimateCost - index > render with commitmentFees and iscommitmentFeesC
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -11980,10 +11980,10 @@ exports[`EstimateCost - index > render with description as node 1`] = `
 .emotion-76 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-76 .fillStroke {
@@ -11994,10 +11994,10 @@ exports[`EstimateCost - index > render with description as node 1`] = `
 .emotion-76 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-76 .fillStroke {
@@ -13342,10 +13342,10 @@ exports[`EstimateCost - index > render with discount 0 and defaultTimeUnit month
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -15282,10 +15282,10 @@ exports[`EstimateCost - index > render with discount 0.5 and defaultTimeUnit mon
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -15296,10 +15296,10 @@ exports[`EstimateCost - index > render with discount 0.5 and defaultTimeUnit mon
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -16646,10 +16646,10 @@ exports[`EstimateCost - index > render with discount 1 and defaultTimeUnit month
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -17904,10 +17904,10 @@ exports[`EstimateCost - index > render with discount 1, isBeta and defaultTimeUn
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -19177,10 +19177,10 @@ exports[`EstimateCost - index > render with discount 100% but no isBeta 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -22134,10 +22134,10 @@ exports[`EstimateCost - index > render with hideTotal 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -22148,10 +22148,10 @@ exports[`EstimateCost - index > render with hideTotal 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -23428,10 +23428,10 @@ exports[`EstimateCost - index > render with isBeta but undefined discount 1`] = 
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -25508,10 +25508,10 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -25522,10 +25522,10 @@ exports[`EstimateCost - index > render with isBeta, discount 0 and defaultTimeUn
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -27763,10 +27763,10 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -27777,10 +27777,10 @@ exports[`EstimateCost - index > render with isBeta, discount 0.5 and defaultTime
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -29256,10 +29256,10 @@ exports[`EstimateCost - index > render with isBeta, price, discount 50% 1`] = `
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {
@@ -30524,10 +30524,10 @@ exports[`EstimateCost - index > render with item discount 50% 1`] = `
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -31742,10 +31742,10 @@ exports[`EstimateCost - index > render with item discount 50% and defaultTimeUni
 .emotion-78 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-78 .fillStroke {
@@ -32999,10 +32999,10 @@ exports[`EstimateCost - index > render with item discount 50% and text 1`] = `
 .emotion-82 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-82 .fillStroke {

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -305,10 +305,10 @@ exports[`SelectInput > renders correctly animated 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -319,10 +319,10 @@ exports[`SelectInput > renders correctly animated 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -697,10 +697,10 @@ exports[`SelectInput > renders correctly controlled 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -1109,10 +1109,10 @@ exports[`SelectInput > renders correctly default values with click 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -1123,10 +1123,10 @@ exports[`SelectInput > renders correctly default values with click 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -1627,10 +1627,10 @@ exports[`SelectInput > renders correctly disabled 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -2032,10 +2032,10 @@ exports[`SelectInput > renders correctly disabled with click 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -2046,10 +2046,10 @@ exports[`SelectInput > renders correctly disabled with click 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -2464,10 +2464,10 @@ exports[`SelectInput > renders correctly multi 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -2478,10 +2478,10 @@ exports[`SelectInput > renders correctly multi 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -2969,10 +2969,10 @@ exports[`SelectInput > renders correctly multi disabled 1`] = `
 .emotion-20 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-20 .fillStroke {
@@ -2983,10 +2983,10 @@ exports[`SelectInput > renders correctly multi disabled 1`] = `
 .emotion-20 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-20 .fillStroke {
@@ -3386,10 +3386,10 @@ exports[`SelectInput > renders correctly required 1`] = `
 .emotion-18 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-18 .fillStroke {
@@ -4658,10 +4658,10 @@ exports[`SelectInput > renders correctly uncontrolled 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -5202,10 +5202,10 @@ exports[`SelectInput > renders correctly with click 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -5761,10 +5761,10 @@ exports[`SelectInput > renders correctly with click and option disabled 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -6360,10 +6360,10 @@ exports[`SelectInput > renders correctly with click and options 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -6910,10 +6910,10 @@ exports[`SelectInput > renders correctly with custom styles 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -7273,10 +7273,10 @@ exports[`SelectInput > renders correctly with emptyState 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -7796,10 +7796,10 @@ exports[`SelectInput > renders with undefined children 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -7810,10 +7810,10 @@ exports[`SelectInput > renders with undefined children 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -7824,10 +7824,10 @@ exports[`SelectInput > renders with undefined children 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -8447,10 +8447,10 @@ exports[`SelectInput > should render correctly custom isLoading 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -8461,10 +8461,10 @@ exports[`SelectInput > should render correctly custom isLoading 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -8475,10 +8475,10 @@ exports[`SelectInput > should render correctly custom isLoading 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -8969,10 +8969,10 @@ exports[`SelectInput > should render correctly description and inlineDescription
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -8983,10 +8983,10 @@ exports[`SelectInput > should render correctly description and inlineDescription
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -8997,10 +8997,10 @@ exports[`SelectInput > should render correctly description and inlineDescription
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -9524,10 +9524,10 @@ exports[`SelectInput > should render correctly isLoading 1`] = `
 .emotion-20 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-20 .fillStroke {
@@ -9538,10 +9538,10 @@ exports[`SelectInput > should render correctly isLoading 1`] = `
 .emotion-20 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-20 .fillStroke {
@@ -9993,10 +9993,10 @@ exports[`SelectInput > should render correctly multi isClearable 1`] = `
 .emotion-19 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-19 .fillStroke {
@@ -10007,10 +10007,10 @@ exports[`SelectInput > should render correctly multi isClearable 1`] = `
 .emotion-19 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-19 .fillStroke {
@@ -10442,10 +10442,10 @@ exports[`SelectInput > should render correctly multi isClearable disabled 1`] = 
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -10456,10 +10456,10 @@ exports[`SelectInput > should render correctly multi isClearable disabled 1`] = 
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -10878,10 +10878,10 @@ exports[`SelectInput > should render correctly multi isSearchable 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -10892,10 +10892,10 @@ exports[`SelectInput > should render correctly multi isSearchable 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -11314,10 +11314,10 @@ exports[`SelectInput > should render correctly multi isSearchable disabled 1`] =
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -11328,10 +11328,10 @@ exports[`SelectInput > should render correctly multi isSearchable disabled 1`] =
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -11799,10 +11799,10 @@ exports[`SelectInput > should render correctly with portal 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -11813,10 +11813,10 @@ exports[`SelectInput > should render correctly with portal 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -11827,10 +11827,10 @@ exports[`SelectInput > should render correctly with portal 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -12321,10 +12321,10 @@ exports[`SelectInput > should render correctly without children 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -12335,10 +12335,10 @@ exports[`SelectInput > should render correctly without children 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {
@@ -12349,10 +12349,10 @@ exports[`SelectInput > should render correctly without children 1`] = `
 .emotion-16 {
   vertical-align: middle;
   fill: currentColor;
-  height: 2rem;
-  width: 2rem;
-  min-width: 2rem;
-  min-height: 2rem;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-16 .fillStroke {

--- a/packages/ui/src/components/SelectInput/index.tsx
+++ b/packages/ui/src/components/SelectInput/index.tsx
@@ -590,12 +590,12 @@ const DropdownIndicator = (
         {time ? <StyledSeparator direction="vertical" /> : null}
         {time ? (
           <ClockOutlineIcon
-            size={time ? 'large' : 'xlarge'}
+            size={time ? 'large' : 'small'}
             disabled={isDisabled}
           />
         ) : (
           <ArrowDownIcon
-            size={time ? 'large' : 'xlarge'}
+            size={time ? 'large' : 'small'}
             disabled={isDisabled}
           />
         )}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Wrong icon size for SelectInput which can lead to display issues.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2025-03-03 at 15 18 27](https://github.com/user-attachments/assets/9fbbc3b1-66a3-4841-90c1-a930e9a56eaf) | ![Screenshot 2025-03-03 at 15 23 48](https://github.com/user-attachments/assets/0f5f369f-ec21-4a86-a8e1-a5614ee0419f) |
