### PR TITLE
fix: label type form

### DIFF
--- a/.changeset/new-mugs-sip.md
+++ b/.changeset/new-mugs-sip.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+`ToggleField` and `SelectableCardField`: Fix type of prop `label`

--- a/packages/form/src/components/SelectableCardField/index.tsx
+++ b/packages/form/src/components/SelectableCardField/index.tsx
@@ -9,7 +9,7 @@ import type { BaseFieldProps } from '../../types'
 type SelectableCardFieldProps<
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues>,
-> = BaseFieldProps<TFieldValues, TFieldName> &
+> = Omit<BaseFieldProps<TFieldValues, TFieldName>, 'label'> &
   Omit<ComponentProps<typeof SelectableCard>, 'name' | 'onChange'>
 
 export const SelectableCardField = <

--- a/packages/form/src/components/ToggleField/index.tsx
+++ b/packages/form/src/components/ToggleField/index.tsx
@@ -10,7 +10,7 @@ import type { BaseFieldProps } from '../../types'
 type ToggleFieldProps<
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues>,
-> = BaseFieldProps<TFieldValues, TFieldName> &
+> = Omit<BaseFieldProps<TFieldValues, TFieldName>, 'label'> &
   Omit<ComponentProps<typeof Toggle>, 'value' | 'onChange'> & {
     parse?: (value: boolean) => PathValue<TFieldValues, TFieldName>
     format?: (value: PathValue<TFieldValues, TFieldName>) => boolean


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarise concisely:

#### What is expected?
Label was a string instead of a ReactNode for `ToggleField` and `SelectableCardField`