### PR TITLE
fix(SelectInputV2): sanitize SearchBarDropdown

### DIFF
--- a/.changeset/big-candies-dream.md
+++ b/.changeset/big-candies-dream.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Sanitize input of `SearchBarDropdown`

--- a/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
@@ -83,9 +83,12 @@ export const SearchBarDropdown = ({
     selectedData,
   } = useSelectInput()
   const handleChange = (search: string) => {
+    const escapeRegExp = (string: string) =>
+      string.replace(/[.*+?^{}()|[\]\\]/g, String.raw`\$&`)
+
     if (search.length > 0) {
       // case insensitive search
-      const regex = new RegExp(search.toString(), 'i')
+      const regex = new RegExp(escapeRegExp(search.toString()), 'i')
       if (!Array.isArray(options)) {
         const filteredOptions = { ...options }
         Object.keys(filteredOptions).map((group: string) => {

--- a/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/SearchBarDropdown.tsx
@@ -82,10 +82,10 @@ export const SearchBarDropdown = ({
     setSelectedData,
     selectedData,
   } = useSelectInput()
-  const handleChange = (search: string) => {
-    const escapeRegExp = (string: string) =>
-      string.replace(/[.*+?^{}()|[\]\\]/g, String.raw`\$&`)
+  const escapeRegExp = (string: string) =>
+    string.replace(/[.*+?^{}()|[\]\\]/g, String.raw`\$&`)
 
+  const handleChange = (search: string) => {
     if (search.length > 0) {
       // case insensitive search
       const regex = new RegExp(escapeRegExp(search.toString()), 'i')


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Remove uncaught input error due to special characters

#### The following changes where made:

Sanitize `SearchBarDropdown` by escaping special characters

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![image](https://github.com/user-attachments/assets/ffe28952-08d7-4c90-8c7c-1dccd75e3811) |  |

