### PR TITLE
fix(icons): system icons weak pronience to work

### DIFF
--- a/.changeset/purple-bears-tease.md
+++ b/.changeset/purple-bears-tease.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/icons": patch
+---
+
+Fix system icons to work with weak prominence

--- a/packages/icons/src/components/Icon/Icon.tsx
+++ b/packages/icons/src/components/Icon/Icon.tsx
@@ -77,7 +77,8 @@ const StyledIcon = styled('svg', {
   fill: ${({ theme, sentiment, prominence, disabled }) => {
     // stronger is available only for neutral sentiment
     const definedProminence =
-      sentiment !== 'neutral' && prominence === 'stronger'
+      (sentiment !== 'neutral' && prominence === 'stronger') ||
+      prominence === 'weak'
         ? capitalize(PROMINENCES.default)
         : capitalize(PROMINENCES[prominence])
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Weak icons associated with sentiment are not working due to the fact that we removed weak tokens in the beta.


## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="993" alt="Screenshot 2025-06-12 at 11 52 53" src="https://github.com/user-attachments/assets/bd82dcf1-eb0d-4508-a9be-7754b115d459" /> | <img width="988" alt="Screenshot 2025-06-12 at 11 53 14" src="https://github.com/user-attachments/assets/90035630-3398-4140-8a65-9a6576d1560d" /> |
