### PR TITLE
fix(Navigation): implement item provider to detect parents

### DIFF
--- a/.changeset/solid-socks-hunt.md
+++ b/.changeset/solid-socks-hunt.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<Navigation.Item />` not to spread `hasParent` in the DOM and use a provider instead

--- a/packages/plus/src/components/Navigation/components/ItemProvider.tsx
+++ b/packages/plus/src/components/Navigation/components/ItemProvider.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react'
+import { createContext, useMemo } from 'react'
+
+// Create the context with a default value
+export const ItemContext = createContext(false)
+
+type ItemProviderProps = {
+  children: ReactNode
+}
+
+export const ItemProvider = ({ children }: ItemProviderProps) => {
+  const value = useMemo(() => true, [])
+
+  return <ItemContext.Provider value={value}>{children}</ItemContext.Provider>
+}

--- a/packages/plus/src/components/Navigation/components/PinnedItems.tsx
+++ b/packages/plus/src/components/Navigation/components/PinnedItems.tsx
@@ -150,7 +150,6 @@ export const PinnedItems = ({
                     onClickPinUnpin={
                       items[itemId]?.onClickPinUnpin ?? undefined
                     }
-                    hasParents
                   />
                 </RelativeDiv>
               ) : null,


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Fix `Navigation.Item` not to spread `hasParent` prop into the children. Instead I made an `ItemProvider` that will act just the same. If the item detects that provider is initialised then it means it has a parent with `ItemProvider` giving same value as `hasParent`
