### PR TITLE
feat(CodeEditor): various improvements

### DIFF
--- a/.changeset/proud-things-live.md
+++ b/.changeset/proud-things-live.md
@@ -1,0 +1,10 @@
+---
+"@ultraviolet/plus": patch
+---
+
+`<CodeEditor />`: 
+- **BREAKING** Rename prop `title` to `label` and change style
+- New prop `helper`
+- New prop `disabled`
+- New prop `copyButton`
+- Update component style to match ultraviolet theme (the component always uses Dark Theme colors)

--- a/.changeset/proud-things-live.md
+++ b/.changeset/proud-things-live.md
@@ -3,7 +3,7 @@
 ---
 
 `<CodeEditor />`: 
-- **BREAKING** Rename prop `title` to `label` and change style
+- Rename prop `title` to `label` and change style
 - New prop `helper`
 - New prop `disabled`
 - New prop `copyButton`

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -42,6 +42,7 @@ const EditorContainer = styled.div`
 
   &[data-disabled="true"] {
     pointer-events: none;
+    user-select: none;
 
     .cm-editor {
       background-color: ${consoleDarkTheme.colors.neutral.backgroundWeakDisabled};
@@ -61,6 +62,13 @@ const EditorContainer = styled.div`
       display: none;
     }
 
+    .cm-selectionMatch {
+      background-color: transparent;
+    }
+
+    .cm-selectionLayer {
+      display: none;
+    }
   }
 `
 const StyledStack = styled(Stack)`
