### PR TITLE
fix(UnitInput): not to be disabled when only one option

### DIFF
--- a/.changeset/thin-pugs-drive.md
+++ b/.changeset/thin-pugs-drive.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/ui": patch
+---
+
+Fix `<UnitInput />` to remove disabled state when only one option is available

--- a/packages/ui/src/components/UnitInput/index.tsx
+++ b/packages/ui/src/components/UnitInput/index.tsx
@@ -350,7 +350,7 @@ export const UnitInput = ({
             searchable={false}
             clearable={false}
             placeholder={placeholderUnit}
-            disabled={disabled || options.length === 1}
+            disabled={disabled}
             size={size}
             multiselect={false}
             readOnly={readOnly}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Unit input select is disabled when there is only one option
