### PR TITLE
fix(SwitchButton): relative card is breaking the display

### DIFF
--- a/.changeset/late-coins-love.md
+++ b/.changeset/late-coins-love.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SwitchButton />` relative selectable card is breaking the display

--- a/packages/form/src/components/SwitchButtonField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SwitchButtonField/__tests__/__snapshots__/index.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`SwitchButtonField > should render correctly 1`] = `
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   white-space: nowrap;
+  background: transparent;
 }
 
 .emotion-3[data-has-label='false']>:first-child {
@@ -584,6 +585,7 @@ exports[`SwitchButtonField > should works with defaultValues 1`] = `
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   white-space: nowrap;
+  background: transparent;
 }
 
 .emotion-3[data-has-label='false']>:first-child {

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`SwitchButton > renders correctly 1`] = `
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   white-space: nowrap;
+  background: transparent;
 }
 
 .emotion-3[data-has-label='false']>:first-child {
@@ -692,6 +693,7 @@ exports[`SwitchButton > renders correctly medium 1`] = `
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   white-space: nowrap;
+  background: transparent;
 }
 
 .emotion-3[data-has-label='false']>:first-child {
@@ -1203,6 +1205,7 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   white-space: nowrap;
+  background: transparent;
 }
 
 .emotion-3[data-has-label='false']>:first-child {
@@ -1722,6 +1725,7 @@ exports[`SwitchButton > renders with tooltip 1`] = `
   -webkit-transition: all 200ms ease-in-out;
   transition: all 200ms ease-in-out;
   white-space: nowrap;
+  background: transparent;
 }
 
 .emotion-5[data-has-label='false']>:first-child {

--- a/packages/ui/src/components/SwitchButton/index.tsx
+++ b/packages/ui/src/components/SwitchButton/index.tsx
@@ -18,6 +18,7 @@ const StyledSelectableCard = styled(SelectableCard)`
   align-items: center;
   transition: all 200ms ease-in-out;
   white-space: nowrap;
+  background: transparent;
 
   &:hover,
   &:active {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

SwitchButton wrong style due to SelectableCard changes.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2025-04-14 at 11 26 26](https://github.com/user-attachments/assets/b0dc8517-a167-48a7-8ffb-a6ddc65d7415) | ![Screenshot 2025-04-14 at 11 26 29](https://github.com/user-attachments/assets/bd310901-b645-4779-afd0-d7b476585048) |