@@ -131,9 +139,7 @@ export const CodeEditor = ({
 }: CodeEditorProps) => (
   <StyledStack gap={0.5} data-disabled={disabled}>
     {label || title ? (
-      <Label labelDescription={labelDescription} disabled={disabled}>
-        {label ?? title}
-      </Label>
+      <Label labelDescription={labelDescription}>{label ?? title}</Label>
     ) : null}
     <EditorContainer data-disabled={disabled}>
       <CodeMirror
@@ -154,6 +160,11 @@ export const CodeEditor = ({
         aria-label={ariaLabel}
         data-testid={dataTestId}
         className={className}
+        editable={!disabled || !readOnly}
+        aria-disabled={disabled}
+        onUpdate={() => {
+          if (disabled) document.getSelection()?.empty()
+        }}
       />
       {copyButton && !disabled ? (
         <StyledCopyButton

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -8,16 +8,65 @@ import { consoleDarkTheme } from '@ultraviolet/themes'
 import { CopyButton, Label, Stack, Text } from '@ultraviolet/ui'
 import type { ComponentProps, ReactNode } from 'react'
 
-const StyledText = styled(Text)`
-  background-color: ${({ theme }) => theme.colors.neutral.backgroundStrong};
-  padding: ${({ theme }) => `${theme.space['1']} ${theme.space['2']}`};
-  border-radius: ${({ theme }) => `${theme.radii.default}`};
-  width: 100%;
-`
-
 const EditorContainer = styled.div`
   position: relative;
   width: 100%;
+
+  .cm-editor {
+    font-family: ${({ theme }) => theme.typography.code.fontFamily};
+    font-size:  ${({ theme }) => theme.typography.code.fontSize};
+    background-color: ${consoleDarkTheme.colors.neutral.backgroundWeak};
+    border-radius: ${({ theme }) => theme.space['0.5']};
+  }
+
+  .cm-content {
+    padding-block: ${({ theme }) => theme.space['2']};
+  };
+
+  .cm-gutters {
+    background-color: ${consoleDarkTheme.colors.neutral.backgroundHover};
+  }
+
+  .cm-lineNumbers {
+    padding-left: ${({ theme }) => theme.space['1']};
+  }
+
+  .cm-gutterElement {
+    color: #545454;
+  }
+
+  .cm-scroller {
+    border-radius: ${({ theme }) => theme.space['0.5']};
+  }
+
+
+  &[data-disabled="true"] {
+    pointer-events: none;
+
+    .cm-editor {
+      background-color: ${consoleDarkTheme.colors.neutral.backgroundWeakDisabled};
+      color: ${consoleDarkTheme.colors.neutral.textDisabled};
+    }
+
+    .cm-line span {
+      color: ${consoleDarkTheme.colors.neutral.textDisabled};
+    }
+
+    .cm-gutter-Element {
+      color: ${consoleDarkTheme.colors.neutral.textWeakDisabled};
+    }
+
+    .cm-cursor {
+      border-left-color: transparent;
+      display: none;
+    }
+
+  }
+`
+const StyledStack = styled(Stack)`
+  &[data-disabled] {
+    cursor: not-allowed;
+  }
 `
 
 const StyledCopyButton = styled(CopyButton)`
@@ -34,53 +83,6 @@ const StyledCopyButton = styled(CopyButton)`
   }
 `
 
-const StyledStack = styled(Stack, {
-  shouldForwardProp: prop => !['disabled'].includes(prop),
-})<{ disabled: boolean }>`
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'auto')};
-
-  .cm-editor {
-    font-family: ${({ theme }) => theme.typography.code.fontFamily};
-    font-size:  ${({ theme }) => theme.typography.code.fontSize};
-    background-color: ${({ disabled }) => (disabled ? consoleDarkTheme.colors.neutral.backgroundWeakDisabled : consoleDarkTheme.colors.neutral.backgroundWeak)};
-    border-radius: ${({ theme }) => theme.space['0.5']};
-
-    ${({ disabled }) =>
-      disabled
-        ? `
-      pointer-events: none;
-      color: ${consoleDarkTheme.colors.neutral.textDisabled};`
-        : ''}
-   }
-
-  .cm-content {
-    padding-block: ${({ theme }) => theme.space['2']};
-  };
-
-  .cm-gutters {
-    background-color: ${consoleDarkTheme.colors.neutral.backgroundHover};
-  }
-
-  .cm-line span {
-    ${({ disabled }) =>
-      disabled
-        ? `
-      color: ${consoleDarkTheme.colors.neutral.textDisabled}`
-        : ''}
-  }
-
-  .cm-lineNumbers {
-    padding-left: ${({ theme }) => theme.space['1']};
-  }
-
-  .cm-gutterElement {
-    color: ${({ disabled }) => (disabled ? consoleDarkTheme.colors.neutral.textWeakDisabled : '#545454')};
-  }
-
-  .cm-scroller {
-    border-radius: ${({ theme }) => theme.space['0.5']};
-  }
-`
 type CodeEditorProps = {
   /**
    * @deprecated use prop `label` instead
@@ -103,6 +105,9 @@ type CodeEditorProps = {
   label?: string
   id?: string
   labelDescription?: ReactNode
+  'aria-label'?: string
+  'data-testid'?: string
+  className?: string
 }
 
 export const CodeEditor = ({
@@ -120,17 +125,17 @@ export const CodeEditor = ({
   id,
   helper,
   labelDescription,
+  'aria-label': ariaLabel,
+  'data-testid': dataTestId,
+  className,
 }: CodeEditorProps) => (
-  <StyledStack gap={0.5} disabled={disabled}>
-    {label ? <Label labelDescription={labelDescription}>{label}</Label> : null}
-    {title && !label ? (
-      <StyledText as="h3" variant="headingSmall">
-        {title}
-      </StyledText>
+  <StyledStack gap={0.5} data-disabled={disabled}>
+    {label || title ? (
+      <Label labelDescription={labelDescription}>{label ?? title}</Label>
     ) : null}
-    <EditorContainer>
+    <EditorContainer data-disabled={disabled}>
       <CodeMirror
-        readOnly={readOnly}
+        readOnly={readOnly || disabled}
         width="100%"
         height={height}
         onChange={onChange}
@@ -143,6 +148,9 @@ export const CodeEditor = ({
         }}
         id={id}
         theme={material}
+        aria-label={ariaLabel}
+        data-testid={dataTestId}
+        className={className}
       />
       {copyButton && !disabled ? (
         <StyledCopyButton

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -8,6 +8,13 @@ import { consoleDarkTheme } from '@ultraviolet/themes'
 import { CopyButton, Label, Stack, Text } from '@ultraviolet/ui'
 import type { ComponentProps, ReactNode } from 'react'
 
+const StyledText = styled(Text)`
+  background-color: ${({ theme }) => theme.colors.neutral.backgroundStrong};
+  padding: ${({ theme }) => `${theme.space['1']} ${theme.space['2']}`};
+  border-radius: ${({ theme }) => `${theme.radii.default}`};
+  width: 100%;
+`
+
 const EditorContainer = styled.div`
   position: relative;
   width: 100%;
@@ -17,7 +24,6 @@ const StyledCopyButton = styled(CopyButton)`
   position: absolute;
   top: ${({ theme }) => theme.space['1']};
   right: ${({ theme }) => theme.space['1']};
-  z-index: 1;
 
   svg > path {
     fill: ${consoleDarkTheme.colors.other.icon.product.original.fill};
@@ -34,8 +40,8 @@ const StyledStack = styled(Stack, {
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'auto')};
 
   .cm-editor {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 14px;
+    font-family: ${({ theme }) => theme.typography.code.fontFamily};
+    font-size:  ${({ theme }) => theme.typography.code.fontSize};
     background-color: ${({ disabled }) => (disabled ? consoleDarkTheme.colors.neutral.backgroundWeakDisabled : consoleDarkTheme.colors.neutral.backgroundWeak)};
     border-radius: ${({ theme }) => theme.space['0.5']};
 
@@ -43,7 +49,7 @@ const StyledStack = styled(Stack, {
       disabled
         ? `
       pointer-events: none;
-      color: ${consoleDarkTheme.colors.neutral.textDisabled}`
+      color: ${consoleDarkTheme.colors.neutral.textDisabled};`
         : ''}
    }
 
