### PR TITLE
fix: add prop to allow dnd

### DIFF
--- a/.changeset/spotty-weeks-unite.md
+++ b/.changeset/spotty-weeks-unite.md
@@ -1,0 +1,9 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Allow DND kit to work with `List` and `Button` : 
+- `List.Row` now supports "style" and "data-dragging" props ;
+- For Security group we don't display header but the List component add to much spaces ;
+- List.Row do not allow data-dragging prop
+- `Button` can have props "aria-describedby", "aria-disabled", "aria-pressed", "aria-roledescription", "onPointerDown" and "onKeyDown" to work with DND kit

--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`Button > render as an anchor with href prop 1`] = `
     data-testid="testing"
   >
     <a
+      aria-disabled="false"
       class="emotion-0 emotion-1"
       href="http://scaleway.com"
       type="button"

--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.test.tsx.snap
@@ -371,12 +371,71 @@ exports[`Button > render with a tooltip 1`] = `
   color: #f9f9fa;
 }
 
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+}
+
+.emotion-2:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-2:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-2 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-2:hover,
+.emotion-2:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
 <div
     data-testid="testing"
   >
     <div
-      aria-controls="«r1m»"
-      aria-describedby="«r1m»"
+      aria-controls="«r23»"
+      aria-describedby="«r23»"
       class="emotion-0 emotion-1"
       data-container-full-width="false"
       tabindex="0"
