### PR TITLE
fix(StepList): width

### DIFF
--- a/.changeset/all-baths-draw.md
+++ b/.changeset/all-baths-draw.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`StepList`: fix width

--- a/packages/plus/src/components/SteppedListCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/SteppedListCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -168,6 +168,7 @@ exports[`SteppedListCard > should hide the toggle button 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 .emotion-21 {
@@ -635,6 +636,7 @@ exports[`SteppedListCard > should work with custom hide action 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 .emotion-25 {
@@ -1098,6 +1100,7 @@ exports[`SteppedListCard > should work with default props 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 .emotion-25 {
@@ -1786,6 +1789,7 @@ exports[`SteppedListCard > should work with pre-completed step 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 .emotion-20 {
@@ -1795,6 +1799,7 @@ exports[`SteppedListCard > should work with pre-completed step 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 .emotion-23 {

--- a/packages/ui/src/components/StepList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/StepList/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`StepList > renders correctly  1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 <div
@@ -185,6 +186,7 @@ exports[`StepList > renders correctly with bulletContent & sentiment 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 <div
@@ -307,6 +309,7 @@ exports[`StepList > renders correctly with bulletContent 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 <div
@@ -429,6 +432,7 @@ exports[`StepList > renders correctly with disabled state & bullet icon 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 <div
@@ -538,6 +542,7 @@ exports[`StepList > renders correctly with disabled state 1`] = `
   margin: auto;
   line-height: 32px;
   font-size: 24px;
+  min-width: 0;
 }
 
 <div
@@ -639,6 +644,7 @@ exports[`StepList > renders correctly with small size 1`] = `
   margin: auto;
   line-height: 24px;
   font-size: 16px;
+  min-width: 0;
 }
 
 <div

--- a/packages/ui/src/components/StepList/index.tsx
+++ b/packages/ui/src/components/StepList/index.tsx
@@ -34,6 +34,7 @@ const StyledDiv = styled('div', {
   margin: auto;
   line-height: ${({ size }) => (size === 'medium' ? '32px' : '24px')};
   font-size: ${({ size }) => (size === 'medium' ? '24px' : '16px')};
+  min-width: 0;
 `
 
 export type Sizes = 'small' | 'medium'


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?
`<StepList />`: no overflow when the content is too long (eg: long snippet)

Before: <img width="1191" alt="Capture d’écran 2025-06-17 à 10 54 27" src="https://github.com/user-attachments/assets/c005a7ae-d794-44a2-b4a6-1015afb23335" />
After: <img width="1191" alt="Capture d’écran 2025-06-17 à 10 54 21" src="https://github.com/user-attachments/assets/853882d6-09a2-48ed-abf1-f840dece94ea" />