@@ -76,6 +82,10 @@ const StyledStack = styled(Stack, {
   }
 `
 type CodeEditorProps = {
+  /**
+   * @deprecated use prop `label` instead
+   */
+  title?: string
   value: string
   onChange: ComponentProps<typeof CodeMirror>['onChange']
   extensions: keyof typeof langs
@@ -92,9 +102,11 @@ type CodeEditorProps = {
   copyButton?: boolean | string
   label?: string
   id?: string
+  labelDescription?: ReactNode
 }
 
 export const CodeEditor = ({
+  title,
   value,
   onChange,
   extensions = 'javascript',
@@ -107,21 +119,16 @@ export const CodeEditor = ({
   copyButton,
   id,
   helper,
+  labelDescription,
 }: CodeEditorProps) => (
   <StyledStack gap={0.5} disabled={disabled}>
-    {label ? <Label>{label}</Label> : null}
-
+    {label ? <Label labelDescription={labelDescription}>{label}</Label> : null}
+    {title && !label ? (
+      <StyledText as="h3" variant="headingSmall">
+        {title}
+      </StyledText>
+    ) : null}
     <EditorContainer>
-      {copyButton && !disabled ? (
-        <StyledCopyButton
-          bordered
-          value={value}
-          sentiment="neutral"
-          size="small"
-        >
-          {typeof copyButton === 'string' ? copyButton : undefined}
-        </StyledCopyButton>
-      ) : null}
       <CodeMirror
         readOnly={readOnly}
         width="100%"
@@ -137,6 +144,16 @@ export const CodeEditor = ({
         id={id}
         theme={material}
       />
+      {copyButton && !disabled ? (
+        <StyledCopyButton
+          bordered
+          value={value}
+          sentiment="neutral"
+          size="small"
+        >
+          {typeof copyButton === 'string' ? copyButton : undefined}
+        </StyledCopyButton>
+      ) : null}
     </EditorContainer>
     {helper ? (
       <Text as="span" variant="caption" prominence="weak" sentiment="neutral">

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -64,7 +64,7 @@ const EditorContainer = styled.div`
   }
 `
 const StyledStack = styled(Stack)`