@@ -519,6 +578,57 @@ exports[`Button > render with icon 1`] = `
   stroke: transparent;
 }
 
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: #e5dbfd;
+  color: #ffffff;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
 .emotion-2 {
   vertical-align: middle;
   fill: currentColor;
@@ -561,6 +671,57 @@ exports[`Button > render with icon 1`] = `
 exports[`Button > render with icon on the right 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: #e5dbfd;
+  color: #ffffff;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -703,6 +864,57 @@ exports[`Button > render with icon only 1`] = `
   stroke: transparent;
 }
 
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: #e5dbfd;
+  color: #ffffff;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
 .emotion-2 {
   vertical-align: middle;
   fill: currentColor;
@@ -743,6 +955,57 @@ exports[`Button > render with icon only 1`] = `
 exports[`Button > render with isLoading with icon 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: #e5dbfd;
+  color: #ffffff;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .emotion-5 {
+  stroke: transparent;
+}
+
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -939,6 +1202,65 @@ exports[`Button > render with isLoading with icon variant 1`] = `
   color: #f9f9fa;
 }
 
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0:active {
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0:hover,
+.emotion-0:active {
+  background: #792dd4;
+  color: #f9f9fa;
+}
+
 .emotion-2 {
   vertical-align: middle;
   fill: currentColor;
@@ -979,6 +1301,57 @@ exports[`Button > render with isLoading with icon variant 1`] = `
 exports[`Button > render with isLoading without icon 1`] = `
 <DocumentFragment>
   .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #8c40ef;
+  border: none;
+  color: #ffffff;
+  background: #e5dbfd;
+  color: #ffffff;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .emotion-5 {
+  stroke: transparent;
+}
+
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1163,7 +1536,9 @@ exports[`Button > render xsmall 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Button > variant-sentiment-disabled combination > render filled&danger 1`] = `
+exports[`Button > variant-sentiment-disabled combination > render filled&black 1`] = `[Function]`;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&black disabled 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-inline-box;
@@ -1200,11 +1575,62 @@ exports[`Button > variant-sentiment-disabled combination > render filled&danger 
   line-height: 1.5rem;
   paragraph-spacing: 0;
   text-case: none;
-  background: #e51963;
+  background: #151a2d;
   border: none;
   color: #ffffff;
-  background: #ffd3e3;
+  background: #e9eaeb;
+  color: #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #151a2d;
+  border: none;
   color: #ffffff;
+  background: #e9eaeb;
+  color: #b5b7bd;
 }
 
 .emotion-0:hover {
@@ -1229,6 +1655,8 @@ exports[`Button > variant-sentiment-disabled combination > render filled&danger 
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&danger 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render filled&danger disabled 1`] = `
 <DocumentFragment>
@@ -1283,23 +1711,7 @@ exports[`Button > variant-sentiment-disabled combination > render filled&danger 
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render filled&info 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1334,10 +1746,10 @@ exports[`Button > variant-sentiment-disabled combination > render filled&info 1`
   line-height: 1.5rem;
   paragraph-spacing: 0;
   text-case: none;
-  background: #0078d2;
+  background: #e51963;
   border: none;
   color: #ffffff;
-  background: #bee3ff;
+  background: #ffd3e3;
   color: #ffffff;
 }
 
@@ -1363,6 +1775,8 @@ exports[`Button > variant-sentiment-disabled combination > render filled&info 1`
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&info 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render filled&info disabled 1`] = `
 <DocumentFragment>
@@ -1417,23 +1831,7 @@ exports[`Button > variant-sentiment-disabled combination > render filled&info di
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render filled&neutral 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1468,11 +1866,11 @@ exports[`Button > variant-sentiment-disabled combination > render filled&neutral
   line-height: 1.5rem;
   paragraph-spacing: 0;
   text-case: none;
-  background: #e9eaeb;
+  background: #0078d2;
   border: none;
-  color: #222638;
-  background: #f3f3f4;
-  color: #b5b7bd;
+  color: #ffffff;
+  background: #bee3ff;
+  color: #ffffff;
 }
 
 .emotion-0:hover {
@@ -1497,6 +1895,8 @@ exports[`Button > variant-sentiment-disabled combination > render filled&neutral
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&neutral 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render filled&neutral disabled 1`] = `
 <DocumentFragment>
@@ -1551,23 +1951,7 @@ exports[`Button > variant-sentiment-disabled combination > render filled&neutral
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render filled&primary 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1602,11 +1986,11 @@ exports[`Button > variant-sentiment-disabled combination > render filled&primary
   line-height: 1.5rem;
   paragraph-spacing: 0;
   text-case: none;
-  background: #8c40ef;
+  background: #e9eaeb;
   border: none;
-  color: #ffffff;
-  background: #e5dbfd;
-  color: #ffffff;
+  color: #222638;
+  background: #f3f3f4;
+  color: #b5b7bd;
 }
 
 .emotion-0:hover {
@@ -1631,6 +2015,8 @@ exports[`Button > variant-sentiment-disabled combination > render filled&primary
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&primary 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render filled&primary disabled 1`] = `
 <DocumentFragment>
@@ -1685,23 +2071,7 @@ exports[`Button > variant-sentiment-disabled combination > render filled&primary
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render filled&secondary 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1736,10 +2106,10 @@ exports[`Button > variant-sentiment-disabled combination > render filled&seconda
   line-height: 1.5rem;
   paragraph-spacing: 0;
   text-case: none;
-  background: #b824f9;
+  background: #8c40ef;
   border: none;
   color: #ffffff;
-  background: #f2d5ff;
+  background: #e5dbfd;
   color: #ffffff;
 }
 
@@ -1765,6 +2135,8 @@ exports[`Button > variant-sentiment-disabled combination > render filled&seconda
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&secondary 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render filled&secondary disabled 1`] = `
 <DocumentFragment>
@@ -1819,23 +2191,7 @@ exports[`Button > variant-sentiment-disabled combination > render filled&seconda
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render filled&success 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1870,10 +2226,10 @@ exports[`Button > variant-sentiment-disabled combination > render filled&success
   line-height: 1.5rem;
   paragraph-spacing: 0;
   text-case: none;
-  background: #2c8564;
+  background: #b824f9;
   border: none;
   color: #ffffff;
-  background: #adebd5;
+  background: #f2d5ff;
   color: #ffffff;
 }
 
@@ -1899,6 +2255,8 @@ exports[`Button > variant-sentiment-disabled combination > render filled&success
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&success 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render filled&success disabled 1`] = `
 <DocumentFragment>
@@ -1953,23 +2311,7 @@ exports[`Button > variant-sentiment-disabled combination > render filled&success
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render filled&warning 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2004,10 +2346,10 @@ exports[`Button > variant-sentiment-disabled combination > render filled&warning
   line-height: 1.5rem;
   paragraph-spacing: 0;
   text-case: none;
-  background: #fbc600;
+  background: #2c8564;
   border: none;
-  color: #222638;
-  background: #fff0b8;
+  color: #ffffff;
+  background: #adebd5;
   color: #ffffff;
 }
 
@@ -2033,6 +2375,8 @@ exports[`Button > variant-sentiment-disabled combination > render filled&warning
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&warning 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render filled&warning disabled 1`] = `
 <DocumentFragment>
@@ -2087,6 +2431,57 @@ exports[`Button > variant-sentiment-disabled combination > render filled&warning
   stroke: transparent;
 }
 
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #fbc600;
+  border: none;
+  color: #222638;
+  background: #fff0b8;
+  color: #ffffff;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
 <div
     data-testid="testing"
   >
@@ -2101,7 +2496,129 @@ exports[`Button > variant-sentiment-disabled combination > render filled&warning
 </DocumentFragment>
 `;
 
-exports[`Button > variant-sentiment-disabled combination > render ghost&danger 1`] = `
+exports[`Button > variant-sentiment-disabled combination > render filled&white 1`] = `[Function]`;
+
+exports[`Button > variant-sentiment-disabled combination > render filled&white disabled 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #ffffff;
+  border: none;
+  color: #151a2d;
+  background: #e9eaeb;
+  color: #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: #ffffff;
+  border: none;
+  color: #151a2d;
+  background: #e9eaeb;
+  color: #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+<div
+    data-testid="testing"
+  >
+    <button
+      class="emotion-0 emotion-1"
+      disabled=""
+      type="button"
+    >
+      Hello
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&black 1`] = `[Function]`;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&black disabled 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-inline-box;
@@ -2140,8 +2657,58 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&danger 1
   text-case: none;
   background: none;
   border: none;
-  color: #b3144d;
-  color: #ffbbd3;
+  color: #151a2d;
+  color: #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: none;
+  color: #151a2d;
+  color: #b5b7bd;
 }
 
 .emotion-0:hover {
@@ -2166,6 +2733,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&danger 1
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&danger 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render ghost&danger disabled 1`] = `
 <DocumentFragment>
@@ -2219,23 +2788,7 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&danger d
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render ghost&info 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2272,8 +2825,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&info 1`]
   text-case: none;
   background: none;
   border: none;
-  color: #005da3;
-  color: #9ad4ff;
+  color: #b3144d;
+  color: #ffbbd3;
 }
 
 .emotion-0:hover {
@@ -2298,6 +2851,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&info 1`]
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&info 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render ghost&info disabled 1`] = `
 <DocumentFragment>
@@ -2351,23 +2906,7 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&info dis
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render ghost&neutral 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2404,8 +2943,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&neutral 
   text-case: none;
   background: none;
   border: none;
-  color: #3f4250;
-  color: #b5b7bd;
+  color: #005da3;
+  color: #9ad4ff;
 }
 
 .emotion-0:hover {
@@ -2430,6 +2969,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&neutral 
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&neutral 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render ghost&neutral disabled 1`] = `
 <DocumentFragment>
@@ -2483,23 +3024,7 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&neutral 
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render ghost&primary 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2536,8 +3061,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&primary 
   text-case: none;
   background: none;
   border: none;
-  color: #641cb3;
-  color: #d8c5fc;
+  color: #3f4250;
+  color: #b5b7bd;
 }
 
 .emotion-0:hover {
@@ -2562,6 +3087,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&primary 
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&primary 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render ghost&primary disabled 1`] = `
 <DocumentFragment>
@@ -2615,23 +3142,7 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&primary 
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render ghost&secondary 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2668,8 +3179,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&secondar
   text-case: none;
   background: none;
   border: none;
-  color: #ac22e7;
-  color: #ebbcff;
+  color: #641cb3;
+  color: #d8c5fc;
 }
 
 .emotion-0:hover {
@@ -2694,6 +3205,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&secondar
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&secondary 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render ghost&secondary disabled 1`] = `
 <DocumentFragment>
@@ -2747,23 +3260,7 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&secondar
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render ghost&success 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2800,8 +3297,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&success 
   text-case: none;
   background: none;
   border: none;
-  color: #22674e;
-  color: #7ee0bc;
+  color: #ac22e7;
+  color: #ebbcff;
 }
 
 .emotion-0:hover {
@@ -2826,6 +3323,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&success 
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&success 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render ghost&success disabled 1`] = `
 <DocumentFragment>
@@ -2879,23 +3378,7 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&success 
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render ghost&warning 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2932,8 +3415,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&warning 
   text-case: none;
   background: none;
   border: none;
-  color: #7c5400;
-  color: #ffdd5f;
+  color: #22674e;
+  color: #7ee0bc;
 }
 
 .emotion-0:hover {
@@ -2958,6 +3441,8 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&warning 
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&warning 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render ghost&warning disabled 1`] = `
 <DocumentFragment>
@@ -3011,6 +3496,56 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&warning 
   stroke: transparent;
 }
 
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: none;
+  color: #7c5400;
+  color: #ffdd5f;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
 <div
     data-testid="testing"
   >
@@ -3025,7 +3560,9 @@ exports[`Button > variant-sentiment-disabled combination > render ghost&warning 
 </DocumentFragment>
 `;
 
-exports[`Button > variant-sentiment-disabled combination > render outlined&danger 1`] = `
+exports[`Button > variant-sentiment-disabled combination > render ghost&white 1`] = `[Function]`;
+
+exports[`Button > variant-sentiment-disabled combination > render ghost&white disabled 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: -webkit-inline-box;
@@ -3063,10 +3600,59 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&dange
   paragraph-spacing: 0;
   text-case: none;
   background: none;
-  border: 1px solid #b3144d;
-  color: #b3144d;
-  color: #ffbbd3;
-  border: 1px solid #ffbbd3;
+  border: none;
+  color: #ffffff;
+  color: #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: none;
+  color: #ffffff;
+  color: #b5b7bd;
 }
 
 .emotion-0:hover {
@@ -3091,6 +3677,128 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&dange
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&black 1`] = `[Function]`;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&black disabled 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: 1px solid #151a2d;
+  color: #151a2d;
+  color: #b5b7bd;
+  border: 1px solid #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: 1px solid #151a2d;
+  color: #151a2d;
+  color: #b5b7bd;
+  border: 1px solid #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+<div
+    data-testid="testing"
+  >
+    <button
+      class="emotion-0 emotion-1"
+      disabled=""
+      type="button"
+    >
+      Hello
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&danger 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render outlined&danger disabled 1`] = `
 <DocumentFragment>
@@ -3145,23 +3853,7 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&dange
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render outlined&info 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3197,10 +3889,10 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&info 
   paragraph-spacing: 0;
   text-case: none;
   background: none;
-  border: 1px solid #005da3;
-  color: #005da3;
-  color: #9ad4ff;
-  border: 1px solid #9ad4ff;
+  border: 1px solid #b3144d;
+  color: #b3144d;
+  color: #ffbbd3;
+  border: 1px solid #ffbbd3;
 }
 
 .emotion-0:hover {
@@ -3225,6 +3917,8 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&info 
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&info 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render outlined&info disabled 1`] = `
 <DocumentFragment>
@@ -3279,23 +3973,7 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&info 
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render outlined&neutral 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3331,10 +4009,10 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&neutr
   paragraph-spacing: 0;
   text-case: none;
   background: none;
-  border: 1px solid #b5b7bd;
-  color: #3f4250;
-  color: #b5b7bd;
-  border: 1px solid #d9dadd;
+  border: 1px solid #005da3;
+  color: #005da3;
+  color: #9ad4ff;
+  border: 1px solid #9ad4ff;
 }
 
 .emotion-0:hover {
@@ -3359,6 +4037,8 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&neutr
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&neutral 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render outlined&neutral disabled 1`] = `
 <DocumentFragment>
@@ -3413,23 +4093,7 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&neutr
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render outlined&primary 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3465,10 +4129,10 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&prima
   paragraph-spacing: 0;
   text-case: none;
   background: none;
-  border: 1px solid #8c40ef;
-  color: #641cb3;
-  color: #d8c5fc;
-  border: 1px solid #d8c5fc;
+  border: 1px solid #b5b7bd;
+  color: #3f4250;
+  color: #b5b7bd;
+  border: 1px solid #d9dadd;
 }
 
 .emotion-0:hover {
@@ -3493,6 +4157,8 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&prima
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&primary 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render outlined&primary disabled 1`] = `
 <DocumentFragment>
@@ -3547,23 +4213,7 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&prima
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render outlined&secondary 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3599,10 +4249,10 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&secon
   paragraph-spacing: 0;
   text-case: none;
   background: none;
-  border: 1px solid #ac22e7;
-  color: #ac22e7;
-  color: #ebbcff;
-  border: 1px solid #ebbcff;
+  border: 1px solid #8c40ef;
+  color: #641cb3;
+  color: #d8c5fc;
+  border: 1px solid #d8c5fc;
 }
 
 .emotion-0:hover {
@@ -3627,6 +4277,8 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&secon
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&secondary 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render outlined&secondary disabled 1`] = `
 <DocumentFragment>
@@ -3681,23 +4333,7 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&secon
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render outlined&success 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3733,10 +4369,10 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&succe
   paragraph-spacing: 0;
   text-case: none;
   background: none;
-  border: 1px solid #22674e;
-  color: #22674e;
-  color: #7ee0bc;
-  border: 1px solid #7ee0bc;
+  border: 1px solid #ac22e7;
+  color: #ac22e7;
+  color: #ebbcff;
+  border: 1px solid #ebbcff;
 }
 
 .emotion-0:hover {
@@ -3761,6 +4397,8 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&succe
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&success 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render outlined&success disabled 1`] = `
 <DocumentFragment>
@@ -3815,23 +4453,7 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&succe
   stroke: transparent;
 }
 
-<div
-    data-testid="testing"
-  >
-    <button
-      class="emotion-0 emotion-1"
-      disabled=""
-      type="button"
-    >
-      Hello
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Button > variant-sentiment-disabled combination > render outlined&warning 1`] = `
-<DocumentFragment>
-  .emotion-0 {
+.emotion-0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3867,10 +4489,10 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&warni
   paragraph-spacing: 0;
   text-case: none;
   background: none;
-  border: 1px solid #7c5400;
-  color: #7c5400;
-  color: #ffdd5f;
-  border: 1px solid #ffdd5f;
+  border: 1px solid #22674e;
+  color: #22674e;
+  color: #7ee0bc;
+  border: 1px solid #7ee0bc;
 }
 
 .emotion-0:hover {
@@ -3895,6 +4517,8 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&warni
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&warning 1`] = `[Function]`;
 
 exports[`Button > variant-sentiment-disabled combination > render outlined&warning disabled 1`] = `
 <DocumentFragment>
@@ -3949,6 +4573,57 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&warni
   stroke: transparent;
 }
 
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: 1px solid #7c5400;
+  color: #7c5400;
+  color: #ffdd5f;
+  border: 1px solid #ffdd5f;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
 <div
     data-testid="testing"
   >
@@ -3962,3 +4637,125 @@ exports[`Button > variant-sentiment-disabled combination > render outlined&warni
   </div>
 </DocumentFragment>
 `;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&white 1`] = `[Function]`;
