### PR TITLE
fix(Notice): icon size

### DIFF
--- a/.changeset/flat-kids-like.md
+++ b/.changeset/flat-kids-like.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Notice />` icon size

--- a/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -636,10 +636,10 @@ exports[`TextInputField > should render correctly notice 1`] = `
 .emotion-12 {
   vertical-align: middle;
   fill: #727683;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-12 .fillStroke {
@@ -677,7 +677,7 @@ exports[`TextInputField > should render correctly notice 1`] = `
         >
           <svg
             class="emotion-12 emotion-13"
-            viewBox="0 0 20 20"
+            viewBox="0 0 16 16"
           >
             <path
               clip-rule="evenodd"

--- a/packages/ui/src/components/Notice/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Notice/__tests__/__snapshots__/index.test.tsx.snap
@@ -26,10 +26,10 @@ exports[`Notice > renders correctly with default props 1`] = `
 .emotion-3 {
   vertical-align: middle;
   fill: #727683;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-3 .fillStroke {
@@ -45,7 +45,7 @@ exports[`Notice > renders correctly with default props 1`] = `
     >
       <svg
         class="emotion-3 emotion-4"
-        viewBox="0 0 20 20"
+        viewBox="0 0 16 16"
       >
         <path
           clip-rule="evenodd"

--- a/packages/ui/src/components/Notice/index.tsx
+++ b/packages/ui/src/components/Notice/index.tsx
@@ -33,7 +33,11 @@ export const Notice = ({
     data-testid={dataTestId}
     className={className}
   >
-    <InformationOutlineIcon size={16} sentiment="neutral" prominence="weak" />
+    <InformationOutlineIcon
+      size="small"
+      sentiment="neutral"
+      prominence="weak"
+    />
     {children}
   </StyledSpan>
 )

--- a/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -4145,10 +4145,10 @@ exports[`TextInput > should render correctly with notice 1`] = `
 .emotion-14 {
   vertical-align: middle;
   fill: #727683;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-14 .fillStroke {
@@ -4190,7 +4190,7 @@ exports[`TextInput > should render correctly with notice 1`] = `
       >
         <svg
           class="emotion-14 emotion-15"
-          viewBox="0 0 20 20"
+          viewBox="0 0 16 16"
         >
           <path
             clip-rule="evenodd"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There was a small alignement issue with the icon on Notice component

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2025-05-09 at 11 01 33](https://github.com/user-attachments/assets/0e68f843-c883-47a3-9b7e-c6166f8ef802) | ![Screenshot 2025-05-09 at 11 01 37](https://github.com/user-attachments/assets/4a829454-51f3-4938-85ea-f98a35071c96) |