-  &[data-disabled] {
+  &[data-disabled="true"] {
     cursor: not-allowed;
   }
 `
@@ -131,13 +131,16 @@ export const CodeEditor = ({
 }: CodeEditorProps) => (
   <StyledStack gap={0.5} data-disabled={disabled}>
     {label || title ? (
-      <Label labelDescription={labelDescription}>{label ?? title}</Label>
+      <Label labelDescription={labelDescription} disabled={disabled}>
+        {label ?? title}
+      </Label>
     ) : null}
     <EditorContainer data-disabled={disabled}>
       <CodeMirror
         readOnly={readOnly || disabled}
         width="100%"
         height={height}
+        theme={material}
         onChange={onChange}
         value={value}
         extensions={[langs[extensions]()]}
@@ -145,9 +148,9 @@ export const CodeEditor = ({
         basicSetup={{
           highlightActiveLine: false,
           highlightActiveLineGutter: false,
+          autocompletion: autoCompletion,
         }}
         id={id}
-        theme={material}
         aria-label={ariaLabel}
         data-testid={dataTestId}
         className={className}
@@ -168,20 +171,5 @@ export const CodeEditor = ({
         {helper}
       </Text>
     ) : null}
-    <CodeMirror
-      readOnly={readOnly}
-      width="100%"
-      height={height}
-      theme={material}
-      onChange={onChange}
-      value={value}
-      extensions={[langs[extensions]()]}
-      onBlur={onBlur}
-      basicSetup={{
-        highlightActiveLine: false,
-        highlightActiveLineGutter: false,
-        autocompletion: autoCompletion,
-      }}
-    />
   </StyledStack>
 )

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -17,6 +17,13 @@ const EditorContainer = styled.div`
     font-size:  ${({ theme }) => theme.typography.code.fontSize};
     background-color: ${consoleDarkTheme.colors.neutral.backgroundWeak};
     border-radius: ${({ theme }) => theme.space['0.5']};
+    border: 1px solid transparent;
+  }
+
+  .cm-editor.cm-focused {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadows.focusPrimary};
+    border: 1px solid ${({ theme }) => theme.colors.primary.border};
   }
 
   .cm-content {
@@ -38,7 +45,6 @@ const EditorContainer = styled.div`
   .cm-scroller {
     border-radius: ${({ theme }) => theme.space['0.5']};
   }
-
 
   &[data-disabled="true"] {
     pointer-events: none;
@@ -68,6 +74,11 @@ const EditorContainer = styled.div`
 
     .cm-selectionLayer {
       display: none;
+    }
+
+    .cm-editor.cm-focused {
+      box-shadow: none;
+      border: 1px solid transparent; 
     }
   }
 `

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -4,18 +4,78 @@ import styled from '@emotion/styled'
 import { langs } from '@uiw/codemirror-extensions-langs'
 import { material } from '@uiw/codemirror-theme-material'
 import CodeMirror from '@uiw/react-codemirror'
-import { Text } from '@ultraviolet/ui'
-import type { ComponentProps } from 'react'
+import { consoleDarkTheme } from '@ultraviolet/themes'
+import { CopyButton, Label, Stack, Text } from '@ultraviolet/ui'
+import type { ComponentProps, ReactNode } from 'react'
 
-const StyledText = styled(Text)`
-  background-color: ${({ theme }) => theme.colors.neutral.backgroundStrong};
-  padding: ${({ theme }) => `${theme.space['1']} ${theme.space['2']}`};
-  border-radius: ${({ theme }) => `${theme.radii.default}`};
+const EditorContainer = styled.div`
+  position: relative;
   width: 100%;
 `
 
