### PR TITLE
fix(Navigation): do not register item if pinned items feature is off

### DIFF
--- a/.changeset/five-bars-yawn.md
+++ b/.changeset/five-bars-yawn.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+Fix `<Navigation />` not to register an item if there is no pinned feature

--- a/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
+++ b/packages/plus/src/components/Navigation/__stories__/Playground.stories.tsx
@@ -346,7 +346,7 @@ export const Playground: StoryFn<ComponentProps<typeof Navigation>> = props => {
         initialWidth={navigationWidth}
         initialPinned={pinnedItems}
         pinLimit={2}
-        pinnedFeature
+        pinnedFeature={false}
       >
         <PlaygroundContent {...props} />
       </NavigationProvider>

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -402,7 +402,7 @@ export const Item = memo(
 
     useEffect(
       () => {
-        if (type !== 'pinnedGroup') {
+        if (type !== 'pinnedGroup' && pinnedFeature) {
           registerItem({ [id]: { label, active, onToggle, onClickPinUnpin } })
         }
       },


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Improve performances on Navigation when pinned feature is off.
