### PR TITLE
fix(SelectableCard): make label clickable by removing pointer events to none

### DIFF
--- a/.changeset/brown-months-repeat.md
+++ b/.changeset/brown-months-repeat.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectableCard />` to be able to click on the label and remove all `pointer-events: none`

--- a/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
@@ -124,7 +124,6 @@ exports[`SelectableCardField > should render correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -181,6 +180,47 @@ exports[`SelectableCardField > should render correctly 1`] = `
 
 .emotion-5 input+svg {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {
@@ -509,7 +549,6 @@ exports[`SelectableCardField > should render correctly checked 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -566,6 +605,47 @@ exports[`SelectableCardField > should render correctly checked 1`] = `
 
 .emotion-5 input+svg {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {
@@ -895,7 +975,6 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -952,6 +1031,47 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
 
 .emotion-5 input+svg {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {
@@ -1280,7 +1400,6 @@ exports[`SelectableCardField > should render correctly with errors 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -1337,6 +1456,47 @@ exports[`SelectableCardField > should render correctly with errors 1`] = `
 
 .emotion-5 input+svg {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {
@@ -1670,7 +1830,6 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -1727,6 +1886,47 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
 
 .emotion-5 input+svg {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {

--- a/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -201,7 +201,6 @@ exports[`SelectableCardField > should render correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-15[aria-disabled='false'],
@@ -258,6 +257,47 @@ exports[`SelectableCardField > should render correctly 1`] = `
 
 .emotion-15 input+svg {
   display: none;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18+.emotion-20 {
+  fill: #d9dadd;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18[aria-invalid='true']+.emotion-20 {
+  fill: #b3144d;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18[aria-invalid='true']+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18+.emotion-20 {
+  fill: #8c40ef;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18[aria-invalid='true']+.emotion-20 {
+  fill: #b3144d;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18[aria-invalid='true']+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15 .emotion-18[aria-disabled='false']:active+.emotion-20 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-15 .emotion-18[aria-disabled='false']:active+.emotion-20 .emotion-22 {
+  fill: #ffffff;
 }
 
 .emotion-17 {
@@ -684,7 +724,6 @@ exports[`SelectableCardField > should render correctly checked as a checkbox 1`]
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-13 .eqr7bqq4 {
@@ -830,6 +869,34 @@ exports[`SelectableCardField > should render correctly checked as a checkbox 1`]
 
 .emotion-13 label {
   width: 100%;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='false']+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='true']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='mixed']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18,
+.emotion-13 .emotion-16:active+.emotion-18 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18 .emotion-20,
+.emotion-13 .emotion-16:active+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-15 {
@@ -1287,7 +1354,6 @@ exports[`SelectableCardField > should render correctly checked as radiofield 1`]
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-15[aria-disabled='false'],
@@ -1344,6 +1410,47 @@ exports[`SelectableCardField > should render correctly checked as radiofield 1`]
 
 .emotion-15 input+svg {
   display: none;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18+.emotion-20 {
+  fill: #d9dadd;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18[aria-invalid='true']+.emotion-20 {
+  fill: #b3144d;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18[aria-invalid='true']+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18+.emotion-20 {
+  fill: #8c40ef;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18[aria-invalid='true']+.emotion-20 {
+  fill: #b3144d;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18[aria-invalid='true']+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15 .emotion-18[aria-disabled='false']:active+.emotion-20 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-15 .emotion-18[aria-disabled='false']:active+.emotion-20 .emotion-22 {
+  fill: #ffffff;
 }
 
 .emotion-17 {
@@ -1708,7 +1815,6 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-13 .eqr7bqq4 {
@@ -1854,6 +1960,34 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
 
 .emotion-13 label {
   width: 100%;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='false']+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='true']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='mixed']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18,
+.emotion-13 .emotion-16:active+.emotion-18 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18 .emotion-20,
+.emotion-13 .emotion-16:active+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-15 {

--- a/packages/form/src/components/SelectableCardOptionGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardOptionGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -209,7 +209,6 @@ exports[`SelectableCardOptionGroupField > should render correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-17[aria-disabled='false'],
@@ -262,6 +261,47 @@ exports[`SelectableCardOptionGroupField > should render correctly 1`] = `
 
 .emotion-17[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20+.emotion-22 {
+  fill: #d9dadd;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20[aria-invalid='true']+.emotion-22 {
+  fill: #b3144d;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20[aria-invalid='true']+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20+.emotion-22 {
+  fill: #8c40ef;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20[aria-invalid='true']+.emotion-22 {
+  fill: #b3144d;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20[aria-invalid='true']+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17 .emotion-20[aria-disabled='false']:active+.emotion-22 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-17 .emotion-20[aria-disabled='false']:active+.emotion-22 .emotion-24 {
+  fill: #ffffff;
 }
 
 .emotion-19 {

--- a/packages/form/src/components/SwitchButtonField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SwitchButtonField/__tests__/__snapshots__/index.test.tsx.snap
@@ -181,7 +181,6 @@ exports[`SwitchButtonField > should render correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-8[aria-disabled='false'],
@@ -238,6 +237,47 @@ exports[`SwitchButtonField > should render correctly 1`] = `
 
 .emotion-8 input+svg {
   display: none;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 {
+  fill: #d9dadd;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 {
+  fill: #8c40ef;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 .emotion-15 {
+  fill: #ffffff;
 }
 
 .emotion-10 {
@@ -655,7 +695,6 @@ exports[`SwitchButtonField > should works with defaultValues 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-8[aria-disabled='false'],
@@ -712,6 +751,47 @@ exports[`SwitchButtonField > should works with defaultValues 1`] = `
 
 .emotion-8 input+svg {
   display: none;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 {
+  fill: #d9dadd;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 {
+  fill: #8c40ef;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 .emotion-15 {
+  fill: #ffffff;
 }
 
 .emotion-10 {

--- a/packages/ui/src/components/Checkbox/index.tsx
+++ b/packages/ui/src/components/Checkbox/index.tsx
@@ -11,7 +11,7 @@ import { Tooltip } from '../Tooltip'
 const ErrorText = styled(Text)`
   padding-top: ${({ theme }) => `${theme.space['0.5']}`};
 `
-const InnerCheckbox = styled.rect`
+export const InnerCheckbox = styled.rect`
   fill: ${({ theme }) => theme.colors.neutral.background};
   stroke: ${({ theme }) => theme.colors.neutral.border};
 `
@@ -36,7 +36,7 @@ const CheckboxIconContainer = ({ children }: { children: ReactNode }) => {
   )
 }
 
-const StyledIcon = styled('svg')<{ size: number | string }>`
+export const StyledIcon = styled('svg')<{ size: number | string }>`
   border-radius: ${({ theme }) => theme.radii.default};
   height: ${({ size }) => (typeof size === 'string' ? size : `${size}px`)};
   width: ${({ size }) => (typeof size === 'string' ? size : `${size}px`)};
@@ -59,7 +59,7 @@ const StyledTextLabel = styled(Text)`
   cursor: pointer;
 `
 
-const CheckboxInput = styled('input', {
+export const CheckboxInput = styled('input', {
   shouldForwardProp: prop => !['inputSize'].includes(prop),
 })<{ inputSize: number | string }>`
   position: absolute;

--- a/packages/ui/src/components/Radio/index.tsx
+++ b/packages/ui/src/components/Radio/index.tsx
@@ -6,7 +6,7 @@ import { Stack } from '../Stack'
 import { Text } from '../Text'
 import { Tooltip } from '../Tooltip'
 
-const InnerCircleRing = styled.circle``
+export const InnerCircleRing = styled.circle``
 const RadioMark = styled.circle``
 
 export const RadioStack = styled(Stack)``
@@ -19,7 +19,7 @@ const RadioMarkedIcon = () => (
   </g>
 )
 
-const Ring = styled.svg`
+export const Ring = styled.svg`
   height: ${({ theme }) => theme.sizing['300']};
   width: ${({ theme }) => theme.sizing['300']};
   min-width: ${({ theme }) => theme.sizing['300']};
@@ -31,7 +31,7 @@ const Ring = styled.svg`
   }
 `
 
-const RadioInput = styled.input`
+export const RadioInput = styled.input`
   cursor: pointer;
   position: absolute;
   height: ${({ theme }) => theme.sizing['300']};

--- a/packages/ui/src/components/SelectableCard/__stories__/Examples.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/Examples.stories.tsx
@@ -10,7 +10,7 @@ import nl from './assets/nl.svg'
 import pl from './assets/pl.svg'
 
 export const Examples: StoryFn = args => {
-  const [value, onChange] = useState('label-14')
+  const [value, onChange] = useState('label-29')
   const [value2, onChange2] = useState({ 'label-20': true, 'label-21': false })
   const [value3, onChange3] = useState({
     'label-22': true,
@@ -29,9 +29,9 @@ export const Examples: StoryFn = args => {
       <Stack gap={1} flex={1}>
         <SelectableCard
           {...args}
-          name="label-14"
-          checked={value === 'label-14'}
-          value="label-14"
+          name="label-29"
+          checked={value === 'label-29'}
+          value="label-29"
           type="radio"
           onChange={event => onChange(event.currentTarget.value)}
           showTick
@@ -51,7 +51,7 @@ export const Examples: StoryFn = args => {
         </SelectableCard>
         <SelectableCard
           {...args}
-          name="label-14"
+          name="label-15"
           checked={value === 'label-15'}
           value="label-15"
           type="radio"

--- a/packages/ui/src/components/SelectableCard/__stories__/Illustration.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/Illustration.stories.tsx
@@ -12,7 +12,7 @@ import { Stack } from '../../Stack'
 import { Text } from '../../Text'
 
 export const Illustration: StoryFn = args => {
-  const [value, onChange] = useState('label-14')
+  const [value, onChange] = useState('label-30')
   const [value2, onChange2] = useState('label-24')
 
   return (
@@ -21,9 +21,9 @@ export const Illustration: StoryFn = args => {
         ProductIcon:
         <SelectableCard
           {...args}
-          name="label-14"
-          checked={value === 'label-14'}
-          value="label-14"
+          name="label-30"
+          checked={value === 'label-30'}
+          value="label-30"
           type="radio"
           onChange={event => onChange(event.currentTarget.value)}
           label={
@@ -47,9 +47,9 @@ export const Illustration: StoryFn = args => {
         </SelectableCard>
         <SelectableCard
           {...args}
-          name="label-15"
-          checked={value === 'label-15'}
-          value="label-15"
+          name="label-31"
+          checked={value === 'label-31'}
+          value="label-31"
           type="radio"
           onChange={event => onChange(event.currentTarget.value)}
           label={

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SelectableCard > renders correctly with aria label 1`] = `
+exports[`SelectableCard > checkbox > renders correctly with aria label 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-box;
@@ -99,6 +99,29 @@ exports[`SelectableCard > renders correctly with aria label 1`] = `
   flex-wrap: nowrap;
 }
 
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
 .emotion-5 {
   position: relative;
   display: -webkit-box;
@@ -121,7 +144,6 @@ exports[`SelectableCard > renders correctly with aria label 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -182,6 +204,108 @@ exports[`SelectableCard > renders correctly with aria label 1`] = `
 
 .emotion-5 label {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
 }
 
 .emotion-7 {
@@ -258,6 +382,51 @@ exports[`SelectableCard > renders correctly with aria label 1`] = `
   fill: #ffffff;
 }
 