+
+exports[`Button > variant-sentiment-disabled combination > render outlined&white disabled 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: 1px solid #ffffff;
+  color: #ffffff;
+  color: #b5b7bd;
+  border: 1px solid #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  position: relative;
+  height: 3rem;
+  padding: 0 1rem;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  box-sizing: border-box;
+  width: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: not-allowed;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  outline-offset: 2px;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  paragraph-spacing: 0;
+  text-case: none;
+  background: none;
+  border: 1px solid #ffffff;
+  color: #ffffff;
+  color: #b5b7bd;
+  border: 1px solid #b5b7bd;
+}
+
+.emotion-0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-0 .e1y1n78x0 {
+  stroke: transparent;
+}
+
+<div
+    data-testid="testing"
+  >
+    <button
+      class="emotion-0 emotion-1"
+      disabled=""
+      type="button"
+    >
+      Hello
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Button > work with onPointerDown and onKeyDown 1`] = `[Function]`;

--- a/packages/ui/src/components/Button/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Button/__tests__/index.test.tsx
@@ -1,17 +1,20 @@
+import { screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { PencilIcon, PencilOutlineIcon } from '@ultraviolet/icons'
-import { shouldMatchEmotionSnapshot } from '@utils/test'
-import { describe, test } from 'vitest'
+import { renderWithTheme, shouldMatchEmotionSnapshot } from '@utils/test'
+import { describe, expect, test, vi } from 'vitest'
 import { Button, buttonSizes, buttonVariants } from '..'
 import { SENTIMENTS } from '../../../theme'
 
 const MockOnClick = () => {}
+const EXTENDED_SENTIMENTS = [...SENTIMENTS, 'black', 'white'] as const
 
 describe('Button', () => {
   describe('variant-sentiment-disabled combination', () => {
     buttonVariants.forEach(variant => {
-      SENTIMENTS.forEach(sentiment => {
-        test(`render ${variant}&${sentiment}`, () =>
-          shouldMatchEmotionSnapshot(
+      EXTENDED_SENTIMENTS.forEach(sentiment => {
+        test(`render ${variant}&${sentiment}`, async () => {
+          const { asFragment } = renderWithTheme(
             <Button
               onClick={MockOnClick}
               variant={variant}
@@ -20,7 +23,11 @@ describe('Button', () => {
             >
               Hello
             </Button>,
-          ))
+          )
+
+          await userEvent.hover(screen.getByRole('button'))
+          expect(asFragment).toMatchSnapshot()
+        })
         test(`render ${variant}&${sentiment} disabled`, () =>
           shouldMatchEmotionSnapshot(
             <Button
@@ -43,6 +50,29 @@ describe('Button', () => {
           Hello
         </Button>,
       ))
+  })
+
+  test(`work with onPointerDown and onKeyDown`, async () => {
+    const onPointerDown = vi.fn()
+    const onKeyDown = vi.fn()
+    const { asFragment } = renderWithTheme(
+      <Button
+        onPointerDown={onPointerDown}
+        onKeyDown={onKeyDown}
+        aria-describedby="test"
+        aria-disabled={false}
+        aria-pressed={false}
+        aria-roledescription="button"
+      >
+        Hello
+      </Button>,
+    )
+    await userEvent.click(screen.getByRole('button'))
+    expect(onPointerDown).toHaveBeenCalledOnce()
+    await userEvent.keyboard('a')
+    expect(onKeyDown).toHaveBeenCalledOnce()
+
+    expect(asFragment).toMatchSnapshot()
   })
 
   test(`render with icon`, () =>

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -115,21 +115,43 @@ const StyledFilledButton = styled('button', {
       ? theme.colors[sentiment].backgroundStrong
       : theme.colors.other.monochrome[sentiment].background};
   border: none;
-  color: ${({ theme, sentiment }) => (!isMonochrome(sentiment) ? theme.colors[sentiment].textStrong : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].text)};
+  color: ${({ theme, sentiment }) =>
+    !isMonochrome(sentiment)
+      ? theme.colors[sentiment].textStrong
+      : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white']
+          .text};
 
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
-            background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundStrongDisabled : theme.colors.other.monochrome[sentiment].backgroundDisabled};
+            background: ${
+              !isMonochrome(sentiment)
+                ? theme.colors[sentiment].backgroundStrongDisabled
+                : theme.colors.other.monochrome[sentiment].backgroundDisabled
+            };
             color:
-              ${!isMonochrome(sentiment) ? theme.colors[sentiment].textStrongDisabled : theme.colors.other.monochrome[sentiment].textDisabled};
+              ${
+                !isMonochrome(sentiment)
+                  ? theme.colors[sentiment].textStrongDisabled
+                  : theme.colors.other.monochrome[sentiment].textDisabled
+              };
         `
       : `
             &:hover, &:active
             {
-                background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundStrongHover : theme.colors.other.monochrome[sentiment].backgroundHover};
+                background: ${
+                  !isMonochrome(sentiment)
+                    ? theme.colors[sentiment].backgroundStrongHover
+                    : theme.colors.other.monochrome[sentiment].backgroundHover
+                };
                 color:
-                ${!isMonochrome(sentiment) ? theme.colors[sentiment].textStrongHover : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].textHover};
+                ${
+                  !isMonochrome(sentiment)
+                    ? theme.colors[sentiment].textStrongHover
+                    : theme.colors.other.monochrome[
+                        sentiment === 'white' ? 'black' : 'white'
+                      ].textHover
+                };
             }
   `}
 `
@@ -151,13 +173,20 @@ const StyledOutlinedButton = styled('button', {
             sentiment === 'neutral' ? 'borderStrong' : 'border'
           ]
         : theme.colors.other.monochrome[sentiment].border};
-  color: ${({ theme, sentiment }) => (!isMonochrome(sentiment) ? theme.colors[sentiment].text : theme.colors.other.monochrome[sentiment].text)};
+  color: ${({ theme, sentiment }) =>
+    !isMonochrome(sentiment)
+      ? theme.colors[sentiment].text
+      : theme.colors.other.monochrome[sentiment].text};
 
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
         color:
-          ${!isMonochrome(sentiment) ? theme.colors[sentiment].textDisabled : theme.colors.other.monochrome[sentiment].textDisabled};
+          ${
+            !isMonochrome(sentiment)
+              ? theme.colors[sentiment].textDisabled
+              : theme.colors.other.monochrome[sentiment].textDisabled
+          };
         border: 1px solid ${
           !isMonochrome(sentiment)
             ? theme.colors[sentiment][
@@ -172,9 +201,19 @@ const StyledOutlinedButton = styled('button', {
       : `
         &:hover, &:active
        {
-            background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundHover : theme.colors.other.monochrome[sentiment].backgroundHover};
+            background: ${
+              !isMonochrome(sentiment)
+                ? theme.colors[sentiment].backgroundHover
+                : theme.colors.other.monochrome[sentiment].backgroundHover
+            };
             color:
-            ${!isMonochrome(sentiment) ? theme.colors[sentiment].textHover : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].textHover};
+            ${
+              !isMonochrome(sentiment)
+                ? theme.colors[sentiment].textHover
+                : theme.colors.other.monochrome[
+                    sentiment === 'white' ? 'black' : 'white'
+                  ].textHover
+            };
             border: 1px solid ${
               !isMonochrome(sentiment)
                 ? theme.colors[sentiment][
@@ -200,20 +239,37 @@ const StyledGhostButton = styled('button', {
 
   background: none;
   border: none;
-  color: ${({ theme, sentiment }) => (!isMonochrome(sentiment) ? theme.colors[sentiment].text : theme.colors.other.monochrome[sentiment].text)};
+  color: ${({ theme, sentiment }) =>
+    !isMonochrome(sentiment)
+      ? theme.colors[sentiment].text
+      : theme.colors.other.monochrome[sentiment].text};
 
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
         color:
-          ${!isMonochrome(sentiment) ? theme.colors[sentiment].textDisabled : theme.colors.other.monochrome[sentiment].textDisabled};
+          ${
+            !isMonochrome(sentiment)
+              ? theme.colors[sentiment].textDisabled
+              : theme.colors.other.monochrome[sentiment].textDisabled
+          };
       `
       : `
         &:hover, &:active
         {
-            background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundHover : theme.colors.other.monochrome[sentiment].backgroundHover};
+            background: ${
+              !isMonochrome(sentiment)
+                ? theme.colors[sentiment].backgroundHover
+                : theme.colors.other.monochrome[sentiment].backgroundHover
+            };
             color:
-              ${!isMonochrome(sentiment) ? theme.colors[sentiment].textHover : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].textHover};
+              ${
+                !isMonochrome(sentiment)
+                  ? theme.colors[sentiment].textHover
+                  : theme.colors.other.monochrome[
+                      sentiment === 'white' ? 'black' : 'white'
+                    ].textHover
+              };
         }
 `}
 `
@@ -255,6 +311,10 @@ type CommonProps = {
   'aria-controls'?: string
   'aria-expanded'?: boolean
   'aria-haspopup'?: boolean
+  'aria-describedby'?: string
+  'aria-disabled'?: boolean
+  'aria-pressed'?: boolean
+  'aria-roledescription'?: string
   onClick?: MouseEventHandler<HTMLElement>
   tooltip?: string
   tabIndex?: ButtonHTMLAttributes<HTMLButtonElement>['tabIndex']
@@ -263,6 +323,8 @@ type CommonProps = {
   onMouseOut?: MouseEventHandler<HTMLElement>
   onMouseEnter?: MouseEventHandler<HTMLElement>
   onMouseLeave?: MouseEventHandler<HTMLElement>
+  onPointerDown?: ButtonHTMLAttributes<HTMLButtonElement>['onPointerDown']
+  onKeyDown?: ButtonHTMLAttributes<HTMLButtonElement>['onKeyDown']
 }
 
 type FinalProps = CommonProps & {
@@ -296,12 +358,18 @@ export const Button = forwardRef<Element, FinalProps>(
       onMouseOut,
       onMouseEnter,
       onMouseLeave,
+      onPointerDown,
+      onKeyDown,
       name,
       'aria-label': ariaLabel,
       'aria-current': ariaCurrent,
       'aria-controls': ariaControls,
       'aria-expanded': ariaExpanded,
       'aria-haspopup': ariaHaspopup,
+      'aria-describedby': ariaDescribedby,
+      'aria-disabled': ariaDisabled,
+      'aria-pressed': ariaPressed,
+      'aria-roledescription': ariaRoledescription,
       href,
       download,
       target,
@@ -354,6 +422,10 @@ export const Button = forwardRef<Element, FinalProps>(
             aria-controls={ariaControls}
             aria-expanded={ariaExpanded}
             aria-haspopup={ariaHaspopup}
+            aria-disabled={ariaDisabled ?? disabled}
+            aria-describedby={ariaDescribedby}
+            aria-pressed={ariaPressed}
+            aria-roledescription={ariaRoledescription}
             href={href}
             target={target}
             download={download}
@@ -400,6 +472,8 @@ export const Button = forwardRef<Element, FinalProps>(
           onMouseOut={onMouseOut}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
+          onPointerDown={onPointerDown}
+          onKeyDown={onKeyDown}
         >
           {content}
         </Component>

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -115,43 +115,21 @@ const StyledFilledButton = styled('button', {
       ? theme.colors[sentiment].backgroundStrong
       : theme.colors.other.monochrome[sentiment].background};
   border: none;
-  color: ${({ theme, sentiment }) =>
-    !isMonochrome(sentiment)
-      ? theme.colors[sentiment].textStrong
-      : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white']
-          .text};
+  color: ${({ theme, sentiment }) => (!isMonochrome(sentiment) ? theme.colors[sentiment].textStrong : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].text)};
 
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
-            background: ${
-              !isMonochrome(sentiment)
-                ? theme.colors[sentiment].backgroundStrongDisabled
-                : theme.colors.other.monochrome[sentiment].backgroundDisabled
-            };
+            background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundStrongDisabled : theme.colors.other.monochrome[sentiment].backgroundDisabled};
             color:
-              ${
-                !isMonochrome(sentiment)
-                  ? theme.colors[sentiment].textStrongDisabled
-                  : theme.colors.other.monochrome[sentiment].textDisabled
-              };
+              ${!isMonochrome(sentiment) ? theme.colors[sentiment].textStrongDisabled : theme.colors.other.monochrome[sentiment].textDisabled};
         `
       : `
             &:hover, &:active
             {
-                background: ${
-                  !isMonochrome(sentiment)
-                    ? theme.colors[sentiment].backgroundStrongHover
-                    : theme.colors.other.monochrome[sentiment].backgroundHover
-                };
+                background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundStrongHover : theme.colors.other.monochrome[sentiment].backgroundHover};
                 color:
-                ${
-                  !isMonochrome(sentiment)
-                    ? theme.colors[sentiment].textStrongHover
-                    : theme.colors.other.monochrome[
-                        sentiment === 'white' ? 'black' : 'white'
-                      ].textHover
-                };
+                ${!isMonochrome(sentiment) ? theme.colors[sentiment].textStrongHover : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].textHover};
             }
   `}
 `
@@ -173,20 +151,13 @@ const StyledOutlinedButton = styled('button', {
             sentiment === 'neutral' ? 'borderStrong' : 'border'
           ]
         : theme.colors.other.monochrome[sentiment].border};
-  color: ${({ theme, sentiment }) =>
-    !isMonochrome(sentiment)
-      ? theme.colors[sentiment].text
-      : theme.colors.other.monochrome[sentiment].text};
+  color: ${({ theme, sentiment }) => (!isMonochrome(sentiment) ? theme.colors[sentiment].text : theme.colors.other.monochrome[sentiment].text)};
 
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
         color:
-          ${
-            !isMonochrome(sentiment)
-              ? theme.colors[sentiment].textDisabled
-              : theme.colors.other.monochrome[sentiment].textDisabled
-          };
+          ${!isMonochrome(sentiment) ? theme.colors[sentiment].textDisabled : theme.colors.other.monochrome[sentiment].textDisabled};
         border: 1px solid ${
           !isMonochrome(sentiment)
             ? theme.colors[sentiment][
@@ -201,19 +172,9 @@ const StyledOutlinedButton = styled('button', {
       : `
         &:hover, &:active
        {
-            background: ${
-              !isMonochrome(sentiment)
-                ? theme.colors[sentiment].backgroundHover
-                : theme.colors.other.monochrome[sentiment].backgroundHover
-            };
+            background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundHover : theme.colors.other.monochrome[sentiment].backgroundHover};
             color:
-            ${
-              !isMonochrome(sentiment)
-                ? theme.colors[sentiment].textHover
-                : theme.colors.other.monochrome[
-                    sentiment === 'white' ? 'black' : 'white'
-                  ].textHover
-            };
+            ${!isMonochrome(sentiment) ? theme.colors[sentiment].textHover : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].textHover};
             border: 1px solid ${
               !isMonochrome(sentiment)
                 ? theme.colors[sentiment][
@@ -239,37 +200,20 @@ const StyledGhostButton = styled('button', {
 
   background: none;
   border: none;
-  color: ${({ theme, sentiment }) =>
-    !isMonochrome(sentiment)
-      ? theme.colors[sentiment].text
-      : theme.colors.other.monochrome[sentiment].text};
+  color: ${({ theme, sentiment }) => (!isMonochrome(sentiment) ? theme.colors[sentiment].text : theme.colors.other.monochrome[sentiment].text)};
 
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
         color:
-          ${
-            !isMonochrome(sentiment)
-              ? theme.colors[sentiment].textDisabled
-              : theme.colors.other.monochrome[sentiment].textDisabled
-          };
+          ${!isMonochrome(sentiment) ? theme.colors[sentiment].textDisabled : theme.colors.other.monochrome[sentiment].textDisabled};
       `
       : `
         &:hover, &:active
         {
-            background: ${
-              !isMonochrome(sentiment)
-                ? theme.colors[sentiment].backgroundHover
-                : theme.colors.other.monochrome[sentiment].backgroundHover
-            };
+            background: ${!isMonochrome(sentiment) ? theme.colors[sentiment].backgroundHover : theme.colors.other.monochrome[sentiment].backgroundHover};
             color:
-              ${
-                !isMonochrome(sentiment)
-                  ? theme.colors[sentiment].textHover
-                  : theme.colors.other.monochrome[
-                      sentiment === 'white' ? 'black' : 'white'
-                    ].textHover
-              };
+              ${!isMonochrome(sentiment) ? theme.colors[sentiment].textHover : theme.colors.other.monochrome[sentiment === 'white' ? 'black' : 'white'].textHover};
         }
 `}
 `

--- a/packages/ui/src/components/List/Row.tsx
+++ b/packages/ui/src/components/List/Row.tsx
@@ -4,7 +4,7 @@ import type { Theme } from '@emotion/react'
 import { keyframes, useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import { ArrowDownIcon, ArrowUpIcon } from '@ultraviolet/icons'
-import type { ReactNode, RefObject } from 'react'
+import type { CSSProperties, ReactNode, RefObject } from 'react'
 import {
   Children,
   forwardRef,
@@ -28,7 +28,8 @@ const ExpandableWrapper = styled.tr`
   vertical-align: middle;
   cursor: auto;
   background: ${({ theme }) => theme.colors.neutral.backgroundWeak};
-  border-radius: 0 0 ${({ theme }) => theme.radii.default} ${({ theme }) => theme.radii.default};
+  border-radius: 0 0 ${({ theme }) => theme.radii.default} ${({ theme }) =>
+    theme.radii.default};
   transform: translate3d(0, -${({ theme }) => theme.space['2']}, 0);
   position: relative;
 
@@ -41,7 +42,8 @@ const ExpandableWrapper = styled.tr`
   td {
     border: 1px solid ${({ theme }) => theme.colors.neutral.border};
     border-top: none;
-    border-radius: 0 0 ${({ theme }) => theme.radii.default} ${({ theme }) => theme.radii.default};
+    border-radius: 0 0 ${({ theme }) => theme.radii.default} ${({ theme }) =>
+      theme.radii.default};
   }
 `
 
@@ -71,14 +73,20 @@ const colorChange = (theme: Theme) => keyframes`
 
 export const StyledRow = styled('tr', {
   shouldForwardProp: prop =>
-    !['highlightAnimation', 'sentiment', 'columns', 'columnsStartAt'].includes(
-      prop,
-    ),
+    ![
+      'highlightAnimation',
+      'sentiment',
+      'columns',
+      'columnsStartAt',
+      'data-dragging',
+      'pointerEvent',
+    ].includes(prop),
 })<{
   sentiment: (typeof SENTIMENTS)[number]
   columns: ColumnProps[]
   columnsStartAt?: number
   highlightAnimation?: boolean
+  'data-dragging'?: boolean
 }>`
   /* List itself also apply style about common templating between HeaderRow and other Rows */
 
@@ -108,11 +116,13 @@ export const StyledRow = styled('tr', {
   }
   td:first-child {
     border-left: 1px solid ${({ theme }) => theme.colors.neutral.border};
-    border-radius: ${({ theme }) => theme.radii.default} 0 0 ${({ theme }) => theme.radii.default};
+    border-radius: ${({ theme }) => theme.radii.default} 0 0 ${({ theme }) =>
+      theme.radii.default};
   }
   td:last-child {
     border-right: 1px solid ${({ theme }) => theme.colors.neutral.border};
-    border-radius: 0 ${({ theme }) => theme.radii.default} ${({ theme }) => theme.radii.default} 0;
+    border-radius: 0 ${({ theme }) => theme.radii.default} ${({ theme }) =>
+      theme.radii.default} 0;
   }
 
   &:not([aria-disabled='true']):hover td, &:not([aria-disabled='true']):hover td:first-child, &:not([aria-disabled='true']):hover td:last-child {
@@ -206,7 +216,8 @@ const NoPaddingCell = styled(Cell, {
 const ExpandableCell = styled(Cell, {
   shouldForwardProp: prop => !['padding'].includes(prop),
 })<{ padding?: keyof typeof space }>`
-  padding: ${({ theme, padding }) => (padding ? theme.space[padding] : theme.space['2'])};
+  padding: ${({ theme, padding }) =>
+    padding ? theme.space[padding] : theme.space['2']};
 `
 
 type RowProps = {
@@ -227,6 +238,8 @@ type RowProps = {
   expandablePadding?: keyof typeof space
   highlightAnimation?: boolean
   'data-testid'?: string
+  style?: CSSProperties
+  'data-dragging'?: boolean
 }
 
 export const Row = forwardRef<HTMLTableRowElement, RowProps>(
@@ -243,6 +256,8 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
       className,
       expandablePadding,
       'data-testid': dataTestid,
+      style,
+      'data-dragging': dataDragging,
     },
     forwardedRef,
   ) => {
@@ -343,6 +358,8 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
           columns={columns}
           columnsStartAt={(selectable ? 1 : 0) + (expandButton ? 1 : 0)}
           highlightAnimation={highlightAnimation}
+          style={style}
+          data-dragging={dataDragging}
         >
           {selectable ? (
             <NoPaddingCell


### PR DESCRIPTION
## Summary

## Type

- Bug
### Summarise concisely:

#### What is expected?
Allow DND kit to work with `List` and `Button` : 
- `List.Row` now supports "style" and "data-dragging" props ;
- For Security group we don't display header but the List component add to much spaces ;
- Can disable overlay with `pointer-events: none` on `List.Row` ;
- List.Row do not allow data-dragging prop
- `Button` can have props "aria-describedby", "aria-disabled", "aria-pressed", "aria-roledescription", "onPointerDown" and "onKeyDown" to work with DND kit
