### PR TITLE
fix(Expandable): animation on first render

### DIFF
--- a/.changeset/tender-regions-share.md
+++ b/.changeset/tender-regions-share.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Expandable`: no animation on first render

--- a/packages/ui/src/components/Expandable/__stories__/NestedExpandable.stories.tsx
+++ b/packages/ui/src/components/Expandable/__stories__/NestedExpandable.stories.tsx
@@ -20,7 +20,7 @@ export const NestedExpandable: StoryFn<typeof Expandable> = args => {
       </Button>
       <Expandable opened={toggled}>
         <Button onClick={toggleNested}>
-          {toggled ? <MinusIcon /> : <PlusIcon />}
+          {toggledNested ? <MinusIcon /> : <PlusIcon />}
           Click me to {toggledNested ? 'hide' : 'show'} content
         </Button>
         <Expandable {...args} opened={toggledNested}>

--- a/packages/ui/src/components/Expandable/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Expandable/__tests__/__snapshots__/index.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Expandable > renders correctly opened 1`] = `
   >
     <div
       class="emotion-0 emotion-1"
-      data-is-animated="true"
+      data-is-animated="false"
     >
       Sample Expandable
     </div>
@@ -40,7 +40,8 @@ exports[`Expandable > renders correctly with animationDuration 1`] = `
   >
     <div
       class="emotion-0 emotion-1"
-      data-is-animated="true"
+      data-is-animated="false"
+      style="max-height: 0px; overflow: hidden;"
     >
       Sample Expandable
     </div>
@@ -78,7 +79,8 @@ exports[`Expandable > renders correctly with className 1`] = `
   >
     <div
       class="test emotion-0 emotion-1"
-      data-is-animated="true"
+      data-is-animated="false"
+      style="max-height: 0px; overflow: hidden;"
     >
       Sample Expandable
     </div>
@@ -102,7 +104,8 @@ exports[`Expandable > renders correctly with default values 1`] = `
   >
     <div
       class="emotion-0 emotion-1"
-      data-is-animated="true"
+      data-is-animated="false"
+      style="max-height: 0px; overflow: hidden;"
     >
       Sample Expandable
     </div>
@@ -126,7 +129,8 @@ exports[`Expandable > renders correctly with minHeight 1`] = `
   >
     <div
       class="emotion-0 emotion-1"
-      data-is-animated="true"
+      data-is-animated="false"
+      style="max-height: 5px; overflow: hidden;"
     >
       Sample Expandable
     </div>

--- a/packages/ui/src/components/Expandable/index.tsx
+++ b/packages/ui/src/components/Expandable/index.tsx
@@ -69,6 +69,14 @@ export const AnimatedExpandable = ({
   const ref = useRef<HTMLDivElement>(null)
   const shouldBeAnimated = animationDuration > 0
 
+  // To avoid expanded animation on first render
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (isFirstRender.current) isFirstRender.current = false
+    }, 0)
+  }, [])
   /**
    * At mount, we set the height variable to the height of the content only if the component is closed.
    * This is to ensure we don't have animation when the component is opened at mount.
@@ -85,7 +93,10 @@ export const AnimatedExpandable = ({
    * Setting it to initial is required to be able to have nested expandable or the height won't follow.
    */
   useEffect(() => {
-    if (opened && ref.current && height) {
+    if (isFirstRender.current && !opened && ref.current) {
+      ref.current.style.maxHeight = `${minHeight ?? 0}px`
+      ref.current.style.overflow = 'hidden'
+    } else if (opened && ref.current && height) {
       ref.current.style.maxHeight = `${height}px`
       ref.current.style.visibility = ''
       transitionTimer.current = setTimeout(() => {
@@ -129,7 +140,7 @@ export const AnimatedExpandable = ({
       ref={ref}
       className={className}
       animationDuration={animationDuration}
-      data-is-animated={shouldBeAnimated}
+      data-is-animated={shouldBeAnimated && !isFirstRender.current}
     >
       {children}
     </StyledExpandable>

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -465,7 +465,8 @@ exports[`Snippet > renders correctly in multiline  1`] = `
       >
         <div
           class="emotion-4 emotion-5"
-          data-is-animated="true"
+          data-is-animated="false"
+          style="max-height: 112px; overflow: hidden;"
         >
           <pre
             class="emotion-6 emotion-7 emotion-8"
@@ -827,7 +828,8 @@ exports[`Snippet > renders correctly in multiline with prefix command 1`] = `
       >
         <div
           class="emotion-4 emotion-5"
-          data-is-animated="true"
+          data-is-animated="false"
+          style="max-height: 112px; overflow: hidden;"
         >
           <pre
             class="emotion-6 emotion-7 emotion-8"
@@ -1190,7 +1192,8 @@ exports[`Snippet > renders correctly in multiline with prefix lines number 1`] =
       >
         <div
           class="emotion-4 emotion-5"
-          data-is-animated="true"
+          data-is-animated="false"
+          style="max-height: 112px; overflow: hidden;"
         >
           <pre
             class="emotion-6 emotion-7 emotion-8"
@@ -2392,7 +2395,8 @@ exports[`Snippet > renders correctly with hideText 1`] = `
       >
         <div
           class="emotion-4 emotion-5"
-          data-is-animated="true"
+          data-is-animated="false"
+          style="max-height: 112px; overflow: hidden;"
         >
           <pre
             class="emotion-6 emotion-7 emotion-8"
@@ -2943,7 +2947,7 @@ exports[`Snippet > renders correctly with initiallyExpanded 1`] = `
       >
         <div
           class="emotion-4 emotion-5"
-          data-is-animated="true"
+          data-is-animated="false"
         >
           <pre
             class="emotion-6 emotion-7 emotion-8"
@@ -3914,7 +3918,8 @@ exports[`Snippet > renders correctly with showText 1`] = `
       >
         <div
           class="emotion-4 emotion-5"
-          data-is-animated="true"
+          data-is-animated="false"
+          style="max-height: 112px; overflow: hidden;"
         >
           <pre
             class="emotion-6 emotion-7 emotion-8"
@@ -4941,6 +4946,7 @@ exports[`Snippet > should click on extend button to display full content on  1`]
         <div
           class="emotion-4 emotion-5"
           data-is-animated="true"
+          style="max-height: 112px; overflow: hidden;"
         >
           <pre
             class="emotion-6 emotion-7 emotion-8"


### PR DESCRIPTION
## Summary

## Type

- Bug
### Summarise concisely:

#### What is expected?
`Expandable`: no animation on first render


Before: 

https://github.com/user-attachments/assets/989e6072-39b3-41b8-8606-f9b9739ae855

After: 

https://github.com/user-attachments/assets/768433e4-8109-4a40-9382-af3a36dc0767