### PR TITLE
fix(SelectInputFieldV2): spread props to avoid missing some of them

### DIFF
--- a/.changeset/wicked-nights-slide.md
+++ b/.changeset/wicked-nights-slide.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Fix `<SelectInputFieldV2 />` spread props to avoid missing some of them

--- a/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputFieldV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -532,7 +532,6 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
             <div
               aria-expanded="true"
               aria-haspopup="listbox"
-              aria-label=""
               class="emotion-6 emotion-7"
               data-disabled="false"
               data-dropdownvisible="true"
@@ -1118,7 +1117,6 @@ exports[`SelectInputField > should render correctly 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label=""
               class="emotion-6 emotion-7"
               data-disabled="false"
               data-dropdownvisible="false"
@@ -1390,7 +1388,6 @@ exports[`SelectInputField > should render correctly disabled 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label=""
               class="emotion-6 emotion-7"
               data-disabled="true"
               data-dropdownvisible="false"
@@ -1662,7 +1659,6 @@ exports[`SelectInputField > should render correctly grouped 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label=""
               class="emotion-6 emotion-7"
               data-disabled="false"
               data-dropdownvisible="false"
@@ -1934,7 +1930,6 @@ exports[`SelectInputField > should render correctly multiselect 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label=""
               class="emotion-6 emotion-7"
               data-disabled="false"
               data-dropdownvisible="false"
@@ -2205,7 +2200,6 @@ exports[`SelectInputField > should trigger events 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-label=""
               class="emotion-6 emotion-7"
               data-disabled="false"
               data-dropdownvisible="false"

--- a/packages/form/src/components/SelectInputFieldV2/index.tsx
+++ b/packages/form/src/components/SelectInputFieldV2/index.tsx
@@ -11,81 +11,23 @@ type SelectInputFieldV2Props<
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues>,
 > = BaseFieldProps<TFieldValues, TFieldName> &
-  Pick<
-    ComponentProps<typeof SelectInputV2>,
-    | 'placeholder'
-    | 'placeholderSearch'
-    | 'label'
-    | 'helper'
-    | 'options'
-    | 'emptyState'
-    | 'searchable'
-    | 'readOnly'
-    | 'clearable'
-    | 'size'
-    | 'multiselect'
-    | 'required'
-    | 'descriptionDirection'
-    | 'footer'
-    | 'labelDescription'
-    | 'success'
-    | 'loadMore'
-    | 'isLoading'
-    | 'selectAll'
-    | 'selectAllGroup'
-    | 'autofocus'
-    | 'data-testid'
-    | 'id'
-    | 'onBlur'
-    | 'aria-label'
-    | 'className'
-    | 'onFocus'
-    | 'optionalInfoPlacement'
-    | 'disabled'
-    | 'tooltip'
-    | 'dropdownAlign'
-  >
+  Omit<ComponentProps<typeof SelectInputV2>, 'value' | 'onChange'>
 
 export const SelectInputFieldV2 = <
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
-  autofocus,
-  className,
-  id,
   label = '',
-  onFocus,
   onBlur,
-  placeholder,
-  readOnly,
   required,
-  size,
-  'data-testid': dataTestId,
-  disabled,
-  placeholderSearch,
-  helper,
-  options,
-  emptyState,
-  onChange,
-  searchable,
-  clearable,
-  multiselect,
-  descriptionDirection,
-  footer,
-  labelDescription,
-  success,
-  loadMore,
-  isLoading,
-  selectAll,
-  selectAllGroup,
   name,
   'aria-label': ariaLabel,
-  optionalInfoPlacement,
   shouldUnregister = false,
   control,
   validate,
-  tooltip,
-  dropdownAlign,
+  onChange,
+  multiselect,
+  ...props
 }: SelectInputFieldV2Props<TFieldValues, TFieldName>) => {
   const {
     field,
@@ -115,43 +57,16 @@ export const SelectInputFieldV2 = <
   return (
     <SelectInputV2
       name={field.name}
-      options={options}
+      multiselect={multiselect}
       required={required}
-      size={size}
-      data-testid={dataTestId}
-      className={className}
-      disabled={disabled}
-      id={id}
-      label={label}
-      onFocus={onFocus}
       onBlur={event => {
         field.onBlur()
         onBlur?.(event)
       }}
-      placeholder={placeholder}
-      readOnly={readOnly}
-      multiselect={multiselect}
       value={field.value as string | string[]}
-      placeholderSearch={placeholderSearch}
-      helper={helper}
-      emptyState={emptyState}
-      searchable={searchable}
-      clearable={clearable}
-      descriptionDirection={descriptionDirection}
-      footer={footer}
-      labelDescription={labelDescription}
       error={getError({ label: label ?? ariaLabel ?? name }, error)}
-      success={success}
-      loadMore={loadMore}
-      isLoading={isLoading}
-      selectAll={selectAll}
-      selectAllGroup={selectAllGroup}
-      autofocus={autofocus}
-      optionalInfoPlacement={optionalInfoPlacement}
-      aria-label={ariaLabel}
       onChange={handleChange}
-      tooltip={tooltip}
-      dropdownAlign={dropdownAlign}
+      {...props}
     />
   )
 }


### PR DESCRIPTION
## Summary

Forgotten `portalTarget` on `SelectInputV2`. I added prop spread so we can't forget to add the props in the field components. FYI a migration onto that is coming for fields to always spread props.
