### PR TITLE
fix(SelectableCardOptionGroupField): add new prop option name

### DIFF
--- a/.changeset/afraid-yaks-happen.md
+++ b/.changeset/afraid-yaks-happen.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Add prop `optionName` on `SelectableCardOptionGroupField` and `UnitInputField` to allow customising the name in the form

--- a/packages/form/src/components/SelectableCardOptionGroupField/__stories__/OptionName.stories.tsx
+++ b/packages/form/src/components/SelectableCardOptionGroupField/__stories__/OptionName.stories.tsx
@@ -1,0 +1,14 @@
+import { Template } from './Template.stories'
+
+export const OptionName = Template.bind({})
+
+OptionName.args = { ...Template.args, optionName: 'version' }
+
+OptionName.parameters = {
+  docs: {
+    description: {
+      story:
+        'By default the option name will be `[name]Option` where `name` is the name of the field. This can be overridden by passing the `optionName` prop.',
+    },
+  },
+}

--- a/packages/form/src/components/SelectableCardOptionGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectableCardOptionGroupField/__stories__/index.stories.tsx
@@ -72,5 +72,6 @@ export default {
 } as Meta
 
 export { Playground } from './Playground.stories'
+export { OptionName } from './OptionName.stories'
 export { Required } from './Required.stories'
 export { Error } from './Error.stories'

--- a/packages/form/src/components/SelectableCardOptionGroupField/__tests__/index.test.tsx
+++ b/packages/form/src/components/SelectableCardOptionGroupField/__tests__/index.test.tsx
@@ -15,6 +15,7 @@ describe('SelectableCardOptionGroupField', () => {
     const { asFragment } = renderWithForm(
       <SelectableCardOptionGroupField
         name="os"
+        optionName="version"
         value="ubuntu"
         optionValue="ubuntu-20.04"
         onChange={() => {}}

--- a/packages/form/src/components/SelectableCardOptionGroupField/index.tsx
+++ b/packages/form/src/components/SelectableCardOptionGroupField/index.tsx
@@ -19,7 +19,9 @@ type SelectableCardOptionGroupFieldProps<
     >
   > &
   BaseFieldProps<TFieldValues, TFieldName> &
-  Omit<BaseFieldProps<TFieldValues, TFieldName>, 'label'>
+  Omit<BaseFieldProps<TFieldValues, TFieldName>, 'label'> & {
+    optionName?: string
+  }
 
 export const SelectableCardOptionGroupField = <
   TFieldValues extends FieldValues,
@@ -28,6 +30,7 @@ export const SelectableCardOptionGroupField = <
   legend,
   control,
   name,
+  optionName,
   onChange,
   onChangeOption,
   required = false,
@@ -56,7 +59,7 @@ export const SelectableCardOptionGroupField = <
   })
 
   const { field: optionField } = useController({
-    name: `${name}Option`,
+    name: optionName ?? `${name}Option`,
     shouldUnregister,
     rules: { required },
   })

--- a/packages/form/src/components/UnitInputField/__stories__/OptionName.stories.tsx
+++ b/packages/form/src/components/UnitInputField/__stories__/OptionName.stories.tsx
@@ -1,0 +1,14 @@
+import { Template } from './Template.stories'
+
+export const OptionName = Template.bind({})
+
+OptionName.args = { ...Template.args, optionName: 'version' }
+
+OptionName.parameters = {
+  docs: {
+    description: {
+      story:
+        'By default the option name will be `[name]Option` where `name` is the name of the field. This can be overridden by passing the `optionName` prop.',
+    },
+  },
+}

--- a/packages/form/src/components/UnitInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/UnitInputField/__stories__/index.stories.tsx
@@ -68,4 +68,5 @@ export default {
 } as Meta
 
 export { Playground } from './Playground.stories'
+export { OptionName } from './OptionName.stories'
 export { Required } from './Required.stories'

--- a/packages/form/src/components/UnitInputField/__tests__/index.test.tsx
+++ b/packages/form/src/components/UnitInputField/__tests__/index.test.tsx
@@ -25,7 +25,12 @@ const optionsSelect = [
 describe('UnitInputField', () => {
   test('should render correctly', () => {
     const { asFragment } = renderWithForm(
-      <UnitInputField label="Test" name="test" options={optionsSelect} />,
+      <UnitInputField
+        label="Test"
+        name="test"
+        optionName="test2"
+        options={optionsSelect}
+      />,
     )
 
     expect(asFragment()).toMatchSnapshot()

--- a/packages/form/src/components/UnitInputField/index.tsx
+++ b/packages/form/src/components/UnitInputField/index.tsx
@@ -31,6 +31,7 @@ type UnitInputFieldProps<
   > & {
     onChangeUnitValue?: ComponentProps<typeof UnitInput>['onChangeUnitValue']
     label: string
+    optionName?: string
   }
 
 export const UnitInputField = <
@@ -57,10 +58,11 @@ export const UnitInputField = <
   shouldUnregister = false,
   validate,
   control,
+  optionName,
 }: UnitInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
   const { field: unitField } = useController({
-    name: `${name}-unit`,
+    name: optionName ?? `${name}-unit`,
     shouldUnregister,
     rules: { required },
   })


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Add `optionName` on SelectableCardOptionGroupField to allow customising it.

![Screenshot 2025-03-31 at 15 35 59](https://github.com/user-attachments/assets/419aedb5-9db5-46cf-b0aa-35b46d55d8c4)

