### PR TITLE
fix(ui): toaster remove blocking auto closing options

### DIFF
--- a/.changeset/dark-kings-travel.md
+++ b/.changeset/dark-kings-travel.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix Toaster component to have more options disabled blocking it from auto closing

--- a/packages/ui/src/components/Toaster/index.tsx
+++ b/packages/ui/src/components/Toaster/index.tsx
@@ -216,6 +216,9 @@ export const ToastContainer = ({
           className={className}
           transition={Slide}
           containerId={containerId}
+          pauseOnFocusLoss={false}
+          draggable={false}
+          pauseOnHover={false}
         />
       )}
     </ClassNames>


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Remove option that makes the toaster not close when out of window or when hovered and remove draggable option.