+.emotion-9 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-15[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-15[data-has-label='false'] {
+  display: contents;
+}
+
 .emotion-15 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -316,8 +485,8 @@ exports[`SelectableCard > renders correctly with aria label 1`] = `
             aria-invalid="false"
             aria-label="test"
             class="emotion-7 emotion-8"
-            id=":r5:"
-            name="radio"
+            id=":r1l:"
+            name="test"
             tabindex="-1"
             type="radio"
             value="choice"
@@ -360,7 +529,7 @@ exports[`SelectableCard > renders correctly with aria label 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with checkbox type 1`] = `
+exports[`SelectableCard > checkbox > renders correctly with checked prop 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-box;
@@ -455,7 +624,6 @@ exports[`SelectableCard > renders correctly with checkbox type 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-3 .eqr7bqq4 {
@@ -605,6 +773,34 @@ exports[`SelectableCard > renders correctly with checkbox type 1`] = `
 
 .emotion-3 label {
   width: 100%;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8,
+.emotion-3 .emotion-6:active+.emotion-8 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8 .emotion-10,
+.emotion-3 .emotion-6:active+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-5 {
@@ -721,406 +917,6 @@ exports[`SelectableCard > renders correctly with checkbox type 1`] = `
 
 .emotion-11[data-has-label='false'] {
   display: contents;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-disabled="false"
-      data-has-label="false"
-      data-image="none"
-      data-type="checkbox"
-      role="button"
-      tabindex="0"
-    >
-      <div
-        aria-disabled="false"
-        class="emotion-2 emotion-3 emotion-4"
-        data-checked="false"
-        data-error="false"
-      >
-        <input
-          aria-checked="false"
-          aria-invalid="false"
-          aria-label="test"
-          class="emotion-5 emotion-6"
-          id=":r8:"
-          name="checkbox"
-          tabindex="-1"
-          type="checkbox"
-          value="choice"
-        />
-        <svg
-          class="emotion-7 emotion-8"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <g>
-            <rect
-              class="emotion-9 emotion-10"
-              height="16"
-              rx="0.125rem"
-              stroke-width="2"
-              width="16"
-              x="4"
-              y="4"
-            />
-            <path
-              clip-rule="evenodd"
-              d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
-              fill="white"
-              fill-rule="evenodd"
-              height="9"
-              width="12"
-              x="5"
-              y="4"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="emotion-11 emotion-12"
-        data-has-label="false"
-      >
-        Checkbox card
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCard > renders correctly with checkbox type and checked prop 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .ehkrmld6,
-.emotion-0[data-has-label='true'] .emotion-4 {
-  width: 100%;
-}
-
-.emotion-3 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.5rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  pointer-events: none;
-}
-
-.emotion-3 .eqr7bqq4 {
-  cursor: pointer;
-}
-
-.emotion-3[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
-  cursor: not-allowed;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-8 {
-  fill: #e9eaeb;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-8 .emotion-10 {
-  stroke: #d9dadd;
-  fill: #f3f3f4;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 {
-  fill: #ffd3e3;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
-  stroke: #ffd3e3;
-  fill: #ffd3e3;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 {
-  fill: #ffebf2;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
-  stroke: #ffbbd3;
-  fill: #ffebf2;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 {
-  fill: #e5dbfd;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 .emotion-10 {
-  stroke: #d8c5fc;
-  fill: #d8c5fc;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 {
-  fill: #e5dbfd;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
-  stroke: #e5dbfd;
-  fill: #e5dbfd;
-}
-
-.emotion-3 .emotion-6:checked+.emotion-8 path {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-}
-
-.emotion-3 .emotion-6:checked+.emotion-8 .emotion-10 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
-  fill: #e51963;
-  stroke: #e51963;
-}
-
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
-  fill: #ffffff;
-}
-
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='false']+.emotion-8 .emotion-10 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='true']+.emotion-8 .emotion-10 {
-  stroke: #d6175c;
-  fill: #d6175c;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 {
-  fill: #e51963;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
-  stroke: #e51963;
-  fill: #ffebf2;
-}
-
-.emotion-3[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-3[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-3[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-3 input+svg {
-  display: none;
-}
-
-.emotion-3 label {
-  display: none;
-}
-
-.emotion-3 label {
-  width: 100%;
-}
-
-.emotion-5 {
-  position: absolute;
-  white-space: nowrap;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  border-width: 0;
-}
-
-.emotion-5:not(:disabled) {
-  cursor: pointer;
-}
-
-.emotion-5:disabled {
-  cursor: not-allowed;
-}
-
-.emotion-5:not(:disabled):checked+.emotion-8,
-.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 {
-  fill: #8c40ef;
-}
-
-.emotion-5:not(:disabled):checked+.emotion-8 .emotion-10,
-.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 .emotion-10 {
-  stroke: #8c40ef;
-}
-
-.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8,
-.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 {
-  fill: #ffebf2;
-}
-
-.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8 .emotion-10,
-.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 .emotion-10 {
-  stroke: #b3144d;
-}
-
-.emotion-5:focus+.emotion-8 {
-  background-color: #f1eefc;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
-}
-
-.emotion-5:focus+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-5[aria-invalid='true']:focus+.emotion-8 {
-  background-color: #ffebf2;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
-}
-
-.emotion-5[aria-invalid='true']:focus+.emotion-8 .emotion-10 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-7 {
-  border-radius: 0.25rem;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-}
-
-.emotion-7 path {
-  fill: #ffffff;
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-9 {
-  fill: #ffffff;
-  stroke: #d9dadd;
 }
 
 .emotion-11 {
@@ -1180,8 +976,8 @@ exports[`SelectableCard > renders correctly with checkbox type and checked prop 
           aria-label="test"
           checked=""
           class="emotion-5 emotion-6"
-          id=":rk:"
-          name="radio"
+          id=":r1r:"
+          name="test"
           tabindex="-1"
           type="checkbox"
           value="choice"
@@ -1225,7 +1021,7 @@ exports[`SelectableCard > renders correctly with checkbox type and checked prop 
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with checkbox type and disabled prop 1`] = `
+exports[`SelectableCard > checkbox > renders correctly with complex children 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-box;
@@ -1233,9 +1029,9 @@ exports[`SelectableCard > renders correctly with checkbox type and disabled prop
   display: -ms-flexbox;
   display: flex;
   gap: 0.25rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   -webkit-align-items: start;
   -webkit-box-align: start;
   -ms-flex-align: start;
@@ -1248,6 +1044,9 @@ exports[`SelectableCard > renders correctly with checkbox type and disabled prop
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   padding: 1rem;
   border-radius: 0.25rem;
   -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
@@ -1301,365 +1100,7 @@ exports[`SelectableCard > renders correctly with checkbox type and disabled prop
   width: 100%;
 }
 
-.emotion-3 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.5rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  pointer-events: none;
-}
-
-.emotion-3 .eqr7bqq4 {
-  cursor: pointer;
-}
-
-.emotion-3[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
-  cursor: not-allowed;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-8 {
-  fill: #e9eaeb;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-8 .emotion-10 {
-  stroke: #d9dadd;
-  fill: #f3f3f4;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 {
-  fill: #ffd3e3;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
-  stroke: #ffd3e3;
-  fill: #ffd3e3;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 {
-  fill: #ffebf2;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
-  stroke: #ffbbd3;
-  fill: #ffebf2;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 {
-  fill: #e5dbfd;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 .emotion-10 {
-  stroke: #d8c5fc;
-  fill: #d8c5fc;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 {
-  fill: #e5dbfd;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
-  stroke: #e5dbfd;
-  fill: #e5dbfd;
-}
-
-.emotion-3 .emotion-6:checked+.emotion-8 path {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-}
-
-.emotion-3 .emotion-6:checked+.emotion-8 .emotion-10 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
-  fill: #e51963;
-  stroke: #e51963;
-}
-
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
-  fill: #ffffff;
-}
-
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='false']+.emotion-8 .emotion-10 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='true']+.emotion-8 .emotion-10 {
-  stroke: #d6175c;
-  fill: #d6175c;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 {
-  fill: #e51963;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
-  stroke: #e51963;
-  fill: #ffebf2;
-}
-
-.emotion-3[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-3[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-3[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-3 input+svg {
-  display: none;
-}
-
-.emotion-3 label {
-  display: none;
-}
-
-.emotion-3 label {
-  width: 100%;
-}
-
-.emotion-5 {
-  position: absolute;
-  white-space: nowrap;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  border-width: 0;
-}
-
-.emotion-5:not(:disabled) {
-  cursor: pointer;
-}
-
-.emotion-5:disabled {
-  cursor: not-allowed;
-}
-
-.emotion-5:not(:disabled):checked+.emotion-8,
-.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 {
-  fill: #8c40ef;
-}
-
-.emotion-5:not(:disabled):checked+.emotion-8 .emotion-10,
-.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 .emotion-10 {
-  stroke: #8c40ef;
-}
-
-.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8,
-.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 {
-  fill: #ffebf2;
-}
-
-.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8 .emotion-10,
-.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 .emotion-10 {
-  stroke: #b3144d;
-}
-
-.emotion-5:focus+.emotion-8 {
-  background-color: #f1eefc;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
-}
-
-.emotion-5:focus+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-5[aria-invalid='true']:focus+.emotion-8 {
-  background-color: #ffebf2;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
-}
-
-.emotion-5[aria-invalid='true']:focus+.emotion-8 .emotion-10 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-7 {
-  border-radius: 0.25rem;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-}
-
-.emotion-7 path {
-  fill: #ffffff;
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-9 {
-  fill: #ffffff;
-  stroke: #d9dadd;
-}
-
-.emotion-11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-11[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-11[data-has-label='false'] {
-  display: contents;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-disabled="true"
-      data-has-label="false"
-      data-image="none"
-      data-type="checkbox"
-      role="button"
-    >
-      <div
-        aria-disabled="true"
-        class="emotion-2 emotion-3 emotion-4"
-        data-checked="false"
-        data-error="false"
-      >
-        <input
-          aria-checked="false"
-          aria-invalid="false"
-          aria-label="test"
-          class="emotion-5 emotion-6"
-          disabled=""
-          id=":rq:"
-          name="radio"
-          tabindex="-1"
-          type="checkbox"
-          value="choice"
-        />
-        <svg
-          class="emotion-7 emotion-8"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <g>
-            <rect
-              class="emotion-9 emotion-10"
-              height="16"
-              rx="0.125rem"
-              stroke-width="2"
-              width="16"
-              x="4"
-              y="4"
-            />
-            <path
-              clip-rule="evenodd"
-              d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
-              fill="white"
-              fill-rule="evenodd"
-              height="9"
-              width="12"
-              x="5"
-              y="4"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="emotion-11 emotion-12"
-        data-has-label="false"
-      >
-        Radio card
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCard > renders correctly with checkbox type and isError prop 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1755,7 +1196,6 @@ exports[`SelectableCard > renders correctly with checkbox type and isError prop 
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-3 .eqr7bqq4 {
@@ -1901,6 +1341,34 @@ exports[`SelectableCard > renders correctly with checkbox type and isError prop 
 
 .emotion-3 label {
   width: 100%;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8,
+.emotion-3 .emotion-6:active+.emotion-8 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8 .emotion-10,
+.emotion-3 .emotion-6:active+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-5 {
@@ -2085,33 +1553,63 @@ exports[`SelectableCard > renders correctly with checkbox type and isError prop 
   display: contents;
 }
 
+.emotion-18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-18[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-18[data-has-label='false'] {
+  display: contents;
+}
+
 <div
     data-testid="testing"
   >
     <div
       class="emotion-0 emotion-1"
       data-checked="false"
-      data-disabled="false"
-      data-error="true"
+      data-disabled="true"
       data-has-label="true"
       data-image="none"
       data-type="checkbox"
       role="button"
-      tabindex="0"
     >
       <div
-        aria-disabled="false"
+        aria-disabled="true"
         class="emotion-2 emotion-3 emotion-4"
         data-checked="false"
-        data-error="true"
+        data-error="false"
       >
         <input
           aria-checked="false"
-          aria-describedby=":rt:-hint"
-          aria-invalid="true"
+          aria-invalid="false"
           class="emotion-5 emotion-6"
-          id=":rt:"
-          name="radio"
+          disabled=""
+          id=":r29:"
+          name="test"
           tabindex="-1"
           type="checkbox"
           value="choice"
@@ -2151,7 +1649,7 @@ exports[`SelectableCard > renders correctly with checkbox type and isError prop 
           >
             <label
               class="emotion-15 emotion-16 emotion-17"
-              for=":rt:"
+              for=":r29:"
             >
               test
             </label>
@@ -2162,50 +1660,20 @@ exports[`SelectableCard > renders correctly with checkbox type and isError prop 
         class="emotion-18 emotion-19"
         data-has-label="false"
       >
-        Radio card
+        <div
+          style="background: gray; color: gray;"
+        >
+          Complex radio card
+        </div>
       </div>
     </div>
   </div>
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 1`] = `
+exports[`SelectableCard > checkbox > renders correctly with default props 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-2 {
-  display: inherit;
-}
-
-.emotion-2[data-container-full-width="true"] {
-  width: 100%;
-}
-
-.emotion-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2239,47 +1707,1430 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
   color: #3f4250;
 }
 
-.emotion-4[data-has-label='false']>:first-child {
+.emotion-0[data-has-label='false']>:first-child {
   margin-bottom: -0.25rem;
 }
 
-.emotion-4[data-checked='true'] {
+.emotion-0[data-checked='true'] {
   border: 1px solid #8c40ef;
 }
 
-.emotion-4[data-error='true'] {
+.emotion-0[data-error='true'] {
   border: 1px solid #b3144d;
 }
 
-.emotion-4[data-disabled='true'] {
+.emotion-0[data-disabled='true'] {
   border: 1px solid #e9eaeb;
   color: #b5b7bd;
   background: #f3f3f4;
   cursor: not-allowed;
 }
 
-.emotion-4[data-image="illustration"] {
+.emotion-0[data-image="illustration"] {
   padding: 0rem;
 }
 
-.emotion-4[data-image="icon"] {
+.emotion-0[data-image="icon"] {
   padding: 0rem;
   padding-right: 1rem;
 }
 
-.emotion-4:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-4:active:not([data-error='true']):not([data-disabled='true']) {
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
   border: 1px solid #8c40ef;
 }
 
-.emotion-4:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-4:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
   box-shadow: 0px 4px 16px 4px #f6f3ffcc;
 }
 
-.emotion-4[data-has-label='true'] .ehkrmld6,
-.emotion-4[data-has-label='true'] .emotion-8 {
+.emotion-0[data-has-label='true'] .emotion-3,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
   width: 100%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .emotion-3,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-5[aria-disabled='false'],
+.emotion-5[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-5[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-5[aria-disabled='true']>label,
+.emotion-5[aria-disabled='true'] .emotion-8 {
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
+  fill: #f3f3f4;
+}
+
+.emotion-5[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-5[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-5[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-5 input+svg {
+  display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-5[aria-disabled='false'],
+.emotion-5[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-5[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-5[aria-disabled='true']>label,
+.emotion-5[aria-disabled='true'] .emotion-8 {
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
+  fill: #f3f3f4;
+}
+
+.emotion-5[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-5[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-5[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-5 input+svg {
+  display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-9 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-16 {
+  font-size: 1rem;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+}
+
+.emotion-16 {
+  font-size: 1rem;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+}
+
+.emotion-18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-18[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-18[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-18[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-18[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="true"
+      data-image="none"
+      data-type="radio"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <div
+          aria-disabled="false"
+          class="emotion-4 emotion-5 emotion-6"
+          data-checked="false"
+        >
+          <input
+            aria-disabled="false"
+            aria-invalid="false"
+            class="emotion-7 emotion-8"
+            id=":r1h:"
+            name="test"
+            tabindex="-1"
+            type="radio"
+            value="choice"
+          />
+          <svg
+            class="emotion-9 emotion-10"
+            viewBox="0 0 24 24"
+          >
+            <g>
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke-width="2"
+              />
+              <circle
+                class="emotion-11 emotion-12"
+                cx="12"
+                cy="12"
+                r="8"
+              />
+              <circle
+                class="emotion-13 emotion-14"
+                cx="12"
+                cy="12"
+                r="5"
+              />
+            </g>
+          </svg>
+          <label
+            class="emotion-15 emotion-16 emotion-17"
+            for=":r1h:"
+          >
+            test
+          </label>
+        </div>
+      </div>
+      <div
+        class="emotion-18 emotion-19"
+        data-has-label="false"
+      >
+        Radio card
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > checkbox > renders correctly with disabled prop 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .ehkrmld6,
+.emotion-0[data-has-label='true'] .emotion-4 {
+  width: 100%;
+}
+
+.emotion-3 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-3 .eqr7bqq4 {
+  cursor: pointer;
+}
+
+.emotion-3[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-3[aria-disabled='true'] .eqr7bqq4 {
+  cursor: not-allowed;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-8 {
+  fill: #e9eaeb;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-8 .emotion-10 {
+  stroke: #d9dadd;
+  fill: #f3f3f4;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 {
+  fill: #ffd3e3;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
+  stroke: #ffd3e3;
+  fill: #ffd3e3;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 {
+  fill: #ffebf2;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
+  stroke: #ffbbd3;
+  fill: #ffebf2;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 {
+  fill: #e5dbfd;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 .emotion-10 {
+  stroke: #d8c5fc;
+  fill: #d8c5fc;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 {
+  fill: #e5dbfd;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
+  stroke: #e5dbfd;
+  fill: #e5dbfd;
+}
+
+.emotion-3 .emotion-6:checked+.emotion-8 path {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+}
+
+.emotion-3 .emotion-6:checked+.emotion-8 .emotion-10 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-3 .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
+  fill: #e51963;
+  stroke: #e51963;
+}
+
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
+  fill: #ffffff;
+}
+
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='false']+.emotion-8 .emotion-10 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #d6175c;
+  fill: #d6175c;
+}
+
+.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 {
+  fill: #e51963;
+}
+
+.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
+  stroke: #e51963;
+  fill: #ffebf2;
+}
+
+.emotion-3[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-3[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-3[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-3 input+svg {
+  display: none;
+}
+
+.emotion-3 label {
+  display: none;
+}
+
+.emotion-3 label {
+  width: 100%;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8,
+.emotion-3 .emotion-6:active+.emotion-8 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8 .emotion-10,
+.emotion-3 .emotion-6:active+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-5 {
+  position: absolute;
+  white-space: nowrap;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  border-width: 0;
+}
+
+.emotion-5:not(:disabled) {
+  cursor: pointer;
+}
+
+.emotion-5:disabled {
+  cursor: not-allowed;
+}
+
+.emotion-5:not(:disabled):checked+.emotion-8,
+.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 {
+  fill: #8c40ef;
+}
+
+.emotion-5:not(:disabled):checked+.emotion-8 .emotion-10,
+.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+}
+
+.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8,
+.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 {
+  fill: #ffebf2;
+}
+
+.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8 .emotion-10,
+.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 .emotion-10 {
+  stroke: #b3144d;
+}
+
+.emotion-5:focus+.emotion-8 {
+  background-color: #f1eefc;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-5:focus+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-5[aria-invalid='true']:focus+.emotion-8 {
+  background-color: #ffebf2;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
+}
+
+.emotion-5[aria-invalid='true']:focus+.emotion-8 .emotion-10 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-7 {
+  border-radius: 0.25rem;
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+}
+
+.emotion-7 path {
+  fill: #ffffff;
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-9 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-11[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-11[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-11[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-11[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="true"
+      data-has-label="false"
+      data-image="none"
+      data-type="checkbox"
+      role="button"
+    >
+      <div
+        aria-disabled="true"
+        class="emotion-2 emotion-3 emotion-4"
+        data-checked="false"
+        data-error="false"
+      >
+        <input
+          aria-checked="false"
+          aria-invalid="false"
+          aria-label="test"
+          class="emotion-5 emotion-6"
+          disabled=""
+          id=":r1u:"
+          name="test"
+          tabindex="-1"
+          type="checkbox"
+          value="choice"
+        />
+        <svg
+          class="emotion-7 emotion-8"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <g>
+            <rect
+              class="emotion-9 emotion-10"
+              height="16"
+              rx="0.125rem"
+              stroke-width="2"
+              width="16"
+              x="4"
+              y="4"
+            />
+            <path
+              clip-rule="evenodd"
+              d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
+              fill="white"
+              fill-rule="evenodd"
+              height="9"
+              width="12"
+              x="5"
+              y="4"
+            />
+          </g>
+        </svg>
+      </div>
+      <div
+        class="emotion-11 emotion-12"
+        data-has-label="false"
+      >
+        Radio card
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > checkbox > renders correctly with illustration 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .ehkrmld6,
+.emotion-0[data-has-label='true'] .emotion-8 {
+  width: 100%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .ehkrmld6,
+.emotion-0[data-has-label='true'] .emotion-8 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  max-width: calc(100% - 10rem);
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .emotion-7 {
@@ -2301,7 +3152,6 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-7 .eqr7bqq4 {
@@ -2441,12 +3291,36 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
   color: #b5b7bd;
 }
 
-.emotion-7 input+svg {
-  display: none;
-}
-
 .emotion-7 label {
   width: 100%;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='false']+.emotion-12 .emotion-14 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='true']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='mixed']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-7 .emotion-10:focus+.emotion-12,
+.emotion-7 .emotion-10:active+.emotion-12 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-7 .emotion-10:focus+.emotion-12 .emotion-14,
+.emotion-7 .emotion-10:active+.emotion-12 .emotion-14 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-9 {
@@ -2631,27 +3505,110 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
   display: contents;
 }
 
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-22[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-22[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-box-flex-flow: column;
+  -webkit-flex-flow: column;
+  -ms-flex-flow: column;
+  flex-flow: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  min-width: 11.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.emotion-28 {
+  object-fit: cover;
+  position: absolute;
+  min-width: 13.75rem;
+  height: auto;
+  left: 0.5rem;
+}
+
 <div
     data-testid="testing"
   >
     <div
       class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="true"
+      data-image="illustration"
+      data-type="checkbox"
+      role="button"
+      tabindex="0"
     >
       <div
-        aria-controls=":r18:"
-        aria-describedby=":r18:"
         class="emotion-2 emotion-3"
-        tabindex="0"
       >
         <div
           class="emotion-4 emotion-5"
-          data-checked="false"
-          data-disabled="false"
-          data-has-label="true"
-          data-image="none"
-          data-type="checkbox"
-          role="button"
-          tabindex="0"
         >
           <div
             aria-disabled="false"
@@ -2663,11 +3620,11 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
               aria-checked="false"
               aria-invalid="false"
               class="emotion-9 emotion-10"
-              id=":r19:"
-              name="checkbox"
+              id=":r2d:"
+              name="label-14"
               tabindex="-1"
               type="checkbox"
-              value="choice"
+              value="label-14"
             />
             <svg
               class="emotion-11 emotion-12"
@@ -2697,26 +3654,39 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
               </g>
             </svg>
             <div
-              class="emotion-15 emotion-1"
+              class="emotion-15 emotion-3"
             >
               <div
-                class="emotion-17 emotion-1"
+                class="emotion-17 emotion-3"
               >
                 <label
                   class="emotion-19 emotion-20 emotion-21"
-                  for=":r19:"
+                  for=":r2d:"
                 >
-                  test
+                  label
                 </label>
               </div>
             </div>
           </div>
           <div
             class="emotion-22 emotion-23"
-            data-has-label="false"
+            data-has-label="true"
           >
-            Checkbox card
+            Offer the best experience to your Mac, iPhone and iPad users with VNC, the remote desktop-sharing protocol. Learn more
           </div>
+        </div>
+        <div
+          class="emotion-24 emotion-3"
+        />
+        <div
+          class="emotion-26 emotion-27"
+        >
+          <img
+            alt="illustration"
+            class="emotion-28 emotion-29"
+            src="/src/components/SelectableCard/__tests__/illustrationTest.svg"
+            width="220"
+          />
         </div>
       </div>
     </div>
@@ -2724,9 +3694,86 @@ exports[`SelectableCard > renders correctly with checkbox type and tooltip prop 
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with complex children 1`] = `
+exports[`SelectableCard > checkbox > renders correctly with isError prop 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .ehkrmld6,
+.emotion-0[data-has-label='true'] .emotion-4 {
+  width: 100%;
+}
+
+.emotion-0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2822,7 +3869,6 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-3 .eqr7bqq4 {
@@ -2968,6 +4014,34 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
 
 .emotion-3 label {
   width: 100%;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8,
+.emotion-3 .emotion-6:active+.emotion-8 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8 .emotion-10,
+.emotion-3 .emotion-6:active+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-5 {
@@ -3152,31 +4226,65 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
   display: contents;
 }
 
+.emotion-18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-18[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-18[data-has-label='false'] {
+  display: contents;
+}
+
 <div
     data-testid="testing"
   >
     <div
       class="emotion-0 emotion-1"
       data-checked="false"
-      data-disabled="true"
+      data-disabled="false"
+      data-error="true"
       data-has-label="true"
       data-image="none"
       data-type="checkbox"
       role="button"
+      tabindex="0"
     >
       <div
-        aria-disabled="true"
+        aria-disabled="false"
         class="emotion-2 emotion-3 emotion-4"
         data-checked="false"
-        data-error="false"
+        data-error="true"
       >
         <input
           aria-checked="false"
-          aria-invalid="false"
+          aria-describedby=":r21:-hint"
+          aria-invalid="true"
           class="emotion-5 emotion-6"
-          disabled=""
-          id=":r1d:"
-          name="radio"
+          id=":r21:"
+          name="test"
           tabindex="-1"
           type="checkbox"
           value="choice"
@@ -3216,7 +4324,7 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
           >
             <label
               class="emotion-15 emotion-16 emotion-17"
-              for=":r1d:"
+              for=":r21:"
             >
               test
             </label>
@@ -3227,10 +4335,804 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
         class="emotion-18 emotion-19"
         data-has-label="false"
       >
+        Radio card
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > checkbox > renders correctly with productIcon 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .ehkrmld6,
+.emotion-0[data-has-label='true'] .emotion-8 {
+  width: 100%;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .ehkrmld6,
+.emotion-0[data-has-label='true'] .emotion-8 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  max-width: calc(100% - 10rem);
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.emotion-7 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-7 .eqr7bqq4 {
+  cursor: pointer;
+}
+
+.emotion-7[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-7[aria-disabled='true'] .eqr7bqq4 {
+  cursor: not-allowed;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-12 {
+  fill: #e9eaeb;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-12 .emotion-14 {
+  stroke: #d9dadd;
+  fill: #f3f3f4;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.emotion-12 .emotion-14 {
+  stroke: #ffd3e3;
+  fill: #ffd3e3;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.emotion-12 .emotion-14 {
+  stroke: #ffbbd3;
+  fill: #ffebf2;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10:checked+.emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10:checked+.emotion-12 .emotion-14 {
+  stroke: #d8c5fc;
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.emotion-12 .emotion-14 {
+  stroke: #e5dbfd;
+  fill: #e5dbfd;
+}
+
+.emotion-7 .emotion-10:checked+.emotion-12 path {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+}
+
+.emotion-7 .emotion-10:checked+.emotion-12 .emotion-14 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-7 .emotion-10[aria-invalid="true"]:checked+.emotion-12 .emotion-14 {
+  fill: #e51963;
+  stroke: #e51963;
+}
+
+.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq6 {
+  fill: #ffffff;
+}
+
+.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .emotion-14 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='false']+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='true']+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='mixed']+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='false']+.emotion-12 .emotion-14 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='true']+.emotion-12 .emotion-14 {
+  stroke: #d6175c;
+  fill: #d6175c;
+}
+
+.emotion-7 .emotion-10[aria-invalid="true"]+.emotion-12 {
+  fill: #e51963;
+}
+
+.emotion-7 .emotion-10[aria-invalid="true"]+.emotion-12 .emotion-14 {
+  stroke: #e51963;
+  fill: #ffebf2;
+}
+
+.emotion-7[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-7[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-7[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-7 label {
+  width: 100%;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='false']+.emotion-12 .emotion-14 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='true']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='mixed']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-7 .emotion-10:focus+.emotion-12,
+.emotion-7 .emotion-10:active+.emotion-12 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-7 .emotion-10:focus+.emotion-12 .emotion-14,
+.emotion-7 .emotion-10:active+.emotion-12 .emotion-14 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-9 {
+  position: absolute;
+  white-space: nowrap;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  border-width: 0;
+}
+
+.emotion-9:not(:disabled) {
+  cursor: pointer;
+}
+
+.emotion-9:disabled {
+  cursor: not-allowed;
+}
+
+.emotion-9:not(:disabled):checked+.emotion-12,
+.emotion-9:not(:disabled)[aria-checked='mixed']+.emotion-12 {
+  fill: #8c40ef;
+}
+
+.emotion-9:not(:disabled):checked+.emotion-12 .emotion-14,
+.emotion-9:not(:disabled)[aria-checked='mixed']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+}
+
+.emotion-9:not(:disabled)[aria-invalid='true']+.emotion-12,
+.emotion-9:not(:disabled)[aria-invalid='mixed']+.emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9:not(:disabled)[aria-invalid='true']+.emotion-12 .emotion-14,
+.emotion-9:not(:disabled)[aria-invalid='mixed']+.emotion-12 .emotion-14 {
+  stroke: #b3144d;
+}
+
+.emotion-9:focus+.emotion-12 {
+  background-color: #f1eefc;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-9:focus+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-9[aria-invalid='true']:focus+.emotion-12 {
+  background-color: #ffebf2;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
+}
+
+.emotion-9[aria-invalid='true']:focus+.emotion-12 .emotion-14 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-11 {
+  border-radius: 0.25rem;
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+}
+
+.emotion-11 path {
+  fill: #ffffff;
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-13 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-20 {
+  color: #3f4250;
+  font-size: 1rem;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+  cursor: pointer;
+}
+
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-22[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-22[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-22[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-22[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-26 {
+  width: 3rem;
+  min-width: 3rem;
+  height: 3rem;
+}
+
+.emotion-26 path[fill].fill,
+.emotion-26 g[fill].fill>*,
+.emotion-26 g.fill>* {
+  fill: #521094;
+}
+
+.emotion-26 path[fill].fillStrong,
+.emotion-26 g[fill].fillStrong>*,
+.emotion-26 g.fillStrong>* {
+  fill: #a060f6;
+}
+
+.emotion-26 path[fill].fillWeak,
+.emotion-26 g[fill].fillWeak>*,
+.emotion-26 g.fillWeak>* {
+  fill: #f1eefc;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="true"
+      data-image="icon"
+      data-type="checkbox"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
         <div
-          style="background: gray; color: gray;"
+          class="emotion-4 emotion-5"
         >
-          Complex radio card
+          <div
+            aria-disabled="false"
+            class="emotion-6 emotion-7 emotion-8"
+            data-checked="false"
+            data-error="false"
+          >
+            <input
+              aria-checked="false"
+              aria-invalid="false"
+              class="emotion-9 emotion-10"
+              id=":r2h:"
+              name="label-14"
+              tabindex="-1"
+              type="checkbox"
+              value="label-14"
+            />
+            <svg
+              class="emotion-11 emotion-12"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <g>
+                <rect
+                  class="emotion-13 emotion-14"
+                  height="16"
+                  rx="0.125rem"
+                  stroke-width="2"
+                  width="16"
+                  x="4"
+                  y="4"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
+                />
+              </g>
+            </svg>
+            <div
+              class="emotion-15 emotion-3"
+            >
+              <div
+                class="emotion-17 emotion-3"
+              >
+                <label
+                  class="emotion-19 emotion-20 emotion-21"
+                  for=":r2h:"
+                >
+                  label
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="emotion-22 emotion-23"
+            data-has-label="true"
+          >
+            Offer the best experience to your Mac, iPhone and iPad users with VNC, the remote desktop-sharing protocol. Learn more
+          </div>
+        </div>
+        <div
+          class="emotion-24 emotion-3"
+        >
+          <svg
+            class="emotion-26 emotion-27"
+            viewBox="0 0 64 64"
+          >
+            <g
+              class="MacMini"
+            >
+              <g
+                class=".Square"
+              >
+                <path
+                  class="fillWeak"
+                  d="M0 16C0 7.163 7.163 0 16 0h32c8.837 0 16 7.163 16 16v32c0 8.837-7.163 16-16 16H16C7.163 64 0 56.837 0 48z"
+                  fill="#F1EEFC"
+                />
+              </g>
+              <g
+                class="Icon MacMini"
+              >
+                <g
+                  class="MacMini"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                >
+                  <path
+                    class="fill"
+                    d="M40 8.5c5.523 0 10 4.477 10 10v16c0 5.523-4.477 10-10 10h-7v5.17a3 3 0 0 1 1.83 1.83h13.334a1 1 0 0 1 .117 1.993l-.117.007H34.83a3.001 3.001 0 0 1-5.658 0H15a1 1 0 0 1-.117-1.993L15 51.5h14.171A3 3 0 0 1 31 49.67V44.5h-7c-5.523 0-10-4.477-10-10v-16c0-5.523 4.477-10 10-10zm-8 34h-8l-.25-.004A8 8 0 0 1 16 34.5v-16l.004-.25A8 8 0 0 1 24 10.5h16l.25.004A8 8 0 0 1 48 18.5v16l-.004.25A8 8 0 0 1 40 42.5zm0 9a1 1 0 1 1 0 2 1 1 0 0 1 0-2"
+                    fill="#521094"
+                  />
+                  <path
+                    class="fillStrong"
+                    d="M45 18.5a5 5 0 0 0-5-5H24a5 5 0 0 0-5 5v16a5 5 0 0 0 5 5h16a5 5 0 0 0 5-5zm-21-3h16l.176.005A3 3 0 0 1 43 18.5v16l-.005.176A3 3 0 0 1 40 37.5H24l-.176-.005A3 3 0 0 1 21 34.5v-16l.005-.176A3 3 0 0 1 24 15.5"
+                    fill="#A060F6"
+                  />
+                  <path
+                    class="fillStrong"
+                    d="M34.5 24h-5v5h5zm-5-2a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-5a2 2 0 0 0-2-2z"
+                    fill="#A060F6"
+                  />
+                </g>
+              </g>
+            </g>
+          </svg>
         </div>
       </div>
     </div>
@@ -3238,7 +5140,1982 @@ exports[`SelectableCard > renders correctly with complex children 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with default props 1`] = `
+exports[`SelectableCard > checkbox > renders correctly with showTick 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .ehkrmld6,
+.emotion-0[data-has-label='true'] .emotion-4 {
+  width: 100%;
+}
+
+.emotion-3 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-3 .eqr7bqq4 {
+  cursor: pointer;
+}
+
+.emotion-3[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-3[aria-disabled='true'] .eqr7bqq4 {
+  cursor: not-allowed;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-8 {
+  fill: #e9eaeb;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-8 .emotion-10 {
+  stroke: #d9dadd;
+  fill: #f3f3f4;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 {
+  fill: #ffd3e3;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
+  stroke: #ffd3e3;
+  fill: #ffd3e3;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 {
+  fill: #ffebf2;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
+  stroke: #ffbbd3;
+  fill: #ffebf2;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 {
+  fill: #e5dbfd;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 .emotion-10 {
+  stroke: #d8c5fc;
+  fill: #d8c5fc;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 {
+  fill: #e5dbfd;
+}
+
+.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
+  stroke: #e5dbfd;
+  fill: #e5dbfd;
+}
+
+.emotion-3 .emotion-6:checked+.emotion-8 path {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+}
+
+.emotion-3 .emotion-6:checked+.emotion-8 .emotion-10 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-3 .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
+  fill: #e51963;
+  stroke: #e51963;
+}
+
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
+  fill: #ffffff;
+}
+
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='false']+.emotion-8 .emotion-10 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #d6175c;
+  fill: #d6175c;
+}
+
+.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 {
+  fill: #e51963;
+}
+
+.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
+  stroke: #e51963;
+  fill: #ffebf2;
+}
+
+.emotion-3[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-3[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-3[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-3 label {
+  width: 100%;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8,
+.emotion-3 .emotion-6:active+.emotion-8 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-3 .emotion-6:focus+.emotion-8 .emotion-10,
+.emotion-3 .emotion-6:active+.emotion-8 .emotion-10 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-5 {
+  position: absolute;
+  white-space: nowrap;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  border-width: 0;
+}
+
+.emotion-5:not(:disabled) {
+  cursor: pointer;
+}
+
+.emotion-5:disabled {
+  cursor: not-allowed;
+}
+
+.emotion-5:not(:disabled):checked+.emotion-8,
+.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 {
+  fill: #8c40ef;
+}
+
+.emotion-5:not(:disabled):checked+.emotion-8 .emotion-10,
+.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 .emotion-10 {
+  stroke: #8c40ef;
+}
+
+.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8,
+.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 {
+  fill: #ffebf2;
+}
+
+.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8 .emotion-10,
+.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 .emotion-10 {
+  stroke: #b3144d;
+}
+
+.emotion-5:focus+.emotion-8 {
+  background-color: #f1eefc;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-5:focus+.emotion-8 .emotion-10 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-5[aria-invalid='true']:focus+.emotion-8 {
+  background-color: #ffebf2;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
+}
+
+.emotion-5[aria-invalid='true']:focus+.emotion-8 .emotion-10 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-7 {
+  border-radius: 0.25rem;
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+}
+
+.emotion-7 path {
+  fill: #ffffff;
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-9 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-11[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-11[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-11[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-11[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="false"
+      data-image="none"
+      data-type="checkbox"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        aria-disabled="false"
+        class="emotion-2 emotion-3 emotion-4"
+        data-checked="false"
+        data-error="false"
+      >
+        <input
+          aria-checked="false"
+          aria-invalid="false"
+          aria-label="test"
+          class="emotion-5 emotion-6"
+          id=":r1o:"
+          name="test"
+          tabindex="-1"
+          type="checkbox"
+          value="choice"
+        />
+        <svg
+          class="emotion-7 emotion-8"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <g>
+            <rect
+              class="emotion-9 emotion-10"
+              height="16"
+              rx="0.125rem"
+              stroke-width="2"
+              width="16"
+              x="4"
+              y="4"
+            />
+            <path
+              clip-rule="evenodd"
+              d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
+              fill="white"
+              fill-rule="evenodd"
+              height="9"
+              width="12"
+              x="5"
+              y="4"
+            />
+          </g>
+        </svg>
+      </div>
+      <div
+        class="emotion-11 emotion-12"
+        data-has-label="false"
+      >
+        Checkbox card
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > checkbox > renders correctly with tooltip prop 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-2 {
+  display: inherit;
+}
+
+.emotion-2[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-4[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-4[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-4[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-4[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-4[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-4[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-4:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-4:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-4:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-4:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-4[data-has-label='true'] .ehkrmld6,
+.emotion-4[data-has-label='true'] .emotion-8 {
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-4[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-4[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-4[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-4[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-4[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-4[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-4:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-4:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-4:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-4:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-4[data-has-label='true'] .ehkrmld6,
+.emotion-4[data-has-label='true'] .emotion-8 {
+  width: 100%;
+}
+
+.emotion-7 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-7 .eqr7bqq4 {
+  cursor: pointer;
+}
+
+.emotion-7[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-7[aria-disabled='true'] .eqr7bqq4 {
+  cursor: not-allowed;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-12 {
+  fill: #e9eaeb;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-12 .emotion-14 {
+  stroke: #d9dadd;
+  fill: #f3f3f4;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.emotion-12 .emotion-14 {
+  stroke: #ffd3e3;
+  fill: #ffd3e3;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.emotion-12 .emotion-14 {
+  stroke: #ffbbd3;
+  fill: #ffebf2;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10:checked+.emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10:checked+.emotion-12 .emotion-14 {
+  stroke: #d8c5fc;
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-7[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.emotion-12 .emotion-14 {
+  stroke: #e5dbfd;
+  fill: #e5dbfd;
+}
+
+.emotion-7 .emotion-10:checked+.emotion-12 path {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+}
+
+.emotion-7 .emotion-10:checked+.emotion-12 .emotion-14 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-7 .emotion-10[aria-invalid="true"]:checked+.emotion-12 .emotion-14 {
+  fill: #e51963;
+  stroke: #e51963;
+}
+
+.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq6 {
+  fill: #ffffff;
+}
+
+.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .emotion-14 {
+  fill: #8c40ef;
+  stroke: #8c40ef;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='false']+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='true']+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='mixed']+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #792dd4;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='false']+.emotion-12 .emotion-14 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='true']+.emotion-12 .emotion-14 {
+  stroke: #d6175c;
+  fill: #d6175c;
+}
+
+.emotion-7 .emotion-10[aria-invalid="true"]+.emotion-12 {
+  fill: #e51963;
+}
+
+.emotion-7 .emotion-10[aria-invalid="true"]+.emotion-12 .emotion-14 {
+  stroke: #e51963;
+  fill: #ffebf2;
+}
+
+.emotion-7[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-7[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-7[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-7 input+svg {
+  display: none;
+}
+
+.emotion-7 label {
+  width: 100%;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='false']+.emotion-12 .emotion-14 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='true']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-7:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='mixed']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-7 .emotion-10:focus+.emotion-12,
+.emotion-7 .emotion-10:active+.emotion-12 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-7 .emotion-10:focus+.emotion-12 .emotion-14,
+.emotion-7 .emotion-10:active+.emotion-12 .emotion-14 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-9 {
+  position: absolute;
+  white-space: nowrap;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  border-width: 0;
+}
+
+.emotion-9:not(:disabled) {
+  cursor: pointer;
+}
+
+.emotion-9:disabled {
+  cursor: not-allowed;
+}
+
+.emotion-9:not(:disabled):checked+.emotion-12,
+.emotion-9:not(:disabled)[aria-checked='mixed']+.emotion-12 {
+  fill: #8c40ef;
+}
+
+.emotion-9:not(:disabled):checked+.emotion-12 .emotion-14,
+.emotion-9:not(:disabled)[aria-checked='mixed']+.emotion-12 .emotion-14 {
+  stroke: #8c40ef;
+}
+
+.emotion-9:not(:disabled)[aria-invalid='true']+.emotion-12,
+.emotion-9:not(:disabled)[aria-invalid='mixed']+.emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9:not(:disabled)[aria-invalid='true']+.emotion-12 .emotion-14,
+.emotion-9:not(:disabled)[aria-invalid='mixed']+.emotion-12 .emotion-14 {
+  stroke: #b3144d;
+}
+
+.emotion-9:focus+.emotion-12 {
+  background-color: #f1eefc;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-9:focus+.emotion-12 .emotion-14 {
+  stroke: #792dd4;
+  fill: #e5dbfd;
+}
+
+.emotion-9[aria-invalid='true']:focus+.emotion-12 {
+  background-color: #ffebf2;
+  fill: #ffebf2;
+  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
+}
+
+.emotion-9[aria-invalid='true']:focus+.emotion-12 .emotion-14 {
+  stroke: #92103f;
+  fill: #ffd3e3;
+}
+
+.emotion-11 {
+  border-radius: 0.25rem;
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+}
+
+.emotion-11 path {
+  fill: #ffffff;
+  -webkit-transform: translate(2px, 2px);
+  -moz-transform: translate(2px, 2px);
+  -ms-transform: translate(2px, 2px);
+  transform: translate(2px, 2px);
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-13 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-20 {
+  color: #3f4250;
+  font-size: 1rem;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+  cursor: pointer;
+}
+
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-22[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-22[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-22[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-22[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+    >
+      <div
+        aria-controls=":r24:"
+        aria-describedby=":r24:"
+        class="emotion-2 emotion-3"
+        tabindex="0"
+      >
+        <div
+          class="emotion-4 emotion-5"
+          data-checked="false"
+          data-disabled="false"
+          data-has-label="true"
+          data-image="none"
+          data-type="checkbox"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            aria-disabled="false"
+            class="emotion-6 emotion-7 emotion-8"
+            data-checked="false"
+            data-error="false"
+          >
+            <input
+              aria-checked="false"
+              aria-invalid="false"
+              class="emotion-9 emotion-10"
+              id=":r25:"
+              name="test"
+              tabindex="-1"
+              type="checkbox"
+              value="choice"
+            />
+            <svg
+              class="emotion-11 emotion-12"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <g>
+                <rect
+                  class="emotion-13 emotion-14"
+                  height="16"
+                  rx="0.125rem"
+                  stroke-width="2"
+                  width="16"
+                  x="4"
+                  y="4"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                  height="9"
+                  width="12"
+                  x="5"
+                  y="4"
+                />
+              </g>
+            </svg>
+            <div
+              class="emotion-15 emotion-1"
+            >
+              <div
+                class="emotion-17 emotion-1"
+              >
+                <label
+                  class="emotion-19 emotion-20 emotion-21"
+                  for=":r25:"
+                >
+                  test
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="emotion-22 emotion-23"
+            data-has-label="false"
+          >
+            Checkbox card
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > radio > renders correctly with aria label 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .emotion-3,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-5[aria-disabled='false'],
+.emotion-5[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-5[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-5[aria-disabled='true']>label,
+.emotion-5[aria-disabled='true'] .emotion-8 {
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
+  fill: #f3f3f4;
+}
+
+.emotion-5[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-5[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-5[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-5 input+svg {
+  display: none;
+}
+
+.emotion-5 label {
+  display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-15[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-15[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="false"
+      data-image="none"
+      data-type="radio"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <div
+          aria-disabled="false"
+          class="emotion-4 emotion-5 emotion-6"
+          data-checked="false"
+        >
+          <input
+            aria-disabled="false"
+            aria-invalid="false"
+            aria-label="test"
+            class="emotion-7 emotion-8"
+            id=":r5:"
+            name="test"
+            tabindex="-1"
+            type="radio"
+            value="choice"
+          />
+          <svg
+            class="emotion-9 emotion-10"
+            viewBox="0 0 24 24"
+          >
+            <g>
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke-width="2"
+              />
+              <circle
+                class="emotion-11 emotion-12"
+                cx="12"
+                cy="12"
+                r="8"
+              />
+              <circle
+                class="emotion-13 emotion-14"
+                cx="12"
+                cy="12"
+                r="5"
+              />
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div
+        class="emotion-15 emotion-16"
+        data-has-label="false"
+      >
+        Radio card
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > radio > renders correctly with checked prop 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .emotion-3,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-5[aria-disabled='false'],
+.emotion-5[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-5[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-5[aria-disabled='true']>label,
+.emotion-5[aria-disabled='true'] .emotion-8 {
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
+  fill: #f3f3f4;
+}
+
+.emotion-5[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-5[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-5[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-5 input+svg {
+  display: none;
+}
+
+.emotion-5 label {
+  display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-15[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-15[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="true"
+      data-disabled="false"
+      data-has-label="false"
+      data-image="none"
+      data-type="radio"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <div
+          aria-disabled="false"
+          class="emotion-4 emotion-5 emotion-6"
+          data-checked="true"
+        >
+          <input
+            aria-disabled="false"
+            aria-invalid="false"
+            aria-label="test"
+            checked=""
+            class="emotion-7 emotion-8"
+            id=":rb:"
+            name="test"
+            tabindex="-1"
+            type="radio"
+            value="choice"
+          />
+          <svg
+            class="emotion-9 emotion-10"
+            viewBox="0 0 24 24"
+          >
+            <g>
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke-width="2"
+              />
+              <circle
+                class="emotion-11 emotion-12"
+                cx="12"
+                cy="12"
+                r="8"
+              />
+              <circle
+                class="emotion-13 emotion-14"
+                cx="12"
+                cy="12"
+                r="5"
+              />
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div
+        class="emotion-15 emotion-16"
+        data-has-label="false"
+      >
+        Radio card
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > radio > renders correctly with complex children 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-box;
@@ -3362,7 +7239,6 @@ exports[`SelectableCard > renders correctly with default props 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -3419,6 +7295,470 @@ exports[`SelectableCard > renders correctly with default props 1`] = `
 
 .emotion-5 input+svg {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-16 {
+  font-size: 1rem;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+}
+
+.emotion-18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-18[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-18[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="true"
+      data-has-label="true"
+      data-image="none"
+      data-type="radio"
+      role="button"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <div
+          aria-disabled="true"
+          class="emotion-4 emotion-5 emotion-6"
+          data-checked="false"
+        >
+          <input
+            aria-disabled="true"
+            aria-invalid="false"
+            class="emotion-7 emotion-8"
+            disabled=""
+            id=":rp:"
+            name="test"
+            tabindex="-1"
+            type="radio"
+            value="choice"
+          />
+          <svg
+            class="emotion-9 emotion-10"
+            viewBox="0 0 24 24"
+          >
+            <g>
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke-width="2"
+              />
+              <circle
+                class="emotion-11 emotion-12"
+                cx="12"
+                cy="12"
+                r="8"
+              />
+              <circle
+                class="emotion-13 emotion-14"
+                cx="12"
+                cy="12"
+                r="5"
+              />
+            </g>
+          </svg>
+          <label
+            class="emotion-15 emotion-16 emotion-17"
+            for=":rp:"
+          >
+            test
+          </label>
+        </div>
+      </div>
+      <div
+        class="emotion-18 emotion-19"
+        data-has-label="false"
+      >
+        <div
+          style="background: gray; color: gray;"
+        >
+          Complex radio card
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > radio > renders correctly with default props 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .emotion-3,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-5[aria-disabled='false'],
+.emotion-5[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-5[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-5[aria-disabled='true']>label,
+.emotion-5[aria-disabled='true'] .emotion-8 {
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
+  fill: #f3f3f4;
+}
+
+.emotion-5[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-5[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-5[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-5 input+svg {
+  display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {
@@ -3568,7 +7908,7 @@ exports[`SelectableCard > renders correctly with default props 1`] = `
             aria-invalid="false"
             class="emotion-7 emotion-8"
             id=":r1:"
-            name="radio"
+            name="test"
             tabindex="-1"
             type="radio"
             value="choice"
@@ -3617,1484 +7957,7 @@ exports[`SelectableCard > renders correctly with default props 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with illustration 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .emotion-7,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
-  width: 100%;
-}
-
-.emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .emotion-7,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
-  width: 100%;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  width: 100%;
-}
-
-.emotion-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 1rem;
-  max-width: calc(100% - 10rem);
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-9 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  gap: 0.5rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  pointer-events: none;
-}
-
-.emotion-9[aria-disabled='false'],
-.emotion-9[aria-disabled='false']>label {
-  cursor: pointer;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 {
-  fill: #8c40ef;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 .emotion-16 {
-  fill: #e5dbfd;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 {
-  fill: #b3144d;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
-  fill: #ffd3e3;
-}
-
-.emotion-9[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-9[aria-disabled='true']>label,
-.emotion-9[aria-disabled='true'] .emotion-12 {
-  cursor: not-allowed;
-}
-
-.emotion-9[aria-disabled='true'] .emotion-14 {
-  fill: #e9eaeb;
-  cursor: not-allowed;
-}
-
-.emotion-9[aria-disabled='true'] .emotion-14 .emotion-16 {
-  fill: #f3f3f4;
-}
-
-.emotion-9[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-9[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-9[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-11 {
-  cursor: pointer;
-  position: absolute;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.emotion-11+.emotion-14 .emotion-18 {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-11:checked+svg .emotion-18 {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-11:checked[aria-disabled='false'][aria-invalid='false']+.emotion-14 {
-  fill: #8c40ef;
-}
-
-.emotion-11:checked[aria-disabled='true'][aria-invalid='false']+.emotion-14 {
-  fill: #d8c5fc;
-}
-
-.emotion-11[aria-invalid='true']:not([aria-disabled='true'])+.emotion-14 {
-  fill: #e51963;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 {
-  background-color: #5e127e40;
-  fill: #8c40ef;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 .emotion-16 {
-  fill: #f1eefc;
-}
-
-.emotion-11[aria-disabled='false']:focus-visible+.emotion-14 {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 {
-  background-color: #f91b6c40;
-  fill: #e51963;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 .emotion-16 {
-  fill: #ffebf2;
-}
-
-.emotion-11 {
-  cursor: pointer;
-  position: absolute;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.emotion-11+.emotion-14 .emotion-18 {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-11:checked+svg .emotion-18 {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-11:checked[aria-disabled='false'][aria-invalid='false']+.emotion-14 {
-  fill: #8c40ef;
-}
-
-.emotion-11:checked[aria-disabled='true'][aria-invalid='false']+.emotion-14 {
-  fill: #d8c5fc;
-}
-
-.emotion-11[aria-invalid='true']:not([aria-disabled='true'])+.emotion-14 {
-  fill: #e51963;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 {
-  background-color: #5e127e40;
-  fill: #8c40ef;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 .emotion-16 {
-  fill: #f1eefc;
-}
-
-.emotion-11[aria-disabled='false']:focus-visible+.emotion-14 {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 {
-  background-color: #f91b6c40;
-  fill: #e51963;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 .emotion-16 {
-  fill: #ffebf2;
-}
-
-.emotion-13 {
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-  border-radius: 100%;
-  fill: #d9dadd;
-}
-
-.emotion-13 .emotion-16 {
-  fill: #ffffff;
-}
-
-.emotion-13 {
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-  border-radius: 100%;
-  fill: #d9dadd;
-}
-
-.emotion-13 .emotion-16 {
-  fill: #ffffff;
-}
-
-.emotion-20 {
-  font-size: 1rem;
-  font-family: Inter,Asap,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  cursor: pointer;
-}
-
-.emotion-20 {
-  font-size: 1rem;
-  font-family: Inter,Asap,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  cursor: pointer;
-}
-
-.emotion-22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-22[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-22[data-has-label='false'] {
-  display: contents;
-}
-
-.emotion-22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-22[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-22[data-has-label='false'] {
-  display: contents;
-}
-
-.emotion-24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0;
-  -webkit-box-flex-flow: column;
-  -webkit-flex-flow: column;
-  -ms-flex-flow: column;
-  flex-flow: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  min-width: 11.25rem;
-  position: relative;
-  overflow: hidden;
-}
-
-.emotion-28 {
-  object-fit: cover;
-  position: absolute;
-  min-width: 13.75rem;
-  height: auto;
-  left: 0.5rem;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-disabled="false"
-      data-has-label="true"
-      data-image="illustration"
-      data-type="radio"
-      role="button"
-      tabindex="0"
-    >
-      <div
-        class="emotion-2 emotion-3"
-      >
-        <div
-          class="emotion-4 emotion-5"
-        >
-          <div
-            class="emotion-6 emotion-7"
-          >
-            <div
-              aria-disabled="false"
-              class="emotion-8 emotion-9 emotion-10"
-              data-checked="false"
-            >
-              <input
-                aria-disabled="false"
-                aria-invalid="false"
-                class="emotion-11 emotion-12"
-                id=":r1l:"
-                name="label-14"
-                tabindex="-1"
-                type="radio"
-                value="label-14"
-              />
-              <svg
-                class="emotion-13 emotion-14"
-                viewBox="0 0 24 24"
-              >
-                <g>
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke-width="2"
-                  />
-                  <circle
-                    class="emotion-15 emotion-16"
-                    cx="12"
-                    cy="12"
-                    r="8"
-                  />
-                  <circle
-                    class="emotion-17 emotion-18"
-                    cx="12"
-                    cy="12"
-                    r="5"
-                  />
-                </g>
-              </svg>
-              <label
-                class="emotion-19 emotion-20 emotion-21"
-                for=":r1l:"
-              >
-                label
-              </label>
-            </div>
-          </div>
-          <div
-            class="emotion-22 emotion-23"
-            data-has-label="true"
-          >
-            Offer the best experience to your Mac, iPhone and iPad users with VNC, the remote desktop-sharing protocol. Learn more
-          </div>
-        </div>
-        <div
-          class="emotion-24 emotion-3"
-        />
-        <div
-          class="emotion-26 emotion-27"
-        >
-          <img
-            alt="illustration"
-            class="emotion-28 emotion-29"
-            src="/src/components/SelectableCard/__tests__/illustrationTest.svg"
-            width="220"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCard > renders correctly with productIcon 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .emotion-7,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
-  width: 100%;
-}
-
-.emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .emotion-7,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
-  width: 100%;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  width: 100%;
-}
-
-.emotion-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 1rem;
-  max-width: calc(100% - 10rem);
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-9 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  gap: 0.5rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  pointer-events: none;
-}
-
-.emotion-9[aria-disabled='false'],
-.emotion-9[aria-disabled='false']>label {
-  cursor: pointer;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 {
-  fill: #8c40ef;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 .emotion-16 {
-  fill: #e5dbfd;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 {
-  fill: #b3144d;
-}
-
-.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
-  fill: #ffd3e3;
-}
-
-.emotion-9[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-9[aria-disabled='true']>label,
-.emotion-9[aria-disabled='true'] .emotion-12 {
-  cursor: not-allowed;
-}
-
-.emotion-9[aria-disabled='true'] .emotion-14 {
-  fill: #e9eaeb;
-  cursor: not-allowed;
-}
-
-.emotion-9[aria-disabled='true'] .emotion-14 .emotion-16 {
-  fill: #f3f3f4;
-}
-
-.emotion-9[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-9[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-9[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-11 {
-  cursor: pointer;
-  position: absolute;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.emotion-11+.emotion-14 .emotion-18 {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-11:checked+svg .emotion-18 {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-11:checked[aria-disabled='false'][aria-invalid='false']+.emotion-14 {
-  fill: #8c40ef;
-}
-
-.emotion-11:checked[aria-disabled='true'][aria-invalid='false']+.emotion-14 {
-  fill: #d8c5fc;
-}
-
-.emotion-11[aria-invalid='true']:not([aria-disabled='true'])+.emotion-14 {
-  fill: #e51963;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 {
-  background-color: #5e127e40;
-  fill: #8c40ef;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 .emotion-16 {
-  fill: #f1eefc;
-}
-
-.emotion-11[aria-disabled='false']:focus-visible+.emotion-14 {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 {
-  background-color: #f91b6c40;
-  fill: #e51963;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 .emotion-16 {
-  fill: #ffebf2;
-}
-
-.emotion-11 {
-  cursor: pointer;
-  position: absolute;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.emotion-11+.emotion-14 .emotion-18 {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-11:checked+svg .emotion-18 {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-11:checked[aria-disabled='false'][aria-invalid='false']+.emotion-14 {
-  fill: #8c40ef;
-}
-
-.emotion-11:checked[aria-disabled='true'][aria-invalid='false']+.emotion-14 {
-  fill: #d8c5fc;
-}
-
-.emotion-11[aria-invalid='true']:not([aria-disabled='true'])+.emotion-14 {
-  fill: #e51963;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 {
-  background-color: #5e127e40;
-  fill: #8c40ef;
-}
-
-.emotion-11[aria-disabled='false']:active+.emotion-14 .emotion-16 {
-  fill: #f1eefc;
-}
-
-.emotion-11[aria-disabled='false']:focus-visible+.emotion-14 {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 {
-  background-color: #f91b6c40;
-  fill: #e51963;
-}
-
-.emotion-11[aria-invalid='true']:focus+.emotion-14 .emotion-16 {
-  fill: #ffebf2;
-}
-
-.emotion-13 {
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-  border-radius: 100%;
-  fill: #d9dadd;
-}
-
-.emotion-13 .emotion-16 {
-  fill: #ffffff;
-}
-
-.emotion-13 {
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-  border-radius: 100%;
-  fill: #d9dadd;
-}
-
-.emotion-13 .emotion-16 {
-  fill: #ffffff;
-}
-
-.emotion-20 {
-  font-size: 1rem;
-  font-family: Inter,Asap,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  cursor: pointer;
-}
-
-.emotion-20 {
-  font-size: 1rem;
-  font-family: Inter,Asap,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  cursor: pointer;
-}
-
-.emotion-22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-22[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-22[data-has-label='false'] {
-  display: contents;
-}
-
-.emotion-22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-22[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-22[data-has-label='false'] {
-  display: contents;
-}
-
-.emotion-24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-26 {
-  width: 3rem;
-  min-width: 3rem;
-  height: 3rem;
-}
-
-.emotion-26 path[fill].fill,
-.emotion-26 g[fill].fill>*,
-.emotion-26 g.fill>* {
-  fill: #521094;
-}
-
-.emotion-26 path[fill].fillStrong,
-.emotion-26 g[fill].fillStrong>*,
-.emotion-26 g.fillStrong>* {
-  fill: #a060f6;
-}
-
-.emotion-26 path[fill].fillWeak,
-.emotion-26 g[fill].fillWeak>*,
-.emotion-26 g.fillWeak>* {
-  fill: #f1eefc;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-disabled="false"
-      data-has-label="true"
-      data-image="icon"
-      data-type="radio"
-      role="button"
-      tabindex="0"
-    >
-      <div
-        class="emotion-2 emotion-3"
-      >
-        <div
-          class="emotion-4 emotion-5"
-        >
-          <div
-            class="emotion-6 emotion-7"
-          >
-            <div
-              aria-disabled="false"
-              class="emotion-8 emotion-9 emotion-10"
-              data-checked="false"
-            >
-              <input
-                aria-disabled="false"
-                aria-invalid="false"
-                class="emotion-11 emotion-12"
-                id=":r1p:"
-                name="label-14"
-                tabindex="-1"
-                type="radio"
-                value="label-14"
-              />
-              <svg
-                class="emotion-13 emotion-14"
-                viewBox="0 0 24 24"
-              >
-                <g>
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke-width="2"
-                  />
-                  <circle
-                    class="emotion-15 emotion-16"
-                    cx="12"
-                    cy="12"
-                    r="8"
-                  />
-                  <circle
-                    class="emotion-17 emotion-18"
-                    cx="12"
-                    cy="12"
-                    r="5"
-                  />
-                </g>
-              </svg>
-              <label
-                class="emotion-19 emotion-20 emotion-21"
-                for=":r1p:"
-              >
-                label
-              </label>
-            </div>
-          </div>
-          <div
-            class="emotion-22 emotion-23"
-            data-has-label="true"
-          >
-            Offer the best experience to your Mac, iPhone and iPad users with VNC, the remote desktop-sharing protocol. Learn more
-          </div>
-        </div>
-        <div
-          class="emotion-24 emotion-3"
-        >
-          <svg
-            class="emotion-26 emotion-27"
-            viewBox="0 0 64 64"
-          >
-            <g
-              class="MacMini"
-            >
-              <g
-                class=".Square"
-              >
-                <path
-                  class="fillWeak"
-                  d="M0 16C0 7.163 7.163 0 16 0h32c8.837 0 16 7.163 16 16v32c0 8.837-7.163 16-16 16H16C7.163 64 0 56.837 0 48z"
-                  fill="#F1EEFC"
-                />
-              </g>
-              <g
-                class="Icon MacMini"
-              >
-                <g
-                  class="MacMini"
-                  clip-rule="evenodd"
-                  fill-rule="evenodd"
-                >
-                  <path
-                    class="fill"
-                    d="M40 8.5c5.523 0 10 4.477 10 10v16c0 5.523-4.477 10-10 10h-7v5.17a3 3 0 0 1 1.83 1.83h13.334a1 1 0 0 1 .117 1.993l-.117.007H34.83a3.001 3.001 0 0 1-5.658 0H15a1 1 0 0 1-.117-1.993L15 51.5h14.171A3 3 0 0 1 31 49.67V44.5h-7c-5.523 0-10-4.477-10-10v-16c0-5.523 4.477-10 10-10zm-8 34h-8l-.25-.004A8 8 0 0 1 16 34.5v-16l.004-.25A8 8 0 0 1 24 10.5h16l.25.004A8 8 0 0 1 48 18.5v16l-.004.25A8 8 0 0 1 40 42.5zm0 9a1 1 0 1 1 0 2 1 1 0 0 1 0-2"
-                    fill="#521094"
-                  />
-                  <path
-                    class="fillStrong"
-                    d="M45 18.5a5 5 0 0 0-5-5H24a5 5 0 0 0-5 5v16a5 5 0 0 0 5 5h16a5 5 0 0 0 5-5zm-21-3h16l.176.005A3 3 0 0 1 43 18.5v16l-.005.176A3 3 0 0 1 40 37.5H24l-.176-.005A3 3 0 0 1 21 34.5v-16l.005-.176A3 3 0 0 1 24 15.5"
-                    fill="#A060F6"
-                  />
-                  <path
-                    class="fillStrong"
-                    d="M34.5 24h-5v5h5zm-5-2a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-5a2 2 0 0 0-2-2z"
-                    fill="#A060F6"
-                  />
-                </g>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCard > renders correctly with radio type and checked prop 1`] = `
+exports[`SelectableCard > radio > renders correctly with disabled prop 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-box;
@@ -5215,7 +8078,6 @@ exports[`SelectableCard > renders correctly with radio type and checked prop 1`]
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -5278,310 +8140,20 @@ exports[`SelectableCard > renders correctly with radio type and checked prop 1`]
   display: none;
 }
 
-.emotion-7 {
-  cursor: pointer;
-  position: absolute;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.emotion-7+.emotion-10 .emotion-14 {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-7:checked+svg .emotion-14 {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
-  fill: #8c40ef;
-}
-
-.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
-  fill: #d8c5fc;
-}
-
-.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
-  fill: #e51963;
-}
-
-.emotion-7[aria-disabled='false']:active+.emotion-10 {
-  background-color: #5e127e40;
-  fill: #8c40ef;
-}
-
-.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
-  fill: #f1eefc;
-}
-
-.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-.emotion-7[aria-invalid='true']:focus+.emotion-10 {
-  background-color: #f91b6c40;
-  fill: #e51963;
-}
-
-.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
-  fill: #ffebf2;
-}
-
-.emotion-9 {
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-  border-radius: 100%;
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
   fill: #d9dadd;
 }
 
-.emotion-9 .emotion-12 {
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
   fill: #ffffff;
 }
 
-.emotion-15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
 }
 
-.emotion-15[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-15[data-has-label='false'] {
-  display: contents;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      class="emotion-0 emotion-1"
-      data-checked="true"
-      data-disabled="false"
-      data-has-label="false"
-      data-image="none"
-      data-type="radio"
-      role="button"
-      tabindex="0"
-    >
-      <div
-        class="emotion-2 emotion-3"
-      >
-        <div
-          aria-disabled="false"
-          class="emotion-4 emotion-5 emotion-6"
-          data-checked="true"
-        >
-          <input
-            aria-disabled="false"
-            aria-invalid="false"
-            aria-label="test"
-            checked=""
-            class="emotion-7 emotion-8"
-            id=":rh:"
-            name="radio"
-            tabindex="-1"
-            type="radio"
-            value="choice"
-          />
-          <svg
-            class="emotion-9 emotion-10"
-            viewBox="0 0 24 24"
-          >
-            <g>
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-                stroke-width="2"
-              />
-              <circle
-                class="emotion-11 emotion-12"
-                cx="12"
-                cy="12"
-                r="8"
-              />
-              <circle
-                class="emotion-13 emotion-14"
-                cx="12"
-                cy="12"
-                r="5"
-              />
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="emotion-15 emotion-16"
-        data-has-label="false"
-      >
-        Radio card
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCard > renders correctly with radio type and disabled prop 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
-  width: 100%;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-5 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  gap: 0.5rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  pointer-events: none;
-}
-
-.emotion-5[aria-disabled='false'],
-.emotion-5[aria-disabled='false']>label {
-  cursor: pointer;
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
@@ -5589,7 +8161,7 @@ exports[`SelectableCard > renders correctly with radio type and disabled prop 1`
 }
 
 .emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
-  fill: #e5dbfd;
+  fill: #ffffff;
 }
 
 .emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
@@ -5597,46 +8169,16 @@ exports[`SelectableCard > renders correctly with radio type and disabled prop 1`
 }
 
 .emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
-  fill: #ffd3e3;
+  fill: #ffffff;
 }
 
-.emotion-5[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
 }
 
-.emotion-5[aria-disabled='true']>label,
-.emotion-5[aria-disabled='true'] .emotion-8 {
-  cursor: not-allowed;
-}
-
-.emotion-5[aria-disabled='true'] .emotion-10 {
-  fill: #e9eaeb;
-  cursor: not-allowed;
-}
-
-.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
-  fill: #f3f3f4;
-}
-
-.emotion-5[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-5[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-5[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-5 input+svg {
-  display: none;
-}
-
-.emotion-5 label {
-  display: none;
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {
@@ -5771,8 +8313,8 @@ exports[`SelectableCard > renders correctly with radio type and disabled prop 1`
             aria-label="test"
             class="emotion-7 emotion-8"
             disabled=""
-            id=":rn:"
-            name="radio"
+            id=":re:"
+            name="test"
             tabindex="-1"
             type="radio"
             value="choice"
@@ -5815,7 +8357,551 @@ exports[`SelectableCard > renders correctly with radio type and disabled prop 1`
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with radio type and isError prop 1`] = `
+exports[`SelectableCard > radio > renders correctly with illustration 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .emotion-7,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  max-width: calc(100% - 10rem);
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-9 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-9[aria-disabled='false'],
+.emotion-9[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 {
+  fill: #8c40ef;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 .emotion-16 {
+  fill: #e5dbfd;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffd3e3;
+}
+
+.emotion-9[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-9[aria-disabled='true']>label,
+.emotion-9[aria-disabled='true'] .emotion-12 {
+  cursor: not-allowed;
+}
+
+.emotion-9[aria-disabled='true'] .emotion-14 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-9[aria-disabled='true'] .emotion-14 .emotion-16 {
+  fill: #f3f3f4;
+}
+
+.emotion-9[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-9[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-9[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12+.emotion-14 {
+  fill: #d9dadd;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 {
+  fill: #8c40ef;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9 .emotion-12[aria-disabled='false']:active+.emotion-14 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-9 .emotion-12[aria-disabled='false']:active+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-11 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-11+.emotion-14 .emotion-18 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-11:checked+svg .emotion-18 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-11:checked[aria-disabled='false'][aria-invalid='false']+.emotion-14 {
+  fill: #8c40ef;
+}
+
+.emotion-11:checked[aria-disabled='true'][aria-invalid='false']+.emotion-14 {
+  fill: #d8c5fc;
+}
+
+.emotion-11[aria-invalid='true']:not([aria-disabled='true'])+.emotion-14 {
+  fill: #e51963;
+}
+
+.emotion-11[aria-disabled='false']:active+.emotion-14 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-11[aria-disabled='false']:active+.emotion-14 .emotion-16 {
+  fill: #f1eefc;
+}
+
+.emotion-11[aria-disabled='false']:focus-visible+.emotion-14 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-11[aria-invalid='true']:focus+.emotion-14 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-11[aria-invalid='true']:focus+.emotion-14 .emotion-16 {
+  fill: #ffebf2;
+}
+
+.emotion-13 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-13 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-20 {
+  font-size: 1rem;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+}
+
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-22[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-22[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0;
+  -webkit-box-flex-flow: column;
+  -webkit-flex-flow: column;
+  -ms-flex-flow: column;
+  flex-flow: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  min-width: 11.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.emotion-28 {
+  object-fit: cover;
+  position: absolute;
+  min-width: 13.75rem;
+  height: auto;
+  left: 0.5rem;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="true"
+      data-image="illustration"
+      data-type="radio"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <div
+          class="emotion-4 emotion-5"
+        >
+          <div
+            class="emotion-6 emotion-7"
+          >
+            <div
+              aria-disabled="false"
+              class="emotion-8 emotion-9 emotion-10"
+              data-checked="false"
+            >
+              <input
+                aria-disabled="false"
+                aria-invalid="false"
+                class="emotion-11 emotion-12"
+                id=":rt:"
+                name="label-14"
+                tabindex="-1"
+                type="radio"
+                value="label-14"
+              />
+              <svg
+                class="emotion-13 emotion-14"
+                viewBox="0 0 24 24"
+              >
+                <g>
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke-width="2"
+                  />
+                  <circle
+                    class="emotion-15 emotion-16"
+                    cx="12"
+                    cy="12"
+                    r="8"
+                  />
+                  <circle
+                    class="emotion-17 emotion-18"
+                    cx="12"
+                    cy="12"
+                    r="5"
+                  />
+                </g>
+              </svg>
+              <label
+                class="emotion-19 emotion-20 emotion-21"
+                for=":rt:"
+              >
+                label
+              </label>
+            </div>
+          </div>
+          <div
+            class="emotion-22 emotion-23"
+            data-has-label="true"
+          >
+            Offer the best experience to your Mac, iPhone and iPad users with VNC, the remote desktop-sharing protocol. Learn more
+          </div>
+        </div>
+        <div
+          class="emotion-24 emotion-3"
+        />
+        <div
+          class="emotion-26 emotion-27"
+        >
+          <img
+            alt="illustration"
+            class="emotion-28 emotion-29"
+            src="/src/components/SelectableCard/__tests__/illustrationTest.svg"
+            width="220"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > radio > renders correctly with isError prop 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-box;
@@ -5939,7 +9025,6 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-5[aria-disabled='false'],
@@ -5996,6 +9081,47 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
 
 .emotion-5 input+svg {
   display: none;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
 }
 
 .emotion-7 {
@@ -6146,8 +9272,8 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
             aria-disabled="false"
             aria-invalid="true"
             class="emotion-7 emotion-8"
-            id=":r11:"
-            name="radio"
+            id=":rh:"
+            name="test"
             tabindex="-1"
             type="radio"
             value="choice"
@@ -6179,7 +9305,7 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
           </svg>
           <label
             class="emotion-15 emotion-16 emotion-17"
-            for=":r11:"
+            for=":rh:"
           >
             test
           </label>
@@ -6196,7 +9322,970 @@ exports[`SelectableCard > renders correctly with radio type and isError prop 1`]
 </DocumentFragment>
 `;
 
-exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`] = `
+exports[`SelectableCard > radio > renders correctly with productIcon 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .emotion-7,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  max-width: calc(100% - 10rem);
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-9 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-9[aria-disabled='false'],
+.emotion-9[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 {
+  fill: #8c40ef;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 .emotion-16 {
+  fill: #e5dbfd;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffd3e3;
+}
+
+.emotion-9[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-9[aria-disabled='true']>label,
+.emotion-9[aria-disabled='true'] .emotion-12 {
+  cursor: not-allowed;
+}
+
+.emotion-9[aria-disabled='true'] .emotion-14 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-9[aria-disabled='true'] .emotion-14 .emotion-16 {
+  fill: #f3f3f4;
+}
+
+.emotion-9[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-9[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-9[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12+.emotion-14 {
+  fill: #d9dadd;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 {
+  fill: #8c40ef;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9 .emotion-12[aria-disabled='false']:active+.emotion-14 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-9 .emotion-12[aria-disabled='false']:active+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-11 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-11+.emotion-14 .emotion-18 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-11:checked+svg .emotion-18 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-11:checked[aria-disabled='false'][aria-invalid='false']+.emotion-14 {
+  fill: #8c40ef;
+}
+
+.emotion-11:checked[aria-disabled='true'][aria-invalid='false']+.emotion-14 {
+  fill: #d8c5fc;
+}
+
+.emotion-11[aria-invalid='true']:not([aria-disabled='true'])+.emotion-14 {
+  fill: #e51963;
+}
+
+.emotion-11[aria-disabled='false']:active+.emotion-14 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-11[aria-disabled='false']:active+.emotion-14 .emotion-16 {
+  fill: #f1eefc;
+}
+
+.emotion-11[aria-disabled='false']:focus-visible+.emotion-14 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-11[aria-invalid='true']:focus+.emotion-14 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-11[aria-invalid='true']:focus+.emotion-14 .emotion-16 {
+  fill: #ffebf2;
+}
+
+.emotion-13 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-13 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-20 {
+  font-size: 1rem;
+  font-family: Inter,Asap,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+}
+
+.emotion-22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-22[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-22[data-has-label='false'] {
+  display: contents;
+}
+
+.emotion-24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-26 {
+  width: 3rem;
+  min-width: 3rem;
+  height: 3rem;
+}
+
+.emotion-26 path[fill].fill,
+.emotion-26 g[fill].fill>*,
+.emotion-26 g.fill>* {
+  fill: #521094;
+}
+
+.emotion-26 path[fill].fillStrong,
+.emotion-26 g[fill].fillStrong>*,
+.emotion-26 g.fillStrong>* {
+  fill: #a060f6;
+}
+
+.emotion-26 path[fill].fillWeak,
+.emotion-26 g[fill].fillWeak>*,
+.emotion-26 g.fillWeak>* {
+  fill: #f1eefc;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="true"
+      data-image="icon"
+      data-type="radio"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <div
+          class="emotion-4 emotion-5"
+        >
+          <div
+            class="emotion-6 emotion-7"
+          >
+            <div
+              aria-disabled="false"
+              class="emotion-8 emotion-9 emotion-10"
+              data-checked="false"
+            >
+              <input
+                aria-disabled="false"
+                aria-invalid="false"
+                class="emotion-11 emotion-12"
+                id=":r11:"
+                name="label-14"
+                tabindex="-1"
+                type="radio"
+                value="label-14"
+              />
+              <svg
+                class="emotion-13 emotion-14"
+                viewBox="0 0 24 24"
+              >
+                <g>
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke-width="2"
+                  />
+                  <circle
+                    class="emotion-15 emotion-16"
+                    cx="12"
+                    cy="12"
+                    r="8"
+                  />
+                  <circle
+                    class="emotion-17 emotion-18"
+                    cx="12"
+                    cy="12"
+                    r="5"
+                  />
+                </g>
+              </svg>
+              <label
+                class="emotion-19 emotion-20 emotion-21"
+                for=":r11:"
+              >
+                label
+              </label>
+            </div>
+          </div>
+          <div
+            class="emotion-22 emotion-23"
+            data-has-label="true"
+          >
+            Offer the best experience to your Mac, iPhone and iPad users with VNC, the remote desktop-sharing protocol. Learn more
+          </div>
+        </div>
+        <div
+          class="emotion-24 emotion-3"
+        >
+          <svg
+            class="emotion-26 emotion-27"
+            viewBox="0 0 64 64"
+          >
+            <g
+              class="MacMini"
+            >
+              <g
+                class=".Square"
+              >
+                <path
+                  class="fillWeak"
+                  d="M0 16C0 7.163 7.163 0 16 0h32c8.837 0 16 7.163 16 16v32c0 8.837-7.163 16-16 16H16C7.163 64 0 56.837 0 48z"
+                  fill="#F1EEFC"
+                />
+              </g>
+              <g
+                class="Icon MacMini"
+              >
+                <g
+                  class="MacMini"
+                  clip-rule="evenodd"
+                  fill-rule="evenodd"
+                >
+                  <path
+                    class="fill"
+                    d="M40 8.5c5.523 0 10 4.477 10 10v16c0 5.523-4.477 10-10 10h-7v5.17a3 3 0 0 1 1.83 1.83h13.334a1 1 0 0 1 .117 1.993l-.117.007H34.83a3.001 3.001 0 0 1-5.658 0H15a1 1 0 0 1-.117-1.993L15 51.5h14.171A3 3 0 0 1 31 49.67V44.5h-7c-5.523 0-10-4.477-10-10v-16c0-5.523 4.477-10 10-10zm-8 34h-8l-.25-.004A8 8 0 0 1 16 34.5v-16l.004-.25A8 8 0 0 1 24 10.5h16l.25.004A8 8 0 0 1 48 18.5v16l-.004.25A8 8 0 0 1 40 42.5zm0 9a1 1 0 1 1 0 2 1 1 0 0 1 0-2"
+                    fill="#521094"
+                  />
+                  <path
+                    class="fillStrong"
+                    d="M45 18.5a5 5 0 0 0-5-5H24a5 5 0 0 0-5 5v16a5 5 0 0 0 5 5h16a5 5 0 0 0 5-5zm-21-3h16l.176.005A3 3 0 0 1 43 18.5v16l-.005.176A3 3 0 0 1 40 37.5H24l-.176-.005A3 3 0 0 1 21 34.5v-16l.005-.176A3 3 0 0 1 24 15.5"
+                    fill="#A060F6"
+                  />
+                  <path
+                    class="fillStrong"
+                    d="M34.5 24h-5v5h5zm-5-2a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2v-5a2 2 0 0 0-2-2z"
+                    fill="#A060F6"
+                  />
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > radio > renders correctly with showTick 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  cursor: pointer;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  color: #3f4250;
+}
+
+.emotion-0[data-has-label='false']>:first-child {
+  margin-bottom: -0.25rem;
+}
+
+.emotion-0[data-checked='true'] {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0[data-error='true'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-0[data-disabled='true'] {
+  border: 1px solid #e9eaeb;
+  color: #b5b7bd;
+  background: #f3f3f4;
+  cursor: not-allowed;
+}
+
+.emotion-0[data-image="illustration"] {
+  padding: 0rem;
+}
+
+.emotion-0[data-image="icon"] {
+  padding: 0rem;
+  padding-right: 1rem;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
+.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
+  border: 1px solid #8c40ef;
+}
+
+.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
+.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
+  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
+}
+
+.emotion-0[data-has-label='true'] .emotion-3,
+.emotion-0[data-has-label='true'] .eqr7bqq1 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0.25rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.emotion-5 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 0.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-5[aria-disabled='false'],
+.emotion-5[aria-disabled='false']>label {
+  cursor: pointer;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #e5dbfd;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffd3e3;
+}
+
+.emotion-5[aria-disabled='true'] {
+  cursor: not-allowed;
+  color: #b5b7bd;
+}
+
+.emotion-5[aria-disabled='true']>label,
+.emotion-5[aria-disabled='true'] .emotion-8 {
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 {
+  fill: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
+  fill: #f3f3f4;
+}
+
+.emotion-5[data-checked='true'] {
+  color: #641cb3;
+}
+
+.emotion-5[data-error='true'] {
+  color: #b3144d;
+}
+
+.emotion-5[aria-disabled='true'] {
+  color: #b5b7bd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 {
+  fill: #d9dadd;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false']:not([data-checked='true']) .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
+  fill: #b3144d;
+}
+
+.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-5 .emotion-8[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-7 {
+  cursor: pointer;
+  position: absolute;
+  height: 1.5rem;
+  width: 1.5rem;
+  opacity: 0;
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.emotion-7+.emotion-10 .emotion-14 {
+  transform-origin: center;
+  -webkit-transition: 200ms -webkit-transform ease-in-out;
+  transition: 200ms transform ease-in-out;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+}
+
+.emotion-7:checked+svg .emotion-14 {
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
+  fill: #8c40ef;
+}
+
+.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
+  fill: #d8c5fc;
+}
+
+.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
+  fill: #e51963;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 {
+  background-color: #5e127e40;
+  fill: #8c40ef;
+}
+
+.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
+  fill: #f1eefc;
+}
+
+.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 {
+  background-color: #f91b6c40;
+  fill: #e51963;
+}
+
+.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
+  fill: #ffebf2;
+}
+
+.emotion-9 {
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
+  border-radius: 100%;
+  fill: #d9dadd;
+}
+
+.emotion-9 .emotion-12 {
+  fill: #ffffff;
+}
+
+.emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 0rem;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.emotion-15[data-has-label='true'] {
+  padding-left: 2rem;
+}
+
+.emotion-15[data-has-label='false'] {
+  display: contents;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      class="emotion-0 emotion-1"
+      data-checked="false"
+      data-disabled="false"
+      data-has-label="false"
+      data-image="none"
+      data-type="radio"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="emotion-2 emotion-3"
+      >
+        <div
+          aria-disabled="false"
+          class="emotion-4 emotion-5 emotion-6"
+          data-checked="false"
+        >
+          <input
+            aria-disabled="false"
+            aria-invalid="false"
+            aria-label="test"
+            class="emotion-7 emotion-8"
+            id=":r8:"
+            name="test"
+            tabindex="-1"
+            type="radio"
+            value="choice"
+          />
+          <svg
+            class="emotion-9 emotion-10"
+            viewBox="0 0 24 24"
+          >
+            <g>
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke-width="2"
+              />
+              <circle
+                class="emotion-11 emotion-12"
+                cx="12"
+                cy="12"
+                r="8"
+              />
+              <circle
+                class="emotion-13 emotion-14"
+                cx="12"
+                cy="12"
+                r="5"
+              />
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div
+        class="emotion-15 emotion-16"
+        data-has-label="false"
+      >
+        Checkbox card
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectableCard > radio > renders correctly with tooltip prop 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-box;
@@ -6354,7 +10443,6 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-9[aria-disabled='false'],
@@ -6411,6 +10499,47 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
 
 .emotion-9 input+svg {
   display: none;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12+.emotion-14 {
+  fill: #d9dadd;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false']:not([data-checked='true']) .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 {
+  fill: #8c40ef;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 {
+  fill: #b3144d;
+}
+
+.emotion-9:hover[aria-disabled='false'] .emotion-12[aria-invalid='true']+.emotion-14 .emotion-16 {
+  fill: #ffffff;
+}
+
+.emotion-9 .emotion-12[aria-disabled='false']:active+.emotion-14 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-9 .emotion-12[aria-disabled='false']:active+.emotion-14 .emotion-16 {
+  fill: #ffffff;
 }
 
 .emotion-11 {
@@ -6541,8 +10670,8 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r14:"
-        aria-describedby=":r14:"
+        aria-controls=":rk:"
+        aria-describedby=":rk:"
         class="emotion-2 emotion-3"
         tabindex="0"
       >
@@ -6568,8 +10697,8 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
                 aria-disabled="false"
                 aria-invalid="false"
                 class="emotion-11 emotion-12"
-                id=":r15:"
-                name="radio"
+                id=":rl:"
+                name="test"
                 tabindex="-1"
                 type="radio"
                 value="choice"
@@ -6601,7 +10730,7 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
               </svg>
               <label
                 class="emotion-19 emotion-20 emotion-21"
-                for=":r15:"
+                for=":rl:"
               >
                 test
               </label>
@@ -6611,785 +10740,9 @@ exports[`SelectableCard > renders correctly with radio type and tooltip prop 1`]
             class="emotion-22 emotion-23"
             data-has-label="false"
           >
-            Radio card
+            Checkbox card
           </div>
         </div>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCard > renders correctly with showTick and type checkbox 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .ehkrmld6,
-.emotion-0[data-has-label='true'] .emotion-4 {
-  width: 100%;
-}
-
-.emotion-3 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.5rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  pointer-events: none;
-}
-
-.emotion-3 .eqr7bqq4 {
-  cursor: pointer;
-}
-
-.emotion-3[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
-  cursor: not-allowed;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-8 {
-  fill: #e9eaeb;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-8 .emotion-10 {
-  stroke: #d9dadd;
-  fill: #f3f3f4;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 {
-  fill: #ffd3e3;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
-  stroke: #ffd3e3;
-  fill: #ffd3e3;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 {
-  fill: #ffebf2;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
-  stroke: #ffbbd3;
-  fill: #ffebf2;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 {
-  fill: #e5dbfd;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6:checked+.emotion-8 .emotion-10 {
-  stroke: #d8c5fc;
-  fill: #d8c5fc;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 {
-  fill: #e5dbfd;
-}
-
-.emotion-3[aria-disabled='true'] .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
-  stroke: #e5dbfd;
-  fill: #e5dbfd;
-}
-
-.emotion-3 .emotion-6:checked+.emotion-8 path {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-}
-
-.emotion-3 .emotion-6:checked+.emotion-8 .emotion-10 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]:checked+.emotion-8 .emotion-10 {
-  fill: #e51963;
-  stroke: #e51963;
-}
-
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
-  fill: #ffffff;
-}
-
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .emotion-10 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='false']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='true']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='false'][aria-checked='mixed']+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='false']+.emotion-8 .emotion-10 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-3:hover[aria-disabled='false'] .emotion-6[aria-invalid='true'][aria-checked='true']+.emotion-8 .emotion-10 {
-  stroke: #d6175c;
-  fill: #d6175c;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 {
-  fill: #e51963;
-}
-
-.emotion-3 .emotion-6[aria-invalid="true"]+.emotion-8 .emotion-10 {
-  stroke: #e51963;
-  fill: #ffebf2;
-}
-
-.emotion-3[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-3[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-3[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-3 label {
-  width: 100%;
-}
-
-.emotion-5 {
-  position: absolute;
-  white-space: nowrap;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  border-width: 0;
-}
-
-.emotion-5:not(:disabled) {
-  cursor: pointer;
-}
-
-.emotion-5:disabled {
-  cursor: not-allowed;
-}
-
-.emotion-5:not(:disabled):checked+.emotion-8,
-.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 {
-  fill: #8c40ef;
-}
-
-.emotion-5:not(:disabled):checked+.emotion-8 .emotion-10,
-.emotion-5:not(:disabled)[aria-checked='mixed']+.emotion-8 .emotion-10 {
-  stroke: #8c40ef;
-}
-
-.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8,
-.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 {
-  fill: #ffebf2;
-}
-
-.emotion-5:not(:disabled)[aria-invalid='true']+.emotion-8 .emotion-10,
-.emotion-5:not(:disabled)[aria-invalid='mixed']+.emotion-8 .emotion-10 {
-  stroke: #b3144d;
-}
-
-.emotion-5:focus+.emotion-8 {
-  background-color: #f1eefc;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
-}
-
-.emotion-5:focus+.emotion-8 .emotion-10 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-5[aria-invalid='true']:focus+.emotion-8 {
-  background-color: #ffebf2;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
-}
-
-.emotion-5[aria-invalid='true']:focus+.emotion-8 .emotion-10 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-7 {
-  border-radius: 0.25rem;
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-}
-
-.emotion-7 path {
-  fill: #ffffff;
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-9 {
-  fill: #ffffff;
-  stroke: #d9dadd;
-}
-
-.emotion-11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-11[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-11[data-has-label='false'] {
-  display: contents;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-disabled="false"
-      data-has-label="false"
-      data-image="none"
-      data-type="checkbox"
-      role="button"
-      tabindex="0"
-    >
-      <div
-        aria-disabled="false"
-        class="emotion-2 emotion-3 emotion-4"
-        data-checked="false"
-        data-error="false"
-      >
-        <input
-          aria-checked="false"
-          aria-invalid="false"
-          aria-label="test"
-          class="emotion-5 emotion-6"
-          id=":re:"
-          name="checkbox"
-          tabindex="-1"
-          type="checkbox"
-          value="choice"
-        />
-        <svg
-          class="emotion-7 emotion-8"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <g>
-            <rect
-              class="emotion-9 emotion-10"
-              height="16"
-              rx="0.125rem"
-              stroke-width="2"
-              width="16"
-              x="4"
-              y="4"
-            />
-            <path
-              clip-rule="evenodd"
-              d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
-              fill="white"
-              fill-rule="evenodd"
-              height="9"
-              width="12"
-              x="5"
-              y="4"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="emotion-11 emotion-12"
-        data-has-label="false"
-      >
-        Checkbox card
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`SelectableCard > renders correctly with showTick and type radio 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 1rem;
-  border-radius: 0.25rem;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  cursor: pointer;
-  background: #ffffff;
-  border: 1px solid #d9dadd;
-  color: #3f4250;
-}
-
-.emotion-0[data-has-label='false']>:first-child {
-  margin-bottom: -0.25rem;
-}
-
-.emotion-0[data-checked='true'] {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0[data-error='true'] {
-  border: 1px solid #b3144d;
-}
-
-.emotion-0[data-disabled='true'] {
-  border: 1px solid #e9eaeb;
-  color: #b5b7bd;
-  background: #f3f3f4;
-  cursor: not-allowed;
-}
-
-.emotion-0[data-image="illustration"] {
-  padding: 0rem;
-}
-
-.emotion-0[data-image="icon"] {
-  padding: 0rem;
-  padding-right: 1rem;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true']),
-.emotion-0:active:not([data-error='true']):not([data-disabled='true']) {
-  border: 1px solid #8c40ef;
-}
-
-.emotion-0:hover:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'],
-.emotion-0:active:not([data-error='true']):not([data-disabled='true'])[data-cheked='false'] {
-  box-shadow: 0px 4px 16px 4px #f6f3ffcc;
-}
-
-.emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
-  width: 100%;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-5 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  gap: 0.5rem;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  pointer-events: none;
-}
-
-.emotion-5[aria-disabled='false'],
-.emotion-5[aria-disabled='false']>label {
-  cursor: pointer;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 {
-  fill: #8c40ef;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8+.emotion-10 .emotion-12 {
-  fill: #e5dbfd;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 {
-  fill: #b3144d;
-}
-
-.emotion-5:hover[aria-disabled='false'] .emotion-8[aria-invalid='true']+.emotion-10 .emotion-12 {
-  fill: #ffd3e3;
-}
-
-.emotion-5[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-5[aria-disabled='true']>label,
-.emotion-5[aria-disabled='true'] .emotion-8 {
-  cursor: not-allowed;
-}
-
-.emotion-5[aria-disabled='true'] .emotion-10 {
-  fill: #e9eaeb;
-  cursor: not-allowed;
-}
-
-.emotion-5[aria-disabled='true'] .emotion-10 .emotion-12 {
-  fill: #f3f3f4;
-}
-
-.emotion-5[data-checked='true'] {
-  color: #641cb3;
-}
-
-.emotion-5[data-error='true'] {
-  color: #b3144d;
-}
-
-.emotion-5[aria-disabled='true'] {
-  color: #b5b7bd;
-}
-
-.emotion-7 {
-  cursor: pointer;
-  position: absolute;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.emotion-7+.emotion-10 .emotion-14 {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-7:checked+svg .emotion-14 {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.emotion-7:checked[aria-disabled='false'][aria-invalid='false']+.emotion-10 {
-  fill: #8c40ef;
-}
-
-.emotion-7:checked[aria-disabled='true'][aria-invalid='false']+.emotion-10 {
-  fill: #d8c5fc;
-}
-
-.emotion-7[aria-invalid='true']:not([aria-disabled='true'])+.emotion-10 {
-  fill: #e51963;
-}
-
-.emotion-7[aria-disabled='false']:active+.emotion-10 {
-  background-color: #5e127e40;
-  fill: #8c40ef;
-}
-
-.emotion-7[aria-disabled='false']:active+.emotion-10 .emotion-12 {
-  fill: #f1eefc;
-}
-
-.emotion-7[aria-disabled='false']:focus-visible+.emotion-10 {
-  outline: -webkit-focus-ring-color auto 1px;
-}
-
-.emotion-7[aria-invalid='true']:focus+.emotion-10 {
-  background-color: #f91b6c40;
-  fill: #e51963;
-}
-
-.emotion-7[aria-invalid='true']:focus+.emotion-10 .emotion-12 {
-  fill: #ffebf2;
-}
-
-.emotion-9 {
-  height: 1.5rem;
-  width: 1.5rem;
-  min-width: 1.5rem;
-  min-height: 1.5rem;
-  border-radius: 100%;
-  fill: #d9dadd;
-}
-
-.emotion-9 .emotion-12 {
-  fill: #ffffff;
-}
-
-.emotion-15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.emotion-15[data-has-label='true'] {
-  padding-left: 2rem;
-}
-
-.emotion-15[data-has-label='false'] {
-  display: contents;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-disabled="false"
-      data-has-label="false"
-      data-image="none"
-      data-type="radio"
-      role="button"
-      tabindex="0"
-    >
-      <div
-        class="emotion-2 emotion-3"
-      >
-        <div
-          aria-disabled="false"
-          class="emotion-4 emotion-5 emotion-6"
-          data-checked="false"
-        >
-          <input
-            aria-disabled="false"
-            aria-invalid="false"
-            aria-label="test"
-            class="emotion-7 emotion-8"
-            id=":rb:"
-            name="checkbox"
-            tabindex="-1"
-            type="radio"
-            value="choice"
-          />
-          <svg
-            class="emotion-9 emotion-10"
-            viewBox="0 0 24 24"
-          >
-            <g>
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-                stroke-width="2"
-              />
-              <circle
-                class="emotion-11 emotion-12"
-                cx="12"
-                cy="12"
-                r="8"
-              />
-              <circle
-                class="emotion-13 emotion-14"
-                cx="12"
-                cy="12"
-                r="5"
-              />
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="emotion-15 emotion-16"
-        data-has-label="false"
-      >
-        Checkbox card
       </div>
     </div>
   </div>

--- a/packages/ui/src/components/SelectableCard/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectableCard/__tests__/index.test.tsx
@@ -1,259 +1,233 @@
-import { act, screen } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme, shouldMatchEmotionSnapshot } from '@utils/test'
-import { describe, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { SelectableCard } from '..'
 import illustration from './illustrationTest.svg'
 
 describe('SelectableCard', () => {
-  test('renders correctly with default props', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        value="choice"
-        label="test"
-      >
-        Radio card
-      </SelectableCard>,
-    ))
+  const types = ['radio', 'checkbox'] as const
 
-  test('renders correctly with aria label', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        value="choice"
-        aria-label="test"
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with checkbox type', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="checkbox"
-        value="choice"
-        type="checkbox"
-        aria-label="test"
-      >
-        Checkbox card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with showTick and type radio', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="checkbox"
-        value="choice"
-        type="radio"
-        aria-label="test"
-        showTick
-      >
-        Checkbox card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with showTick and type checkbox', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="checkbox"
-        value="choice"
-        type="checkbox"
-        showTick
-        aria-label="test"
-      >
-        Checkbox card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with radio type and checked prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        type="radio"
-        value="choice"
-        aria-label="test"
-        checked
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with checkbox type and checked prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        type="checkbox"
-        aria-label="test"
-        value="choice"
-        checked
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with radio type and disabled prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        type="radio"
-        aria-label="test"
-        value="choice"
-        disabled
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with checkbox type and disabled prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        type="checkbox"
-        aria-label="test"
-        value="choice"
-        disabled
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with checkbox type and isError prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        label="test"
-        type="checkbox"
-        value="choice"
-        isError
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with radio type and isError prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        type="radio"
-        value="choice"
-        label="test"
-        isError
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with radio type and tooltip prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        type="radio"
-        value="choice"
-        label="test"
-        tooltip="test"
-      >
-        Radio card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with checkbox type and tooltip prop', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="checkbox"
-        type="checkbox"
-        label="test"
-        value="choice"
-        tooltip="test"
-      >
-        Checkbox card
-      </SelectableCard>,
-    ))
-
-  test('renders correctly with complex children', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        onChange={() => {}}
-        name="radio"
-        label="test"
-        type="checkbox"
-        value="choice"
-        disabled
-      >
-        {({ checked, disabled }) => (
-          <div
-            style={{
-              background: disabled ? 'gray' : 'green',
-              color: checked ? 'green' : 'gray',
-            }}
+  types.forEach(type => {
+    describe(`${type}`, () => {
+      test('renders correctly with default props', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            value="choice"
+            label="test"
           >
-            Complex radio card
-          </div>
-        )}
-      </SelectableCard>,
-    ))
+            Radio card
+          </SelectableCard>,
+        ))
 
-  test('accessibility working with space key pressed to select', async () => {
-    const onChange = vi.fn()
+      test('renders correctly with aria label', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            value="choice"
+            aria-label="test"
+          >
+            Radio card
+          </SelectableCard>,
+        ))
 
-    renderWithTheme(
-      <SelectableCard
-        onChange={onChange}
-        name="radio"
-        value="choice"
-        label="test"
-      >
-        Radio card
-      </SelectableCard>,
-    )
+      test('renders correctly with showTick', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            value="choice"
+            type={type}
+            aria-label="test"
+            showTick
+          >
+            Checkbox card
+          </SelectableCard>,
+        ))
 
-    const button = screen.getByRole('button')
-    act(() => button.focus())
+      test('renders correctly with checked prop', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            type={type}
+            aria-label="test"
+            value="choice"
+            checked
+          >
+            Radio card
+          </SelectableCard>,
+        ))
 
-    await userEvent.keyboard('{Space}')
+      test('renders correctly with disabled prop', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            type={type}
+            aria-label="test"
+            value="choice"
+            disabled
+          >
+            Radio card
+          </SelectableCard>,
+        ))
+
+      test('renders correctly with isError prop', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            label="test"
+            type={type}
+            value="choice"
+            isError
+          >
+            Radio card
+          </SelectableCard>,
+        ))
+
+      test('renders correctly with tooltip prop', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            type={type}
+            label="test"
+            value="choice"
+            tooltip="test"
+          >
+            Checkbox card
+          </SelectableCard>,
+        ))
+
+      test('renders correctly with complex children', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            onChange={() => {}}
+            name="test"
+            label="test"
+            type={type}
+            value="choice"
+            disabled
+          >
+            {({ checked, disabled }) => (
+              <div
+                style={{
+                  background: disabled ? 'gray' : 'green',
+                  color: checked ? 'green' : 'gray',
+                }}
+              >
+                Complex radio card
+              </div>
+            )}
+          </SelectableCard>,
+        ))
+
+      test('renders correctly with illustration', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            name="label-14"
+            value="label-14"
+            type={type}
+            label="label"
+            showTick
+            onChange={() => {}}
+            illustration={illustration}
+          >
+            Offer the best experience to your Mac, iPhone and iPad users with
+            VNC, the remote desktop-sharing protocol. Learn more
+          </SelectableCard>,
+        ))
+
+      test('renders correctly with productIcon', () =>
+        shouldMatchEmotionSnapshot(
+          <SelectableCard
+            name="label-14"
+            value="label-14"
+            type={type}
+            label="label"
+            productIcon="macMini"
+            showTick
+            onChange={() => {}}
+          >
+            Offer the best experience to your Mac, iPhone and iPad users with
+            VNC, the remote desktop-sharing protocol. Learn more
+          </SelectableCard>,
+        ))
+
+      test('accessibility working with space key pressed to select', async () => {
+        const onChange = vi.fn()
+
+        renderWithTheme(
+          <SelectableCard
+            onChange={onChange}
+            value="choice"
+            label="test"
+            type={type}
+            name="test"
+          >
+            {`${type.charAt(0).toUpperCase() + type.slice(1)} card`}
+          </SelectableCard>,
+        )
+
+        const button = screen.getByRole('button')
+        act(() => button.focus())
+
+        await userEvent.keyboard('[Space]')
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalled()
+        })
+      })
+
+      test(`should trigger onChange when click on the label`, async () => {
+        const onChange = vi.fn()
+
+        renderWithTheme(
+          <SelectableCard
+            onChange={onChange}
+            type={type}
+            value="choice"
+            label="test"
+            name="test"
+          >
+            {`${type.charAt(0).toUpperCase() + type.slice(1)} card`}
+          </SelectableCard>,
+        )
+
+        const label = screen.getByLabelText('test')
+        await userEvent.click(label)
+
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalled()
+        })
+      })
+
+      test(`should trigger onChange when click on the card`, async () => {
+        const onChange = vi.fn()
+
+        renderWithTheme(
+          <SelectableCard
+            onChange={onChange}
+            type={type}
+            value="choice"
+            label="test"
+            name="test"
+          >
+            {`${type.charAt(0).toUpperCase() + type.slice(1)} card`}
+          </SelectableCard>,
+        )
+
+        const card = screen.getByRole('button')
+        await userEvent.click(card)
+
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalled()
+        })
+      })
+    })
   })
-
-  test('renders correctly with illustration', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        name="label-14"
-        value="label-14"
-        type="radio"
-        label="label"
-        showTick
-        onChange={() => {}}
-        illustration={illustration}
-      >
-        Offer the best experience to your Mac, iPhone and iPad users with VNC,
-        the remote desktop-sharing protocol. Learn more
-      </SelectableCard>,
-    ))
-  test('renders correctly with productIcon', () =>
-    shouldMatchEmotionSnapshot(
-      <SelectableCard
-        name="label-14"
-        value="label-14"
-        type="radio"
-        label="label"
-        productIcon="macMini"
-        showTick
-        onChange={() => {}}
-      >
-        Offer the best experience to your Mac, iPhone and iPad users with VNC,
-        the remote desktop-sharing protocol. Learn more
-      </SelectableCard>,
-    ))
 })

--- a/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -175,7 +175,6 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-13 .eqr7bqq4 {
@@ -321,6 +320,34 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
 
 .emotion-13 label {
   width: 100%;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='false']+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='true']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='mixed']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18,
+.emotion-13 .emotion-16:active+.emotion-18 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18 .emotion-20,
+.emotion-13 .emotion-16:active+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-15 {
@@ -843,7 +870,6 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-15[aria-disabled='false'],
@@ -900,6 +926,47 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
 
 .emotion-15 input+svg {
   display: none;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18+.emotion-20 {
+  fill: #d9dadd;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18[aria-invalid='true']+.emotion-20 {
+  fill: #b3144d;
+}
+
+.emotion-15:hover[aria-disabled='false']:not([data-checked='true']) .emotion-18[aria-invalid='true']+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18+.emotion-20 {
+  fill: #8c40ef;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18[aria-invalid='true']+.emotion-20 {
+  fill: #b3144d;
+}
+
+.emotion-15:hover[aria-disabled='false'] .emotion-18[aria-invalid='true']+.emotion-20 .emotion-22 {
+  fill: #ffffff;
+}
+
+.emotion-15 .emotion-18[aria-disabled='false']:active+.emotion-20 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-15 .emotion-18[aria-disabled='false']:active+.emotion-20 .emotion-22 {
+  fill: #ffffff;
 }
 
 .emotion-17 {
@@ -1355,7 +1422,6 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-16 .eqr7bqq4 {
@@ -1497,6 +1563,34 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
 
 .emotion-16 label {
   width: 100%;
+}
+
+.emotion-16:hover[aria-disabled='false'] .emotion-19[aria-invalid='false'][aria-checked='false']+.emotion-21 .emotion-23 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-16:hover[aria-disabled='false'] .emotion-19[aria-invalid='false'][aria-checked='true']+.emotion-21 .emotion-23 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-16:hover[aria-disabled='false'] .emotion-19[aria-invalid='false'][aria-checked='mixed']+.emotion-21 .emotion-23 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-16 .emotion-19:focus+.emotion-21,
+.emotion-16 .emotion-19:active+.emotion-21 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-16 .emotion-19:focus+.emotion-21 .emotion-23,
+.emotion-16 .emotion-19:active+.emotion-21 .emotion-23 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-18 {
@@ -2001,7 +2095,6 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-13 .eqr7bqq4 {
@@ -2147,6 +2240,34 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
 
 .emotion-13 label {
   width: 100%;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='false']+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='true']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='mixed']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18,
+.emotion-13 .emotion-16:active+.emotion-18 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18 .emotion-20,
+.emotion-13 .emotion-16:active+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-15 {
@@ -2643,7 +2764,6 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-13 .eqr7bqq4 {
@@ -2789,6 +2909,34 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
 
 .emotion-13 label {
   width: 100%;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='false']+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='true']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='mixed']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18,
+.emotion-13 .emotion-16:active+.emotion-18 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18 .emotion-20,
+.emotion-13 .emotion-16:active+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-15 {
@@ -3304,7 +3452,6 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-13 .eqr7bqq4 {
@@ -3450,6 +3597,34 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
 
 .emotion-13 label {
   width: 100%;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='false']+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='true']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13:hover[aria-disabled='false'] .emotion-16[aria-invalid='false'][aria-checked='mixed']+.emotion-18 .emotion-20 {
+  stroke: #8c40ef;
+  fill: #8c40ef;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18,
+.emotion-13 .emotion-16:active+.emotion-18 {
+  background-color: #ffffff;
+  fill: #ffffff;
+  outline: none;
+}
+
+.emotion-13 .emotion-16:focus+.emotion-18 .emotion-20,
+.emotion-13 .emotion-16:active+.emotion-18 .emotion-20 {
+  fill: #ffffff;
+  stroke: #d9dadd;
 }
 
 .emotion-15 {

--- a/packages/ui/src/components/SelectableCardOptionGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardOptionGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -196,7 +196,6 @@ exports[`SelectableCardOptionGroup > onChange and onChangeOption are being calle
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -249,6 +248,47 @@ exports[`SelectableCardOptionGroup > onChange and onChangeOption are being calle
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -1349,7 +1389,6 @@ exports[`SelectableCardOptionGroup > renders correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-17[aria-disabled='false'],
@@ -1402,6 +1441,47 @@ exports[`SelectableCardOptionGroup > renders correctly 1`] = `
 
 .emotion-17[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20+.emotion-22 {
+  fill: #d9dadd;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20[aria-invalid='true']+.emotion-22 {
+  fill: #b3144d;
+}
+
+.emotion-17:hover[aria-disabled='false']:not([data-checked='true']) .emotion-20[aria-invalid='true']+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20+.emotion-22 {
+  fill: #8c40ef;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20[aria-invalid='true']+.emotion-22 {
+  fill: #b3144d;
+}
+
+.emotion-17:hover[aria-disabled='false'] .emotion-20[aria-invalid='true']+.emotion-22 .emotion-24 {
+  fill: #ffffff;
+}
+
+.emotion-17 .emotion-20[aria-disabled='false']:active+.emotion-22 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-17 .emotion-20[aria-disabled='false']:active+.emotion-22 .emotion-24 {
+  fill: #ffffff;
 }
 
 .emotion-19 {
@@ -2494,7 +2574,6 @@ exports[`SelectableCardOptionGroup > renders correctly 4 columns 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -2547,6 +2626,47 @@ exports[`SelectableCardOptionGroup > renders correctly 4 columns 1`] = `
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -3634,7 +3754,6 @@ exports[`SelectableCardOptionGroup > renders correctly with all options disabled
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -3687,6 +3806,47 @@ exports[`SelectableCardOptionGroup > renders correctly with all options disabled
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -4777,7 +4937,6 @@ exports[`SelectableCardOptionGroup > renders correctly with aria-label 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -4830,6 +4989,47 @@ exports[`SelectableCardOptionGroup > renders correctly with aria-label 1`] = `
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -5873,7 +6073,6 @@ exports[`SelectableCardOptionGroup > renders correctly with error as boolean 1`]
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -5926,6 +6125,47 @@ exports[`SelectableCardOptionGroup > renders correctly with error as boolean 1`]
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -7057,7 +7297,6 @@ exports[`SelectableCardOptionGroup > renders correctly with error message 1`] = 
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -7110,6 +7349,47 @@ exports[`SelectableCardOptionGroup > renders correctly with error message 1`] = 
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -8258,7 +8538,6 @@ exports[`SelectableCardOptionGroup > renders correctly with helper 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -8311,6 +8590,47 @@ exports[`SelectableCardOptionGroup > renders correctly with helper 1`] = `
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -9415,7 +9735,6 @@ exports[`SelectableCardOptionGroup > renders correctly with id 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -9468,6 +9787,47 @@ exports[`SelectableCardOptionGroup > renders correctly with id 1`] = `
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -10555,7 +10915,6 @@ exports[`SelectableCardOptionGroup > renders correctly with image as ReactNode 1
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -10608,6 +10967,47 @@ exports[`SelectableCardOptionGroup > renders correctly with image as ReactNode 1
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -11684,7 +12084,6 @@ exports[`SelectableCardOptionGroup > renders correctly with medium size 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -11737,6 +12136,47 @@ exports[`SelectableCardOptionGroup > renders correctly with medium size 1`] = `
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {
@@ -12824,7 +13264,6 @@ exports[`SelectableCardOptionGroup > renders correctly with partial disabled 1`]
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-14[aria-disabled='false'],
@@ -12877,6 +13316,47 @@ exports[`SelectableCardOptionGroup > renders correctly with partial disabled 1`]
 
 .emotion-14[aria-disabled='true'] {
   color: #b5b7bd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 {
+  fill: #d9dadd;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false']:not([data-checked='true']) .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 {
+  fill: #8c40ef;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 {
+  fill: #b3144d;
+}
+
+.emotion-14:hover[aria-disabled='false'] .emotion-17[aria-invalid='true']+.emotion-19 .emotion-21 {
+  fill: #ffffff;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-14 .emotion-17[aria-disabled='false']:active+.emotion-19 .emotion-21 {
+  fill: #ffffff;
 }
 
 .emotion-16 {

--- a/packages/ui/src/components/SelectableCardOptionGroup/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectableCardOptionGroup/__tests__/index.test.tsx
@@ -215,7 +215,7 @@ describe('SelectableCardOptionGroup', () => {
       </SelectableCardOptionGroup>,
     )
 
-    await userEvent.click(screen.getByText('Debian'))
+    await userEvent.click(screen.getByLabelText('Debian'))
     expect(onChange).toHaveBeenCalledTimes(0)
 
     await userEvent.click(screen.getByLabelText('Debian option'))
@@ -422,9 +422,9 @@ describe('SelectableCardOptionGroup', () => {
       </SelectableCardOptionGroup>,
     )
 
-    await userEvent.click(screen.getByText('Debian'))
+    await userEvent.click(screen.getByLabelText('Debian'))
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalledTimes(2)
+      expect(onChange).toHaveBeenCalledTimes(1)
     })
 
     await userEvent.click(screen.getByLabelText('Debian option'))

--- a/packages/ui/src/components/SelectableCardOptionGroup/components/Option.tsx
+++ b/packages/ui/src/components/SelectableCardOptionGroup/components/Option.tsx
@@ -65,6 +65,7 @@ type OptionProps = Omit<ComponentProps<typeof SelectableCard>, 'onChange'> & {
   image?: ReactNode
   labelDescription?: ComponentProps<typeof Label>['labelDescription']
   id?: string
+  'data-testid'?: string
 }
 
 export const Option = ({
@@ -78,6 +79,7 @@ export const Option = ({
   image,
   disabled,
   id,
+  'data-testid': dataTestId,
 }: OptionProps) => {
   const {
     onChange,
@@ -107,6 +109,7 @@ export const Option = ({
       disabled={disabled || groupDisabled}
       checked={groupValue === value}
       isError={error}
+      data-testid={dataTestId}
       {...(label ? { id: inputId } : { 'aria-label': ariaLabel as string })}
     >
       <FullHeightStack

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -293,7 +293,6 @@ exports[`SwitchButton > renders correctly 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-8[aria-disabled='false'],
@@ -350,6 +349,47 @@ exports[`SwitchButton > renders correctly 1`] = `
 
 .emotion-8 input+svg {
   display: none;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 {
+  fill: #d9dadd;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 {
+  fill: #8c40ef;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 .emotion-15 {
+  fill: #ffffff;
 }
 
 .emotion-10 {
@@ -763,7 +803,6 @@ exports[`SwitchButton > renders correctly medium 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-8[aria-disabled='false'],
@@ -820,6 +859,47 @@ exports[`SwitchButton > renders correctly medium 1`] = `
 
 .emotion-8 input+svg {
   display: none;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 {
+  fill: #d9dadd;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 {
+  fill: #8c40ef;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 .emotion-15 {
+  fill: #ffffff;
 }
 
 .emotion-10 {
@@ -1233,7 +1313,6 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-8[aria-disabled='false'],
@@ -1290,6 +1369,47 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
 
 .emotion-8 input+svg {
   display: none;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 {
+  fill: #d9dadd;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false']:not([data-checked='true']) .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 {
+  fill: #8c40ef;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 {
+  fill: #b3144d;
+}
+
+.emotion-8:hover[aria-disabled='false'] .emotion-11[aria-invalid='true']+.emotion-13 .emotion-15 {
+  fill: #ffffff;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-8 .emotion-11[aria-disabled='false']:active+.emotion-13 .emotion-15 {
+  fill: #ffffff;
 }
 
 .emotion-10 {
@@ -1711,7 +1831,6 @@ exports[`SwitchButton > renders with tooltip 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  pointer-events: none;
 }
 
 .emotion-10[aria-disabled='false'],
@@ -1768,6 +1887,47 @@ exports[`SwitchButton > renders with tooltip 1`] = `
 
 .emotion-10 input+svg {
   display: none;
+}
+
+.emotion-10:hover[aria-disabled='false']:not([data-checked='true']) .emotion-13+.emotion-15 {
+  fill: #d9dadd;
+}
+
+.emotion-10:hover[aria-disabled='false']:not([data-checked='true']) .emotion-13+.emotion-15 .emotion-17 {
+  fill: #ffffff;
+}
+
+.emotion-10:hover[aria-disabled='false']:not([data-checked='true']) .emotion-13[aria-invalid='true']+.emotion-15 {
+  fill: #b3144d;
+}
+
+.emotion-10:hover[aria-disabled='false']:not([data-checked='true']) .emotion-13[aria-invalid='true']+.emotion-15 .emotion-17 {
+  fill: #ffffff;
+}
+
+.emotion-10:hover[aria-disabled='false'] .emotion-13+.emotion-15 {
+  fill: #8c40ef;
+}
+
+.emotion-10:hover[aria-disabled='false'] .emotion-13+.emotion-15 .emotion-17 {
+  fill: #ffffff;
+}
+
+.emotion-10:hover[aria-disabled='false'] .emotion-13[aria-invalid='true']+.emotion-15 {
+  fill: #b3144d;
+}
+
+.emotion-10:hover[aria-disabled='false'] .emotion-13[aria-invalid='true']+.emotion-15 .emotion-17 {
+  fill: #ffffff;
+}
+
+.emotion-10 .emotion-13[aria-disabled='false']:active+.emotion-15 {
+  background: none;
+  fill: #8c40ef;
+}
+
+.emotion-10 .emotion-13[aria-disabled='false']:active+.emotion-15 .emotion-17 {
+  fill: #ffffff;
 }
 
 .emotion-12 {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Current SelectableCard is hard to test especially when you try to click on the label. This was due to the `pointer-events: none;` set on checkbox and radio in order to avoid having double state change.

I fixed this issue by no triggering the event 2 times when the click is specifically on the label / input. This way we only generate one change and we don't need to add `pointer-events: none;`. I also needed to change to add an extra layer of style inside `SelectableCard` for `Checkbox` and `Radio` as we remove pointer events. We don't want the hover effects etc.

I have also reformatted internal testing to test both checkbox and radio on the same series of tests as both should work the same.

Before this was not working, it now works.
```tsx
    test(`should trigger onChange when click on the label`, async () => {
        const onChange = vi.fn()

        renderWithTheme(
          <SelectableCard
            onChange={onChange}
            type={type}
            value="choice"
            label="test"
            name="test"
          >
            blabla
          </SelectableCard>,
        )

        const label = screen.getByLabelText('test')
        await userEvent.click(label)

        await waitFor(() => {
          expect(onChange).toHaveBeenCalled()
        })
      })
```
