### PR TITLE
fix(dateinput): harmonized props with time input

### DIFF
--- a/.changeset/afraid-mails-raise.md
+++ b/.changeset/afraid-mails-raise.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Change Date Input props and remove accepting string

--- a/packages/ui/src/components/DateInput/__stories__/Size.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/Size.stories.tsx
@@ -11,7 +11,7 @@ export const Size: StoryFn<typeof DateInput> = args => (
 )
 
 Size.args = {
-  value: 'Sat 24 Dec 2024',
+  value: new Date('Sat 24 Dec 2024'),
 }
 Size.decorators = [
   StoryComponent => (

--- a/packages/ui/src/components/DateInput/index.tsx
+++ b/packages/ui/src/components/DateInput/index.tsx
@@ -41,7 +41,7 @@ type DateInputProps<IsRange extends undefined | boolean = false> = {
    * Label of the field
    */
   label?: string
-  value?: Date | string | null
+  value?: Date | null
   className?: string
   'data-testid'?: string
   excludeDates?: Date[]

--- a/packages/ui/src/components/TimeInputV2/__tests__/helper.test.ts
+++ b/packages/ui/src/components/TimeInputV2/__tests__/helper.test.ts
@@ -45,6 +45,8 @@ describe('Helper functions dateInput', () => {
     expect(getValueByType('h', date)).toBe(13)
     expect(getValueByType('m', date)).toBe(30)
     expect(getValueByType('s', date)).toBe(59)
+    expect(getValueByType('s', undefined)).toBe(0)
+    expect(getValueByType('s', null)).toBe(0)
   })
 
   test('setValueByType should work', () => {

--- a/packages/ui/src/components/TimeInputV2/helpers.ts
+++ b/packages/ui/src/components/TimeInputV2/helpers.ts
@@ -46,7 +46,7 @@ export const getLastTypedChar = (value: string, oldValue?: number) => {
 
 export const getValueByType = (
   type: (typeof TIME_KEYS)[number],
-  value?: Date,
+  value?: Date | null,
 ) => {
   if (!value) return 0
   if (type === 'h') return value.getHours()

--- a/packages/ui/src/components/TimeInputV2/index.tsx
+++ b/packages/ui/src/components/TimeInputV2/index.tsx
@@ -157,7 +157,7 @@ padding-inline: ${({ theme }) => theme.space['0.25']};
 
 type TimeInputProps = {
   placeholder?: Time
-  value?: Date
+  value?: Date | null
   clearable?: boolean
   required?: boolean
   labelDescription?: ReactNode


### PR DESCRIPTION
## Summary

Before DateInput was accepting string, it should be the responsibility of the form to provide a Date as a value and not a string. And should accept null, such as for TimeInput

## Type

- Bug
