### PR TITLE
ci: beta sync with main and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - beta
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
@@ -20,12 +21,14 @@ jobs:
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
+
       - uses: pnpm/action-setup@v4.1.0
       - name: Use Node.js
         uses: actions/setup-node@v4.4.0
         with:
           node-version: 22
           cache: "pnpm"
+
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/sync-main-to-beta.yml
+++ b/.github/workflows/sync-main-to-beta.yml
@@ -1,0 +1,54 @@
+name: Sync Main to Beta
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-main-to-beta:
+    name: Sync Main to Beta
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Check if Beta Branch Exists
+        id: check-beta
+        run: |
+          if git ls-remote --heads origin beta | grep -q beta; then
+            echo "Beta branch exists."
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "Beta branch does not exist. Exiting."
+            echo "exists=false" >> $GITHUB_ENV
+          fi
+
+      - name: Exit if Beta Branch Does Not Exist
+        if: env.exists == 'false'
+        run: exit 0
+
+      - name: Set Git Identity
+        run: |
+          git config --global user.name $FRONT_USER_NAME
+          git config --global user.email $FRONT_USER_EMAIL
+
+      - name: Fetch All Branches
+        run: git fetch --all
+
+      - name: Create or Update Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: beta
+          head: main
+          title: "Sync Main to Beta"
+          body: |
+            This pull request keeps the `beta` branch in sync with the latest changes from the `main` branch.
+          branch: sync-main-to-beta # Temporary branch for the PR
+          update-existing-pr: true # Update the existing PR if one already exists


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

- New job that will create a PR when an update is available on main and beta branch needs to be sync. It will only be triggered if the beta branch exists.
- Added beta branch in the release github action so it will open a PR when something is merged into it and release when the release PR is merged.
