### PR TITLE
ci: fix date field to force utc zone in vitest

### DIFF
--- a/utils/test/src/vitest/setup.ts
+++ b/utils/test/src/vitest/setup.ts
@@ -15,6 +15,7 @@ const MockResize = vi.fn(() => ({
 }))
 
 export const setup = () => {
+  process.env.TZ = 'UTC'
   expect.extend(matchers)
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   expect.addSnapshotSerializer(createSerializer())


### PR DESCRIPTION
Fix ci by forcing UTC time zone for vitest
