### PR TITLE
feat(css): root class to identify theme

### DIFF
--- a/utils/scripts/create-css-variables.tsx
+++ b/utils/scripts/create-css-variables.tsx
@@ -70,8 +70,11 @@ type UvThemeType = {
   breakpoints: Record<string, string>
 }
 
-export const generateThemeCss = (uvTheme: UvThemeType) =>
-  `:root {\n${
+export const generateThemeCss = ({
+  uvTheme,
+  filename,
+}: { uvTheme: UvThemeType; filename: string }) =>
+  `:root.${filename}-theme {\n${
     createCssVariables('screen', screens) +
     createCssVariables('color', uvTheme.colors) +
     createCssVariables('radius', uvTheme.radii) +

--- a/utils/scripts/figma-synchronise-tokens.tsx
+++ b/utils/scripts/figma-synchronise-tokens.tsx
@@ -64,7 +64,7 @@ type UvThemeType = {
 }
 
 const createCSSFile = (theme: string, content: UvThemeType) => {
-  const cssContent = generateThemeCss(content)
+  const cssContent = generateThemeCss({ uvTheme: content, filename: theme })
   const filePath = `packages/themes/public/style/${theme}.css`
   fs.writeFileSync(filePath, cssContent, 'utf8')
 }


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

We have to load 2 themes, then apply the client chosen mode browser side to simply switch custom properties.

The class help to switch automatically vars values.

As we (frontweb team) are the only users of these css files, this change may be legit.

#### The following changes where made:

(Describe what you did)

1. pass filename to generateThemeCss function

2. use the filename to set a class on :root declaration

