### PR TITLE
fix(EstimateCost): fix unit state

### DIFF
--- a/.changeset/wicked-yaks-clap.md
+++ b/.changeset/wicked-yaks-clap.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<EstimateCost.Unit />` to have correct amount updated according to the item

--- a/packages/plus/src/components/EstimateCost/Components/Unit.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/Unit.tsx
@@ -41,9 +41,10 @@ export const Unit = ({
   const [capacity, setCapacity] = useState(amount === 0 ? undefined : amount)
 
   useEffect(() => {
-    itemCallback?.(capacity, true)
-    getAmountValue?.(capacity)
-  }, [getAmountValue, itemCallback, capacity])
+    setCapacity(amount)
+    itemCallback?.(amount, true)
+    getAmountValue?.(amount)
+  }, [getAmountValue, itemCallback, capacity, amount])
 
   return isOverlay ? (
     <ItemResourceName animated={false}>

--- a/packages/plus/src/components/EstimateCost/Components/Unit.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/Unit.tsx
@@ -60,7 +60,10 @@ export const Unit = ({
         name="capacity"
         value={capacity?.toString()}
         onChange={capacityText => {
-          setCapacity(Number(capacityText) < 0 ? 0 : Number(capacityText))
+          const newCapacity =
+            Number(capacityText) < 0 ? 0 : Number(capacityText)
+          setCapacity(newCapacity)
+          itemCallback?.(newCapacity, true)
           getAmountValue?.(capacity)
         }}
       />

--- a/packages/plus/src/components/EstimateCost/__stories__/Unit.stories.tsx
+++ b/packages/plus/src/components/EstimateCost/__stories__/Unit.stories.tsx
@@ -1,27 +1,28 @@
+import type { StoryFn } from '@storybook/react'
+import { Button, Stack } from '@ultraviolet/ui'
+import type { ComponentProps } from 'react'
+import { useState } from 'react'
 import { EstimateCost } from '..'
-import { Template } from './Template'
 
-export const Unit = Template.bind({})
+export const Unit: StoryFn<ComponentProps<typeof EstimateCost>> = props => {
+  const [value, setValue] = useState<number | undefined>(0)
 
-Unit.args = {
-  children: [
-    <EstimateCost.Item
-      label="Storage"
-      subLabel="50 GB Free"
-      price={0.001}
-      unit="samples"
-      amountFree={50}
-      amount={100}
-    >
-      <EstimateCost.Unit unit="GB" />
-    </EstimateCost.Item>,
-    <EstimateCost.Item label="Screen pixels" price={1} unit="Px" amount={100}>
-      <EstimateCost.Unit />
-    </EstimateCost.Item>,
-    <EstimateCost.Item label="Screen pixels" price={1} unit="Px" amount={100}>
-      <EstimateCost.Regular>Test</EstimateCost.Regular>
-    </EstimateCost.Item>,
-  ],
+  return (
+    <Stack gap={1}>
+      <Button onClick={() => setValue(10)}>Set value to 10</Button>
+      <Button onClick={() => setValue(20)}>Set value to 20</Button>
+      <EstimateCost {...props} hideOverlay>
+        <EstimateCost.Item
+          label="Screen pixels"
+          price={1}
+          unit="Px"
+          amount={value}
+        >
+          <EstimateCost.Unit />
+        </EstimateCost.Item>
+      </EstimateCost>
+    </Stack>
+  )
 }
 
 Unit.parameters = {

--- a/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.test.tsx.snap
+++ b/packages/plus/src/components/EstimateCost/__tests__/__snapshots__/Unit.test.tsx.snap
@@ -15464,7 +15464,9 @@ exports[`EstimateCost - Unit Item > render with 0 amount 1`] = `
                   >
                     <div
                       class="emotion-20 emotion-21"
-                    />
+                    >
+                      0
+                    </div>
                   </div>
                 </div>
               </div>
@@ -15728,6 +15730,7 @@ exports[`EstimateCost - Unit Item > render with 0 amount 1`] = `
                             name="capacity"
                             placeholder="00"
                             type="number"
+                            value="0"
                           />
                           <div
                             class="emotion-105 emotion-106"
@@ -17987,7 +17990,7 @@ exports[`EstimateCost - Unit Item > render with 10 amount 1`] = `
                             aria-live="assertive"
                             as="label"
                             class="emotion-70 emotion-71"
-                            for=":r2p:"
+                            for=":r2o:"
                           >
                             Select...
                           </label>
@@ -18009,7 +18012,7 @@ exports[`EstimateCost - Unit Item > render with 10 amount 1`] = `
                               autocomplete="off"
                               autocorrect="off"
                               class=""
-                              id=":r2p:"
+                              id=":r2o:"
                               role="combobox"
                               spellcheck="false"
                               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -20360,7 +20363,7 @@ exports[`EstimateCost - Unit Item > render with getAmountValue 1`] = `
                             aria-live="assertive"
                             as="label"
                             class="emotion-70 emotion-71"
-                            for=":r3o:"
+                            for=":r3n:"
                           >
                             Select...
                           </label>
@@ -20382,7 +20385,7 @@ exports[`EstimateCost - Unit Item > render with getAmountValue 1`] = `
                               autocomplete="off"
                               autocorrect="off"
                               class=""
-                              id=":r3o:"
+                              id=":r3n:"
                               role="combobox"
                               spellcheck="false"
                               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

`EstimateCost.Unit` doesn't change the state according to it's `EstimateCost.Item` parent.


## Relevant logs and/or screenshots

Before:

https://github.com/user-attachments/assets/c3d3065b-8abb-4a55-a959-8b989ac52405

After:

https://github.com/user-attachments/assets/abaa194e-ee7d-4692-9cd8-21f7e3ec9eb1


