### PR TITLE
fix(UnitInput): value to change in controlled

### DIFF
--- a/.changeset/warm-wombats-kiss.md
+++ b/.changeset/warm-wombats-kiss.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<UnitInput />` value not updating when changing in controlled

--- a/packages/ui/src/components/UnitInput/index.tsx
+++ b/packages/ui/src/components/UnitInput/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { AlertCircleIcon, CheckCircleIcon } from '@ultraviolet/icons'
 import type { ComponentProps, InputHTMLAttributes, ReactNode } from 'react'
-import { useId, useMemo, useState } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import { Label } from '../Label'
 import { SelectInputV2 } from '../SelectInputV2'
 import type { OptionType } from '../SelectInputV2/types'
@@ -274,6 +274,12 @@ export const UnitInput = ({
 
     return 'neutral'
   }, [error, success])
+
+  useEffect(() => {
+    if (value !== undefined) {
+      setVal(value)
+    }
+  }, [value])
 
   return (
     <Stack gap={0.5}>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

UnitInput not changing value when controlled as `useEffect` is missing for it.