+const StyledCopyButton = styled(CopyButton)`
+  position: absolute;
+  top: ${({ theme }) => theme.space['1']};
+  right: ${({ theme }) => theme.space['1']};
+  z-index: 1;
+
+  svg > path {
+    fill: ${consoleDarkTheme.colors.other.icon.product.original.fill};
+  }
+
+  &:hover {
+    background-color: ${consoleDarkTheme.colors.neutral.backgroundHover};
+  }
+`
+
+const StyledStack = styled(Stack, {
+  shouldForwardProp: prop => !['disabled'].includes(prop),
+})<{ disabled: boolean }>`
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'auto')};
+
+  .cm-editor {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    background-color: ${({ disabled }) => (disabled ? consoleDarkTheme.colors.neutral.backgroundWeakDisabled : consoleDarkTheme.colors.neutral.backgroundWeak)};
+    border-radius: ${({ theme }) => theme.space['0.5']};
+
+    ${({ disabled }) =>
+      disabled
+        ? `
+      pointer-events: none;
+      color: ${consoleDarkTheme.colors.neutral.textDisabled}`
+        : ''}
+   }
+
+  .cm-content {
+    padding-block: ${({ theme }) => theme.space['2']};
+  };
+
+  .cm-gutters {
+    background-color: ${consoleDarkTheme.colors.neutral.backgroundHover};
+  }
+
+  .cm-line span {
+    ${({ disabled }) =>
+      disabled
+        ? `
+      color: ${consoleDarkTheme.colors.neutral.textDisabled}`
+        : ''}
+  }
+
+  .cm-lineNumbers {
+    padding-left: ${({ theme }) => theme.space['1']};
+  }
+
+  .cm-gutterElement {
+    color: ${({ disabled }) => (disabled ? consoleDarkTheme.colors.neutral.textWeakDisabled : '#545454')};
+  }
+
+  .cm-scroller {
+    border-radius: ${({ theme }) => theme.space['0.5']};
+  }
+`
 type CodeEditorProps = {
-  title?: string
   value: string
   onChange: ComponentProps<typeof CodeMirror>['onChange']
   extensions: keyof typeof langs
@@ -23,10 +83,18 @@ type CodeEditorProps = {
   height?: string
   readOnly?: boolean
   autoCompletion?: boolean
+  disabled?: boolean
+  helper?: ReactNode
+  /**
+   * When set to true, a copy button is displayed in the top right corner of the editor.
+   * If a string is provided, it is used as the button's label. Otherwise, no label is displayed.
+   */
+  copyButton?: boolean | string
+  label?: string
+  id?: string
 }
 
 export const CodeEditor = ({
-  title,
   value,
   onChange,
   extensions = 'javascript',
@@ -34,12 +102,46 @@ export const CodeEditor = ({
   height,
   readOnly,
   autoCompletion,
+  disabled = false,
+  label,
+  copyButton,
+  id,
+  helper,
 }: CodeEditorProps) => (
-  <div>
-    {title ? (
-      <StyledText as="h3" variant="headingSmall">
-        {title}
-      </StyledText>
+  <StyledStack gap={0.5} disabled={disabled}>
+    {label ? <Label>{label}</Label> : null}
+
+    <EditorContainer>
+      {copyButton && !disabled ? (
+        <StyledCopyButton
+          bordered
+          value={value}
+          sentiment="neutral"
+          size="small"
+        >
+          {typeof copyButton === 'string' ? copyButton : undefined}
+        </StyledCopyButton>
+      ) : null}
+      <CodeMirror
+        readOnly={readOnly}
+        width="100%"
+        height={height}
+        onChange={onChange}
+        value={value}
+        extensions={[langs[extensions]()]}
+        onBlur={onBlur}
+        basicSetup={{
+          highlightActiveLine: false,
+          highlightActiveLineGutter: false,
+        }}
+        id={id}
+        theme={material}
+      />
+    </EditorContainer>
+    {helper ? (
+      <Text as="span" variant="caption" prominence="weak" sentiment="neutral">
+        {helper}
+      </Text>
     ) : null}
     <CodeMirror
       readOnly={readOnly}
@@ -56,5 +158,5 @@ export const CodeEditor = ({
         autocompletion: autoCompletion,
       }}
     />
-  </div>
+  </StyledStack>
 )

--- a/packages/plus/src/components/CodeEditor/__stories__/CopyButton.stories.tsx
+++ b/packages/plus/src/components/CodeEditor/__stories__/CopyButton.stories.tsx
@@ -1,0 +1,25 @@
+import type { StoryFn } from '@storybook/react'
+import { useState } from 'react'
+import type { ComponentProps } from 'react'
+import { CodeEditor } from '..'
+
+const DEFAULT_VALUE = `function findSequence(goal) {
+    function find(start, history) {
+      if (start == goal)
+        return history;
+      else if (start > goal)
+        return null;
+      else
+        return find(start + 5, "(" + history + " + 5)") ||
+               find(start * 3, "(" + history + " * 3)");
+    }
+    return find(1, "1");
+  }
+`
+export const CopyButton: StoryFn<ComponentProps<typeof CodeEditor>> = ({
+  ...props
+}) => {
+  const [value, setValue] = useState(DEFAULT_VALUE)
+
+  return <CodeEditor {...props} value={value} copyButton onChange={setValue} />
+}

--- a/packages/plus/src/components/CodeEditor/__stories__/Disabled.stories.tsx
+++ b/packages/plus/src/components/CodeEditor/__stories__/Disabled.stories.tsx
@@ -1,0 +1,5 @@
+import { Template } from './Template.stories'
+
+export const Disabled = Template.bind({})
+
+Disabled.args = { ...Template.args, disabled: true }

--- a/packages/plus/src/components/CodeEditor/__stories__/Template.stories.tsx
+++ b/packages/plus/src/components/CodeEditor/__stories__/Template.stories.tsx
@@ -7,9 +7,10 @@ export const Template: StoryFn<ComponentProps<typeof CodeEditor>> = ({
 }) => <CodeEditor {...props} />
 
 Template.args = {
-  title: 'Code Editor',
+  label: 'Code Editor',
   extensions: 'javascript',
   height: '300px',
   readOnly: false,
   value: "console.debug('CodeEditor')",
+  helper: 'Example of helper text',
 }

--- a/packages/plus/src/components/CodeEditor/__stories__/index.stories.tsx
+++ b/packages/plus/src/components/CodeEditor/__stories__/index.stories.tsx
@@ -8,3 +8,5 @@ export default {
 
 export { Playground } from './Playground.stories'
 export { AutoCompletion } from './AutoCompletion.stories'
+export { Disabled } from './Disabled.stories'
+export { CopyButton } from './CopyButton.stories'

--- a/packages/plus/src/components/CodeEditor/__tests__/index.test.tsx
+++ b/packages/plus/src/components/CodeEditor/__tests__/index.test.tsx
@@ -16,6 +16,19 @@ describe.skip('CodeEditor', () => {
         onChange={newValue => newValue}
         helper="Helper text"
         label="Code"
+        labelDescription="Code description"
+      />,
+    ))
+
+  it('should render correctly with title', () =>
+    shouldMatchEmotionSnapshot(
+      <CodeEditor
+        value="configuration: 1/ntest: 'ok'"
+        extensions="yaml"
+        height="600px"
+        onChange={newValue => newValue}
+        helper="Helper text"
+        title="title"
       />,
     ))
 

--- a/packages/plus/src/components/CodeEditor/__tests__/index.test.tsx
+++ b/packages/plus/src/components/CodeEditor/__tests__/index.test.tsx
@@ -14,6 +14,41 @@ describe.skip('CodeEditor', () => {
         extensions="yaml"
         height="600px"
         onChange={newValue => newValue}
+        helper="Helper text"
+        label="Code"
+      />,
+    ))
+
+  it('should render correctly disbled', () =>
+    shouldMatchEmotionSnapshot(
+      <CodeEditor
+        value="configuration: 1/ntest: 'ok'"
+        extensions="yaml"
+        height="600px"
+        onChange={newValue => newValue}
+        disabled
+      />,
+    ))
+
+  it('should render correctly with copyButton as boolean', () =>
+    shouldMatchEmotionSnapshot(
+      <CodeEditor
+        value="configuration: 1/ntest: 'ok'"
+        extensions="yaml"
+        height="600px"
+        onChange={newValue => newValue}
+        copyButton
+      />,
+    ))
+
+  it('should render correctly with copyButton as string', () =>
+    shouldMatchEmotionSnapshot(
+      <CodeEditor
+        value="configuration: 1/ntest: 'ok'"
+        extensions="yaml"
+        height="600px"
+        onChange={newValue => newValue}
+        copyButton="Copy"
       />,
     ))
 })


### PR DESCRIPTION
## Summary

## Type
- Enhancement
- Documentation
- Migration
- Refactor

### Summarise concisely:
`<CodeEditor />`: 
- **BREAKING** Rename prop `title` to `label` and change style
- New prop `helper`
- New prop `disabled`
- New prop `copyButton`
- Update component style to match ultraviolet theme (the component always uses Dark Theme colors)

Before : 
<img width="1028" alt="Capture d’écran 2025-03-20 à 16 37 55" src="https://github.com/user-attachments/assets/642983b8-855b-42d8-883b-607f4ac6d896" />

After :
<img width="1028" alt="Capture d’écran 2025-03-20 à 16 38 07" src="https://github.com/user-attachments/assets/3e0e3e51-175a-4103-b235-4445a6baf418" />
