### PR TITLE
fix(Navigation): active state

### DIFF
--- a/.changeset/rude-paths-stick.md
+++ b/.changeset/rude-paths-stick.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": patch
+---
+
+`Navigation`: isActive should work when the Item is wrapped in a Link/NavLink (React rooter)

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -116,7 +116,8 @@ const StyledMenuItem = styled(Menu.Item, {
     }
 
     ${StyledBadge} {
-      opacity: ${({ isPinnable, pinnedFeature }) => (isPinnable && pinnedFeature ? 0 : 1)};
+      opacity: ${({ isPinnable, pinnedFeature }) =>
+        isPinnable && pinnedFeature ? 0 : 1};
     }
   }
 `
@@ -265,6 +266,10 @@ const ContainerCategoryIcon = styled(Stack)`
 
 type ItemType = 'default' | 'pinned' | 'pinnedGroup'
 
+type LinkProps = {
+  to: string
+  children?: { props: ItemProps }
+}
 type ItemProps = {
   children?: ReactNode
   /**
@@ -437,9 +442,18 @@ export const Item = memo(
       if (!children) return false
 
       return (
-        Children.map(children, child =>
-          isValidElement<ItemProps>(child) ? child.props?.active : false,
-        ) as boolean[]
+        Children.map(children, child => {
+          if (isValidElement<ItemProps | LinkProps>(child)) {
+            // In case the Item is wrapped in a link
+            if ('to' in child.props) {
+              return child.props.children?.props.active
+            }
+
+            return child.props.active
+          }
+
+          return null
+        }) as boolean[]
       ).includes(true)
     }, [children])
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?
`Navigation`: active state should work when the Item is wrapped in a Link/NavLink (React router)

Before : <img width="209" alt="Capture d’écran 2025-06-18 à 17 31 05" src="https://github.com/user-attachments/assets/8c1bc0da-d896-4751-bf30-0dfcdd3cde5f" />
After: <img width="209" alt="Capture d’écran 2025-06-18 à 17 31 28" src="https://github.com/user-attachments/assets/67dfa1d1-4fe7-479e-b730-5029bcb1c5dc" />