### PR TITLE
revert(react-hook-form): useless re-render

### DIFF
--- a/.changeset/polite-keys-crash.md
+++ b/.changeset/polite-keys-crash.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Revert update react-hook-form

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -83,7 +83,7 @@
     "@babel/runtime": "7.27.1",
     "@ultraviolet/themes": "workspace:*",
     "@ultraviolet/ui": "workspace:*",
-    "react-hook-form": "7.56.1",
+    "react-hook-form": "7.55.0",
     "react-select": "5.10.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,8 +567,8 @@ importers:
         specifier: workspace:*
         version: link:../ui
       react-hook-form:
-        specifier: 7.56.1
-        version: 7.56.1(react@19.0.0)
+        specifier: 7.55.0
+        version: 7.55.0(react@19.0.0)
       react-select:
         specifier: 5.10.0
         version: 5.10.0(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -7093,8 +7093,8 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
-  react-hook-form@7.56.1:
-    resolution: {integrity: sha512-qWAVokhSpshhcEuQDSANHx3jiAEFzu2HAaaQIzi/r9FNPm1ioAvuJSD4EuZzWd7Al7nTRKcKPnBKO7sRn+zavQ==}
+  react-hook-form@7.55.0:
+    resolution: {integrity: sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -16044,7 +16044,7 @@ snapshots:
       react: 19.0.0
       scheduler: 0.25.0
 
-  react-hook-form@7.56.1(react@19.0.0):
+  react-hook-form@7.55.0(react@19.0.0):
     dependencies:
       react: 19.0.0
 


### PR DESCRIPTION
Revert react hook form failing since 7.56.X
