### PR TITLE
feat: remove deprecated props Card, Checkbox and Copybutton

### DIFF
--- a/.changeset/little-badgers-go.md
+++ b/.changeset/little-badgers-go.md
@@ -1,0 +1,10 @@
+---
+"@ultraviolet/ui": major
+---
+
+**BREAKING CHANGES**
+
+Deprecated props removed:
+- `Card`: prop "isActive" removed -> use "active" instead
+- `Checkbox`: props "progress" and "size" removed
+- `CopyButton`: prop "noBorder" removed -> use "bordered" instead

--- a/packages/form/src/components/CheckboxField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/CheckboxField/__tests__/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`CheckboxField > should render correctly 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -28,7 +28,7 @@ exports[`CheckboxField > should render correctly 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -101,7 +101,7 @@ exports[`CheckboxField > should render correctly 1`] = `
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -301,7 +301,7 @@ exports[`CheckboxField > should render correctly checked without value 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -310,7 +310,7 @@ exports[`CheckboxField > should render correctly checked without value 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -383,7 +383,7 @@ exports[`CheckboxField > should render correctly checked without value 1`] = `
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -584,7 +584,7 @@ exports[`CheckboxField > should render correctly disabled 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -593,7 +593,7 @@ exports[`CheckboxField > should render correctly disabled 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -666,7 +666,7 @@ exports[`CheckboxField > should render correctly disabled 1`] = `
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -867,7 +867,7 @@ exports[`CheckboxField > should render correctly not checked without value 1`] =
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -876,7 +876,7 @@ exports[`CheckboxField > should render correctly not checked without value 1`] =
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -949,7 +949,7 @@ exports[`CheckboxField > should render correctly not checked without value 1`] =
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1149,7 +1149,7 @@ exports[`CheckboxField > should render correctly with aria-label 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1158,7 +1158,7 @@ exports[`CheckboxField > should render correctly with aria-label 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1231,7 +1231,7 @@ exports[`CheckboxField > should render correctly with aria-label 1`] = `
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1432,7 +1432,7 @@ exports[`CheckboxField > should render correctly with errors 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1441,7 +1441,7 @@ exports[`CheckboxField > should render correctly with errors 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1514,7 +1514,7 @@ exports[`CheckboxField > should render correctly with errors 1`] = `
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1816,7 +1816,7 @@ exports[`CheckboxField > should trigger events correctly 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1825,7 +1825,7 @@ exports[`CheckboxField > should trigger events correctly 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1898,7 +1898,7 @@ exports[`CheckboxField > should trigger events correctly 1`] = `
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 

--- a/packages/form/src/components/CheckboxGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/CheckboxGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`CheckboxField > should render correctly checked 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-16 .eqr7bqq4 {
+.emotion-16 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -116,7 +116,7 @@ exports[`CheckboxField > should render correctly checked 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-16[aria-disabled='true'] .eqr7bqq4 {
+.emotion-16[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -189,7 +189,7 @@ exports[`CheckboxField > should render correctly checked 1`] = `
   stroke: #e51963;
 }
 
-.emotion-16 .emotion-19[aria-checked="mixed"]+.emotion-21 .eqr7bqq6 {
+.emotion-16 .emotion-19[aria-checked="mixed"]+.emotion-21 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -681,7 +681,7 @@ exports[`CheckboxField > should trigger events correctly with required prop 1`] 
   gap: 0.5rem;
 }
 
-.emotion-20 .eqr7bqq4 {
+.emotion-20 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -690,7 +690,7 @@ exports[`CheckboxField > should trigger events correctly with required prop 1`] 
   color: #b5b7bd;
 }
 
-.emotion-20[aria-disabled='true'] .eqr7bqq4 {
+.emotion-20[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -763,7 +763,7 @@ exports[`CheckboxField > should trigger events correctly with required prop 1`] 
   stroke: #e51963;
 }
 
-.emotion-20 .emotion-23[aria-checked="mixed"]+.emotion-25 .eqr7bqq6 {
+.emotion-20 .emotion-23[aria-checked="mixed"]+.emotion-25 .eqr7bqq5 {
   fill: #ffffff;
 }
 

--- a/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardField/__tests__/__snapshots__/index.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`SelectableCardField > should render correctly 1`] = `
 }
 
 .emotion-2[data-has-label='true'] .emotion-5,
-.emotion-2[data-has-label='true'] .eqr7bqq1 {
+.emotion-2[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -525,7 +525,7 @@ exports[`SelectableCardField > should render correctly checked 1`] = `
 }
 
 .emotion-2[data-has-label='true'] .emotion-5,
-.emotion-2[data-has-label='true'] .eqr7bqq1 {
+.emotion-2[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -967,7 +967,7 @@ exports[`SelectableCardField > should render correctly disabled 1`] = `
 }
 
 .emotion-2[data-has-label='true'] .emotion-5,
-.emotion-2[data-has-label='true'] .eqr7bqq1 {
+.emotion-2[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1408,7 +1408,7 @@ exports[`SelectableCardField > should render correctly with errors 1`] = `
 }
 
 .emotion-2[data-has-label='true'] .emotion-5,
-.emotion-2[data-has-label='true'] .eqr7bqq1 {
+.emotion-2[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1854,7 +1854,7 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
 }
 
 .emotion-2[data-has-label='true'] .emotion-5,
-.emotion-2[data-has-label='true'] .eqr7bqq1 {
+.emotion-2[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 

--- a/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`SelectableCardField > should render correctly 1`] = `
 }
 
 .emotion-13[data-has-label='true'] .emotion-16,
-.emotion-13[data-has-label='true'] .eqr7bqq1 {
+.emotion-13[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -751,7 +751,7 @@ exports[`SelectableCardField > should render correctly checked as a checkbox 1`]
   align-items: start;
 }
 
-.emotion-16 .eqr7bqq4 {
+.emotion-16 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -760,7 +760,7 @@ exports[`SelectableCardField > should render correctly checked as a checkbox 1`]
   color: #b5b7bd;
 }
 
-.emotion-16[aria-disabled='true'] .eqr7bqq4 {
+.emotion-16[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -833,7 +833,7 @@ exports[`SelectableCardField > should render correctly checked as a checkbox 1`]
   stroke: #e51963;
 }
 
-.emotion-16 .emotion-19[aria-checked="mixed"]+.emotion-21 .eqr7bqq6 {
+.emotion-16 .emotion-19[aria-checked="mixed"]+.emotion-21 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1342,7 +1342,7 @@ exports[`SelectableCardField > should render correctly checked as radiofield 1`]
 }
 
 .emotion-13[data-has-label='true'] .emotion-16,
-.emotion-13[data-has-label='true'] .eqr7bqq1 {
+.emotion-13[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1867,7 +1867,7 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
   align-items: start;
 }
 
-.emotion-16 .eqr7bqq4 {
+.emotion-16 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1876,7 +1876,7 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-16[aria-disabled='true'] .eqr7bqq4 {
+.emotion-16[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1949,7 +1949,7 @@ exports[`SelectableCardField > should trigger events correctly 1`] = `
   stroke: #e51963;
 }
 
-.emotion-16 .emotion-19[aria-checked="mixed"]+.emotion-21 .eqr7bqq6 {
+.emotion-16 .emotion-19[aria-checked="mixed"]+.emotion-21 .eqr7bqq5 {
   fill: #ffffff;
 }
 

--- a/packages/form/src/components/SelectableCardOptionGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardOptionGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`SelectableCardOptionGroupField > should render correctly 1`] = `
 }
 
 .emotion-14[data-has-label='true'] .emotion-17,
-.emotion-14[data-has-label='true'] .eqr7bqq1 {
+.emotion-14[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 

--- a/packages/form/src/components/SwitchButtonField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SwitchButtonField/__tests__/__snapshots__/index.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`SwitchButtonField > should render correctly 1`] = `
 }
 
 .emotion-7[data-has-label='true'] .emotion-10,
-.emotion-7[data-has-label='true'] .eqr7bqq1 {
+.emotion-7[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -701,7 +701,7 @@ exports[`SwitchButtonField > should works with defaultValues 1`] = `
 }
 
 .emotion-7[data-has-label='true'] .emotion-10,
-.emotion-7[data-has-label='true'] .eqr7bqq1 {
+.emotion-7[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 

--- a/packages/ui/src/components/Card/__stories__/Active.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/Active.stories.tsx
@@ -13,8 +13,8 @@ export const Active: StoryFn = args => {
     <Card {...args} header="Active Card" active={active}>
       <Stack gap={6} direction="row" justifyContent="space-between">
         <Text as="p" variant="body" sentiment={active ? 'primary' : 'neutral'}>
-          This card is currently highlighted through isActive prop. In this
-          example we use it to show the content is being edited.
+          This card is currently highlighted through <strong>active</strong>{' '}
+          prop. In this example we use it to show the content is being edited.
         </Text>
 
         {active ? (
@@ -47,7 +47,7 @@ export const Active: StoryFn = args => {
 Active.parameters = {
   docs: {
     description: {
-      story: 'You can highlight a Card by passing the `isActive` prop.',
+      story: 'You can highlight a Card by passing the `active` prop.',
     },
   },
 }

--- a/packages/ui/src/components/Card/index.tsx
+++ b/packages/ui/src/components/Card/index.tsx
@@ -14,10 +14,6 @@ type CardProps = {
   header?: ReactNode
   subHeader?: ReactNode
   /**
-   * @deprecated use `active` property instead
-   */
-  isActive?: boolean
-  /**
    * active enable a primary style on Card component for when you need to highlight it.
    */
   active?: boolean
@@ -57,7 +53,6 @@ export const Card = forwardRef(
       header,
       subHeader,
       disabled = false,
-      isActive = false,
       active = false,
       children,
       className,
@@ -86,10 +81,7 @@ export const Card = forwardRef(
         ) : (
           header
         )}
-        <BorderedBox
-          data-is-active={isActive || active}
-          data-disabled={disabled}
-        >
+        <BorderedBox data-is-active={active} data-disabled={disabled}>
           {subHeader ? (
             <Stack gap={2}>
               {typeof subHeader === 'string' ? (
@@ -113,7 +105,7 @@ export const Card = forwardRef(
       </StyledStack>
     ) : (
       <BorderedBox
-        data-is-active={active || isActive}
+        data-is-active={active}
         data-disabled={disabled}
         className={className}
         data-testid={dataTestId}

--- a/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Checkbox/__tests__/__snapshots__/index.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Checkbox > renders correctly 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -24,7 +24,7 @@ exports[`Checkbox > renders correctly 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -97,7 +97,7 @@ exports[`Checkbox > renders correctly 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -368,7 +368,7 @@ exports[`Checkbox > renders correctly checked 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -377,7 +377,7 @@ exports[`Checkbox > renders correctly checked 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -450,7 +450,7 @@ exports[`Checkbox > renders correctly checked 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -721,7 +721,7 @@ exports[`Checkbox > renders correctly checked and disabled 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -730,7 +730,7 @@ exports[`Checkbox > renders correctly checked and disabled 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -803,7 +803,7 @@ exports[`Checkbox > renders correctly checked and disabled 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1075,7 +1075,7 @@ exports[`Checkbox > renders correctly checked with helper 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1084,7 +1084,7 @@ exports[`Checkbox > renders correctly checked with helper 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1157,7 +1157,7 @@ exports[`Checkbox > renders correctly checked with helper 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1445,7 +1445,7 @@ exports[`Checkbox > renders correctly disabled 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1454,7 +1454,7 @@ exports[`Checkbox > renders correctly disabled 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1527,7 +1527,7 @@ exports[`Checkbox > renders correctly disabled 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1798,7 +1798,7 @@ exports[`Checkbox > renders correctly indeterminate 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1807,7 +1807,7 @@ exports[`Checkbox > renders correctly indeterminate 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2148,7 +2148,7 @@ exports[`Checkbox > renders correctly indeterminate and disabled 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2157,7 +2157,7 @@ exports[`Checkbox > renders correctly indeterminate and disabled 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2499,7 +2499,7 @@ exports[`Checkbox > renders correctly invisible 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2508,7 +2508,7 @@ exports[`Checkbox > renders correctly invisible 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2581,7 +2581,7 @@ exports[`Checkbox > renders correctly invisible 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -2852,7 +2852,7 @@ exports[`Checkbox > renders correctly no child 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2861,7 +2861,7 @@ exports[`Checkbox > renders correctly no child 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2934,7 +2934,7 @@ exports[`Checkbox > renders correctly no child 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3125,7 +3125,7 @@ exports[`Checkbox > renders correctly required 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -3134,7 +3134,7 @@ exports[`Checkbox > renders correctly required 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -3207,7 +3207,7 @@ exports[`Checkbox > renders correctly required 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3495,7 +3495,7 @@ exports[`Checkbox > renders correctly with a value 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -3504,7 +3504,7 @@ exports[`Checkbox > renders correctly with a value 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -3577,7 +3577,7 @@ exports[`Checkbox > renders correctly with a value 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3783,7 +3783,7 @@ exports[`Checkbox > renders correctly with a value 1`] = `
         aria-checked="false"
         aria-invalid="false"
         class="emotion-2 emotion-3"
-        id="«r1b»"
+        id="«r16»"
         type="checkbox"
         value="test"
       />
@@ -3822,7 +3822,7 @@ exports[`Checkbox > renders correctly with a value 1`] = `
         >
           <label
             class="emotion-12 emotion-13 emotion-14"
-            for="«r1b»"
+            for="«r16»"
           >
             Checkbox Label
           </label>
@@ -3848,7 +3848,7 @@ exports[`Checkbox > renders correctly with an error 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -3857,7 +3857,7 @@ exports[`Checkbox > renders correctly with an error 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -3930,7 +3930,7 @@ exports[`Checkbox > renders correctly with an error 1`] = `
   stroke: #e51963;
 }
 
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
+.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -4219,7 +4219,7 @@ exports[`Checkbox > renders correctly with indeterminate state 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-0 .eqr7bqq4 {
+.emotion-0 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -4228,7 +4228,7 @@ exports[`Checkbox > renders correctly with indeterminate state 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
+.emotion-0[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -4507,7 +4507,7 @@ exports[`Checkbox > renders correctly with indeterminate state 1`] = `
         aria-checked="mixed"
         aria-invalid="false"
         class="emotion-2 emotion-3"
-        id="«r1k»"
+        id="«r19»"
         type="checkbox"
       />
       <svg
@@ -4543,1085 +4543,7 @@ exports[`Checkbox > renders correctly with indeterminate state 1`] = `
         >
           <label
             class="emotion-14 emotion-15 emotion-16"
-            for="«r1k»"
-          >
-            Checkbox Label
-          </label>
-        </div>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Checkbox > renders correctly with progress 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.emotion-0 .eqr7bqq4 {
-  cursor: pointer;
-}
-
-.emotion-0[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
-  cursor: not-allowed;
-}
-
-.emotion-0[aria-disabled='true'] .eqr7bqq5 {
-  fill: #e9eaeb;
-}
-
-.emotion-0[aria-disabled='true'] .eqr7bqq5 .eqr7bqq7 {
-  stroke: #d9dadd;
-  fill: #f3f3f4;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.eqr7bqq5 {
-  fill: #ffd3e3;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #ffd3e3;
-  fill: #ffd3e3;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.eqr7bqq5 {
-  fill: #ffebf2;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #ffbbd3;
-  fill: #ffebf2;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10:checked+.eqr7bqq5 {
-  fill: #e5dbfd;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10:checked+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #d8c5fc;
-  fill: #d8c5fc;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.eqr7bqq5 {
-  fill: #e5dbfd;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #e5dbfd;
-  fill: #e5dbfd;
-}
-
-.emotion-0 .emotion-10:checked+.eqr7bqq5 path {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-}
-
-.emotion-0 .emotion-10:checked+.eqr7bqq5 .eqr7bqq7 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-0 .emotion-10[aria-invalid="true"]:checked+.eqr7bqq5 .eqr7bqq7 {
-  fill: #e51963;
-  stroke: #e51963;
-}
-
-.emotion-0 .emotion-10[aria-checked="mixed"]+.eqr7bqq5 .eqr7bqq6 {
-  fill: #ffffff;
-}
-
-.emotion-0 .emotion-10[aria-checked="mixed"]+.eqr7bqq5 .eqr7bqq7 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='false']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='true']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='false']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='true']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #d6175c;
-  fill: #d6175c;
-}
-
-.emotion-0 .emotion-10[aria-invalid="true"]+.eqr7bqq5 {
-  fill: #e51963;
-}
-
-.emotion-0 .emotion-10[aria-invalid="true"]+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #e51963;
-  fill: #ffebf2;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-4 {
-  -webkit-animation: spin 0.75s linear infinite;
-  animation: spin 0.75s linear infinite;
-}
-
-.emotion-6 {
-  stroke: #d9dadd;
-}
-
-.emotion-8 {
-  -webkit-transition: stroke-dashoffset 0.5s ease 0s;
-  transition: stroke-dashoffset 0.5s ease 0s;
-}
-
-.emotion-9 {
-  position: absolute;
-  white-space: nowrap;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  border-width: 0;
-}
-
-.emotion-9:not(:disabled) {
-  cursor: pointer;
-}
-
-.emotion-9:disabled {
-  cursor: not-allowed;
-}
-
-.emotion-9:not(:disabled):checked+.eqr7bqq5,
-.emotion-9:not(:disabled)[aria-checked='mixed']+.eqr7bqq5 {
-  fill: #8c40ef;
-}
-
-.emotion-9:not(:disabled):checked+.eqr7bqq5 .eqr7bqq7,
-.emotion-9:not(:disabled)[aria-checked='mixed']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #8c40ef;
-}
-
-.emotion-9:not(:disabled)[aria-invalid='true']+.eqr7bqq5,
-.emotion-9:not(:disabled)[aria-invalid='mixed']+.eqr7bqq5 {
-  fill: #ffebf2;
-}
-
-.emotion-9:not(:disabled)[aria-invalid='true']+.eqr7bqq5 .eqr7bqq7,
-.emotion-9:not(:disabled)[aria-invalid='mixed']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #b3144d;
-}
-
-.emotion-9:focus+.eqr7bqq5 {
-  background-color: #f1eefc;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
-}
-
-.emotion-9:focus+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-9[aria-invalid='true']:focus+.eqr7bqq5 {
-  background-color: #ffebf2;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
-}
-
-.emotion-9[aria-invalid='true']:focus+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-16 {
-  color: #3f4250;
-  font-size: 1rem;
-  font-family: Inter,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-  cursor: pointer;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      aria-disabled="true"
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-error="false"
-    >
-      <div
-        class="emotion-2 emotion-3"
-      >
-        <svg
-          aria-label="Loading"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="20"
-          aria-valuetext="20%"
-          class="emotion-4 emotion-5"
-          role="progressbar"
-          style="height: 1rem; width: 1rem;"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            class="emotion-6 emotion-7"
-            cx="50"
-            cy="50"
-            fill="none"
-            r="42"
-            stroke-width="16"
-          />
-          <circle
-            class="emotion-8"
-            cx="50"
-            cy="50"
-            fill="none"
-            r="42"
-            stroke="#8c40ef"
-            stroke-dasharray="263.89378290154264"
-            stroke-dashoffset="211.11502632123413"
-            stroke-linecap="round"
-            stroke-width="16"
-          />
-        </svg>
-      </div>
-      <input
-        aria-checked="false"
-        aria-invalid="false"
-        class="emotion-9 emotion-10"
-        disabled=""
-        id="«r16»"
-        type="checkbox"
-      />
-      <div
-        class="emotion-11 emotion-12"
-      >
-        <div
-          class="emotion-13 emotion-12"
-        >
-          <label
-            class="emotion-15 emotion-16 emotion-17"
-            for="«r16»"
-          >
-            Checkbox Label
-          </label>
-        </div>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Checkbox > renders correctly with progress and no child 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.emotion-0 .eqr7bqq4 {
-  cursor: pointer;
-}
-
-.emotion-0[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
-  cursor: not-allowed;
-}
-
-.emotion-0[aria-disabled='true'] .eqr7bqq5 {
-  fill: #e9eaeb;
-}
-
-.emotion-0[aria-disabled='true'] .eqr7bqq5 .eqr7bqq7 {
-  stroke: #d9dadd;
-  fill: #f3f3f4;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.eqr7bqq5 {
-  fill: #ffd3e3;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]:checked+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #ffd3e3;
-  fill: #ffd3e3;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.eqr7bqq5 {
-  fill: #ffebf2;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-invalid="true"]+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #ffbbd3;
-  fill: #ffebf2;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10:checked+.eqr7bqq5 {
-  fill: #e5dbfd;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10:checked+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #d8c5fc;
-  fill: #d8c5fc;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.eqr7bqq5 {
-  fill: #e5dbfd;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-10[aria-checked="mixed"]+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #e5dbfd;
-  fill: #e5dbfd;
-}
-
-.emotion-0 .emotion-10:checked+.eqr7bqq5 path {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-}
-
-.emotion-0 .emotion-10:checked+.eqr7bqq5 .eqr7bqq7 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-0 .emotion-10[aria-invalid="true"]:checked+.eqr7bqq5 .eqr7bqq7 {
-  fill: #e51963;
-  stroke: #e51963;
-}
-
-.emotion-0 .emotion-10[aria-checked="mixed"]+.eqr7bqq5 .eqr7bqq6 {
-  fill: #ffffff;
-}
-
-.emotion-0 .emotion-10[aria-checked="mixed"]+.eqr7bqq5 .eqr7bqq7 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='false']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='true']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='false'][aria-checked='mixed']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='false']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-10[aria-invalid='true'][aria-checked='true']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #d6175c;
-  fill: #d6175c;
-}
-
-.emotion-0 .emotion-10[aria-invalid="true"]+.eqr7bqq5 {
-  fill: #e51963;
-}
-
-.emotion-0 .emotion-10[aria-invalid="true"]+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #e51963;
-  fill: #ffebf2;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-4 {
-  -webkit-animation: spin 0.75s linear infinite;
-  animation: spin 0.75s linear infinite;
-}
-
-.emotion-6 {
-  stroke: #d9dadd;
-}
-
-.emotion-8 {
-  -webkit-transition: stroke-dashoffset 0.5s ease 0s;
-  transition: stroke-dashoffset 0.5s ease 0s;
-}
-
-.emotion-9 {
-  position: absolute;
-  white-space: nowrap;
-  height: 1.5rem;
-  width: 1.5rem;
-  opacity: 0;
-  border-width: 0;
-}
-
-.emotion-9:not(:disabled) {
-  cursor: pointer;
-}
-
-.emotion-9:disabled {
-  cursor: not-allowed;
-}
-
-.emotion-9:not(:disabled):checked+.eqr7bqq5,
-.emotion-9:not(:disabled)[aria-checked='mixed']+.eqr7bqq5 {
-  fill: #8c40ef;
-}
-
-.emotion-9:not(:disabled):checked+.eqr7bqq5 .eqr7bqq7,
-.emotion-9:not(:disabled)[aria-checked='mixed']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #8c40ef;
-}
-
-.emotion-9:not(:disabled)[aria-invalid='true']+.eqr7bqq5,
-.emotion-9:not(:disabled)[aria-invalid='mixed']+.eqr7bqq5 {
-  fill: #ffebf2;
-}
-
-.emotion-9:not(:disabled)[aria-invalid='true']+.eqr7bqq5 .eqr7bqq7,
-.emotion-9:not(:disabled)[aria-invalid='mixed']+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #b3144d;
-}
-
-.emotion-9:focus+.eqr7bqq5 {
-  background-color: #f1eefc;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
-}
-
-.emotion-9:focus+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-9[aria-invalid='true']:focus+.eqr7bqq5 {
-  background-color: #ffebf2;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
-}
-
-.emotion-9[aria-invalid='true']:focus+.eqr7bqq5 .eqr7bqq7 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      aria-disabled="true"
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-error="false"
-    >
-      <div
-        class="emotion-2 emotion-3"
-      >
-        <svg
-          aria-label="Loading"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="20"
-          aria-valuetext="20%"
-          class="emotion-4 emotion-5"
-          role="progressbar"
-          style="height: 1rem; width: 1rem;"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            class="emotion-6 emotion-7"
-            cx="50"
-            cy="50"
-            fill="none"
-            r="42"
-            stroke-width="16"
-          />
-          <circle
-            class="emotion-8"
-            cx="50"
-            cy="50"
-            fill="none"
-            r="42"
-            stroke="#8c40ef"
-            stroke-dasharray="263.89378290154264"
-            stroke-dashoffset="211.11502632123413"
-            stroke-linecap="round"
-            stroke-width="16"
-          />
-        </svg>
-      </div>
-      <input
-        aria-checked="false"
-        aria-invalid="false"
-        aria-label="check"
-        class="emotion-9 emotion-10"
-        disabled=""
-        id="«r19»"
-        type="checkbox"
-      />
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Checkbox > renders correctly with sizes 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.emotion-0 .eqr7bqq4 {
-  cursor: pointer;
-}
-
-.emotion-0[aria-disabled='true'] {
-  cursor: not-allowed;
-  color: #b5b7bd;
-}
-
-.emotion-0[aria-disabled='true'] .eqr7bqq4 {
-  cursor: not-allowed;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-5 {
-  fill: #e9eaeb;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-5 .emotion-7 {
-  stroke: #d9dadd;
-  fill: #f3f3f4;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3[aria-invalid="true"]:checked+.emotion-5 {
-  fill: #ffd3e3;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3[aria-invalid="true"]:checked+.emotion-5 .emotion-7 {
-  stroke: #ffd3e3;
-  fill: #ffd3e3;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3[aria-invalid="true"]+.emotion-5 {
-  fill: #ffebf2;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3[aria-invalid="true"]+.emotion-5 .emotion-7 {
-  stroke: #ffbbd3;
-  fill: #ffebf2;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3:checked+.emotion-5 {
-  fill: #e5dbfd;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3:checked+.emotion-5 .emotion-7 {
-  stroke: #d8c5fc;
-  fill: #d8c5fc;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3[aria-checked="mixed"]+.emotion-5 {
-  fill: #e5dbfd;
-}
-
-.emotion-0[aria-disabled='true'] .emotion-3[aria-checked="mixed"]+.emotion-5 .emotion-7 {
-  stroke: #e5dbfd;
-  fill: #e5dbfd;
-}
-
-.emotion-0 .emotion-3:checked+.emotion-5 path {
-  transform-origin: center;
-  -webkit-transition: 200ms -webkit-transform ease-in-out;
-  transition: 200ms transform ease-in-out;
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-}
-
-.emotion-0 .emotion-3:checked+.emotion-5 .emotion-7 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-0 .emotion-3[aria-invalid="true"]:checked+.emotion-5 .emotion-7 {
-  fill: #e51963;
-  stroke: #e51963;
-}
-
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .eqr7bqq6 {
-  fill: #ffffff;
-}
-
-.emotion-0 .emotion-3[aria-checked="mixed"]+.emotion-5 .emotion-7 {
-  fill: #8c40ef;
-  stroke: #8c40ef;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-3[aria-invalid='false'][aria-checked='false']+.emotion-5 .emotion-7 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-3[aria-invalid='false'][aria-checked='true']+.emotion-5 .emotion-7 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-3[aria-invalid='false'][aria-checked='mixed']+.emotion-5 .emotion-7 {
-  stroke: #792dd4;
-  fill: #792dd4;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-3[aria-invalid='true'][aria-checked='false']+.emotion-5 .emotion-7 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-0:hover[aria-disabled='false'] .emotion-3[aria-invalid='true'][aria-checked='true']+.emotion-5 .emotion-7 {
-  stroke: #d6175c;
-  fill: #d6175c;
-}
-
-.emotion-0 .emotion-3[aria-invalid="true"]+.emotion-5 {
-  fill: #e51963;
-}
-
-.emotion-0 .emotion-3[aria-invalid="true"]+.emotion-5 .emotion-7 {
-  stroke: #e51963;
-  fill: #ffebf2;
-}
-
-.emotion-2 {
-  position: absolute;
-  white-space: nowrap;
-  height: 37px;
-  width: 37px;
-  opacity: 0;
-  border-width: 0;
-}
-
-.emotion-2:not(:disabled) {
-  cursor: pointer;
-}
-
-.emotion-2:disabled {
-  cursor: not-allowed;
-}
-
-.emotion-2:not(:disabled):checked+.emotion-5,
-.emotion-2:not(:disabled)[aria-checked='mixed']+.emotion-5 {
-  fill: #8c40ef;
-}
-
-.emotion-2:not(:disabled):checked+.emotion-5 .emotion-7,
-.emotion-2:not(:disabled)[aria-checked='mixed']+.emotion-5 .emotion-7 {
-  stroke: #8c40ef;
-}
-
-.emotion-2:not(:disabled)[aria-invalid='true']+.emotion-5,
-.emotion-2:not(:disabled)[aria-invalid='mixed']+.emotion-5 {
-  fill: #ffebf2;
-}
-
-.emotion-2:not(:disabled)[aria-invalid='true']+.emotion-5 .emotion-7,
-.emotion-2:not(:disabled)[aria-invalid='mixed']+.emotion-5 .emotion-7 {
-  stroke: #b3144d;
-}
-
-.emotion-2:focus+.emotion-5 {
-  background-color: #f1eefc;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #8c40ef40;
-}
-
-.emotion-2:focus+.emotion-5 .emotion-7 {
-  stroke: #792dd4;
-  fill: #e5dbfd;
-}
-
-.emotion-2[aria-invalid='true']:focus+.emotion-5 {
-  background-color: #ffebf2;
-  fill: #ffebf2;
-  outline: 1px solid 0px 0px 0px 3px #f91b6c40;
-}
-
-.emotion-2[aria-invalid='true']:focus+.emotion-5 .emotion-7 {
-  stroke: #92103f;
-  fill: #ffd3e3;
-}
-
-.emotion-4 {
-  border-radius: 0.25rem;
-  height: 37px;
-  width: 37px;
-  min-width: 37px;
-  min-height: 37px;
-}
-
-.emotion-4 path {
-  fill: #ffffff;
-  -webkit-transform: translate(2px, 2px);
-  -moz-transform: translate(2px, 2px);
-  -ms-transform: translate(2px, 2px);
-  transform: translate(2px, 2px);
-  -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -ms-transform: scale(0);
-  transform: scale(0);
-}
-
-.emotion-6 {
-  fill: #ffffff;
-  stroke: #d9dadd;
-}
-
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 0.25rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-13 {
-  color: #3f4250;
-  font-size: 1rem;
-  font-family: Inter,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  width: 100%;
-  cursor: pointer;
-}
-
-.emotion-17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-19 {
-  -webkit-animation: spin 0.75s linear infinite;
-  animation: spin 0.75s linear infinite;
-}
-
-.emotion-21 {
-  stroke: #d9dadd;
-}
-
-.emotion-23 {
-  -webkit-transition: stroke-dashoffset 0.5s ease 0s;
-  transition: stroke-dashoffset 0.5s ease 0s;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      aria-disabled="false"
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-error="false"
-    >
-      <input
-        aria-checked="false"
-        aria-invalid="false"
-        class="emotion-2 emotion-3"
-        id="«r1e»"
-        type="checkbox"
-        value="test"
-      />
-      <svg
-        class="emotion-4 emotion-5"
-        fill="none"
-        size="37"
-        viewBox="0 0 24 24"
-      >
-        <g>
-          <rect
-            class="emotion-6 emotion-7"
-            height="16"
-            rx="0.125rem"
-            stroke-width="2"
-            width="16"
-            x="4"
-            y="4"
-          />
-          <path
-            clip-rule="evenodd"
-            d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
-            fill="white"
-            fill-rule="evenodd"
-            height="9"
-            width="12"
-            x="5"
-            y="4"
-          />
-        </g>
-      </svg>
-      <div
-        class="emotion-8 emotion-9"
-      >
-        <div
-          class="emotion-10 emotion-9"
-        >
-          <label
-            class="emotion-12 emotion-13 emotion-14"
-            for="«r1e»"
-          >
-            Checkbox Label
-          </label>
-        </div>
-      </div>
-    </div>
-    <div
-      aria-disabled="true"
-      class="emotion-0 emotion-1"
-      data-checked="false"
-      data-error="false"
-    >
-      <div
-        class="emotion-17 emotion-18"
-      >
-        <svg
-          aria-label="Loading"
-          aria-valuemax="100"
-          aria-valuemin="0"
-          aria-valuenow="20"
-          aria-valuetext="20%"
-          class="emotion-19 emotion-20"
-          role="progressbar"
-          style="height: 1rem; width: 1rem;"
-          viewBox="0 0 100 100"
-        >
-          <circle
-            class="emotion-21 emotion-22"
-            cx="50"
-            cy="50"
-            fill="none"
-            r="42"
-            stroke-width="16"
-          />
-          <circle
-            class="emotion-23"
-            cx="50"
-            cy="50"
-            fill="none"
-            r="42"
-            stroke="#8c40ef"
-            stroke-dasharray="263.89378290154264"
-            stroke-dashoffset="211.11502632123413"
-            stroke-linecap="round"
-            stroke-width="16"
-          />
-        </svg>
-      </div>
-      <input
-        aria-checked="false"
-        aria-invalid="false"
-        class="emotion-2 emotion-3"
-        disabled=""
-        id="«r1h»"
-        type="checkbox"
-        value="test"
-      />
-      <div
-        class="emotion-8 emotion-9"
-      >
-        <div
-          class="emotion-10 emotion-9"
-        >
-          <label
-            class="emotion-12 emotion-13 emotion-14"
-            for="«r1h»"
+            for="«r19»"
           >
             Checkbox Label
           </label>
@@ -5659,7 +4581,7 @@ exports[`Checkbox > renders correctly with tooltip 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-2 .eqr7bqq4 {
+.emotion-2 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -5668,7 +4590,7 @@ exports[`Checkbox > renders correctly with tooltip 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-2[aria-disabled='true'] .eqr7bqq4 {
+.emotion-2[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -5741,7 +4663,7 @@ exports[`Checkbox > renders correctly with tooltip 1`] = `
   stroke: #e51963;
 }
 
-.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq6 {
+.emotion-2 .emotion-5[aria-checked="mixed"]+.emotion-7 .eqr7bqq5 {
   fill: #ffffff;
 }
 

--- a/packages/ui/src/components/Checkbox/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Checkbox/__tests__/index.test.tsx
@@ -105,35 +105,11 @@ describe('Checkbox', () => {
       </Checkbox>,
     ))
 
-  test('renders correctly with progress', () =>
-    shouldMatchEmotionSnapshot(
-      <Checkbox onChange={() => {}} progress>
-        Checkbox Label
-      </Checkbox>,
-    ))
-
-  test('renders correctly with progress and no child', () =>
-    shouldMatchEmotionSnapshot(
-      <Checkbox aria-label="check" onChange={() => {}} progress />,
-    ))
-
   test('renders correctly with a value', () =>
     shouldMatchEmotionSnapshot(
       <Checkbox onChange={() => {}} value="test">
         Checkbox Label
       </Checkbox>,
-    ))
-
-  test('renders correctly with sizes', () =>
-    shouldMatchEmotionSnapshot(
-      <>
-        <Checkbox onChange={() => {}} size={37} value="test">
-          Checkbox Label
-        </Checkbox>
-        <Checkbox onChange={() => {}} progress size={37} value="test">
-          Checkbox Label
-        </Checkbox>
-      </>,
     ))
 
   test('renders correctly with indeterminate state', () =>
@@ -147,12 +123,7 @@ describe('Checkbox', () => {
     renderWithTheme(
       <LocalControlValue>
         {({ checked, onChange }) => (
-          <Checkbox
-            onChange={onChange}
-            checked={checked}
-            size={37}
-            value="test"
-          >
+          <Checkbox onChange={onChange} checked={checked} value="test">
             Checkbox Label
           </Checkbox>
         )}
@@ -162,33 +133,6 @@ describe('Checkbox', () => {
     const input = screen.getByRole<HTMLInputElement>('checkbox', {
       hidden: true,
     })
-    await userEvent.click(input)
-    expect(input.checked).toBeTruthy()
-  })
-
-  test('renders with click event with progress', async () => {
-    renderWithTheme(
-      <LocalControlValue defaultChecked={false}>
-        {({ checked, onChange }) => (
-          <Checkbox
-            checked={checked}
-            onChange={onChange}
-            size={37}
-            value="test"
-            progress={checked}
-          >
-            Checkbox Label
-          </Checkbox>
-        )}
-      </LocalControlValue>,
-    )
-
-    const input = screen.getByRole<HTMLInputElement>('checkbox', {
-      hidden: true,
-    })
-    await userEvent.click(input)
-    expect(input.checked).toBeTruthy()
-    // checked value cannot change during progress/loading
     await userEvent.click(input)
     expect(input.checked).toBeTruthy()
   })

--- a/packages/ui/src/components/Checkbox/index.tsx
+++ b/packages/ui/src/components/Checkbox/index.tsx
@@ -4,7 +4,6 @@ import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { InputHTMLAttributes, ReactNode } from 'react'
 import { forwardRef, useId } from 'react'
-import { Loader } from '../Loader'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
 import { Tooltip } from '../Tooltip'
@@ -65,8 +64,10 @@ export const CheckboxInput = styled('input', {
 })<{ inputSize: number | string }>`
   position: absolute;
   white-space: nowrap;
-  height: ${({ inputSize }) => (typeof inputSize === 'string' ? inputSize : `${inputSize}px`)};
-  width: ${({ inputSize }) => (typeof inputSize === 'string' ? inputSize : `${inputSize}px`)};
+  height: ${({ inputSize }) =>
+    typeof inputSize === 'string' ? inputSize : `${inputSize}px`};
+  width: ${({ inputSize }) =>
+    typeof inputSize === 'string' ? inputSize : `${inputSize}px`};
   opacity: 0;
   border-width: 0;
 
@@ -256,10 +257,6 @@ export const CheckboxContainer = styled.div`
   }
 `
 
-const StyledActivityContainer = styled.div`
-  display: flex;
-`
-
 type LabelProp =
   | {
       children: ReactNode
@@ -272,14 +269,6 @@ type LabelProp =
 
 type CheckboxProps = {
   error?: string | ReactNode
-  /**
-   * @deprecated Size prop is deprecated and will be removed in next major update.
-   */
-  size?: number
-  /**
-   * @deprecated Progress prop is deprecated and will be removed in next major update.
-   */
-  progress?: boolean
   helper?: ReactNode
   disabled?: boolean
   checked?: boolean | 'indeterminate'
@@ -317,9 +306,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       name,
       helper,
       value,
-      size,
       children,
-      progress = false,
       disabled = false,
       autoFocus = false,
       className,
@@ -336,25 +323,18 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const uniqId = useId()
     const localId = id ?? uniqId
 
-    const isDisabled = disabled || progress
     const isCheck = checked === true ? checked : false
 
     return (
       <Tooltip text={tooltip}>
         <CheckboxContainer
           className={className}
-          aria-disabled={isDisabled}
+          aria-disabled={disabled}
           data-visibility={dataVisibility}
           data-checked={checked}
           data-error={!!error}
           data-testid={dataTestId}
         >
-          {progress ? (
-            <StyledActivityContainer>
-              <Loader active size="small" />
-            </StyledActivityContainer>
-          ) : null}
-
           <CheckboxInput
             id={localId}
             type="checkbox"
@@ -363,11 +343,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             aria-checked={checked === 'indeterminate' ? 'mixed' : isCheck}
             aria-label={ariaLabel}
             checked={isCheck}
-            inputSize={size ?? theme.sizing['300']}
+            inputSize={theme.sizing['300']}
             onChange={onChange}
             onFocus={onFocus}
             onBlur={onBlur}
-            disabled={isDisabled}
+            disabled={disabled}
             value={value}
             name={name}
             autoFocus={autoFocus}
@@ -376,30 +356,28 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             tabIndex={tabIndex}
           />
 
-          {!progress ? (
-            <StyledIcon
-              size={size ?? theme.sizing['300']}
-              viewBox="0 0 24 24"
-              fill="none"
-            >
-              <CheckboxIconContainer>
-                {checked !== 'indeterminate' ? (
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    width={12}
-                    height={9}
-                    x="5"
-                    y="4"
-                    d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
-                    fill="white"
-                  />
-                ) : (
-                  <CheckMixedMark x="6" y="11" rx="1" width="12" height="2" />
-                )}
-              </CheckboxIconContainer>
-            </StyledIcon>
-          ) : null}
+          <StyledIcon
+            size={theme.sizing['300']}
+            viewBox="0 0 24 24"
+            fill="none"
+          >
+            <CheckboxIconContainer>
+              {checked !== 'indeterminate' ? (
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  width={12}
+                  height={9}
+                  x="5"
+                  y="4"
+                  d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
+                  fill="white"
+                />
+              ) : (
+                <CheckMixedMark x="6" y="11" rx="1" width="12" height="2" />
+              )}
+            </CheckboxIconContainer>
+          </StyledIcon>
 
           {!children && !required && !helper && !error ? null : (
             <Stack gap={0.5} flex={1}>

--- a/packages/ui/src/components/CheckboxGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/CheckboxGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`CheckboxGroup > renders correctly 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -112,7 +112,7 @@ exports[`CheckboxGroup > renders correctly 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -185,7 +185,7 @@ exports[`CheckboxGroup > renders correctly 1`] = `
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -656,7 +656,7 @@ exports[`CheckboxGroup > renders correctly with direction row 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -665,7 +665,7 @@ exports[`CheckboxGroup > renders correctly with direction row 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -738,7 +738,7 @@ exports[`CheckboxGroup > renders correctly with direction row 1`] = `
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1186,7 +1186,7 @@ exports[`CheckboxGroup > renders correctly with error content 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1195,7 +1195,7 @@ exports[`CheckboxGroup > renders correctly with error content 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1268,7 +1268,7 @@ exports[`CheckboxGroup > renders correctly with error content 1`] = `
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1735,7 +1735,7 @@ exports[`CheckboxGroup > renders correctly with helper content 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1744,7 +1744,7 @@ exports[`CheckboxGroup > renders correctly with helper content 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1817,7 +1817,7 @@ exports[`CheckboxGroup > renders correctly with helper content 1`] = `
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -2282,7 +2282,7 @@ exports[`CheckboxGroup > renders correctly with no CheckboxGroup.Checkbox name 1
   gap: 0.5rem;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2291,7 +2291,7 @@ exports[`CheckboxGroup > renders correctly with no CheckboxGroup.Checkbox name 1
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2364,7 +2364,7 @@ exports[`CheckboxGroup > renders correctly with no CheckboxGroup.Checkbox name 1
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -2847,7 +2847,7 @@ exports[`CheckboxGroup > renders correctly with required prop 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-18 .eqr7bqq4 {
+.emotion-18 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2856,7 +2856,7 @@ exports[`CheckboxGroup > renders correctly with required prop 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-18[aria-disabled='true'] .eqr7bqq4 {
+.emotion-18[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2929,7 +2929,7 @@ exports[`CheckboxGroup > renders correctly with required prop 1`] = `
   stroke: #e51963;
 }
 
-.emotion-18 .emotion-21[aria-checked="mixed"]+.emotion-23 .eqr7bqq6 {
+.emotion-18 .emotion-21[aria-checked="mixed"]+.emotion-23 .eqr7bqq5 {
   fill: #ffffff;
 }
 

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -953,8 +953,8 @@ exports[`CopyButton > renders correctly with bordered 1`] = `
     data-testid="testing"
   >
     <div
-      aria-controls="«r9»"
-      aria-describedby="«r9»"
+      aria-controls="«r7»"
+      aria-describedby="«r7»"
       class="emotion-0 emotion-1"
       data-container-full-width="false"
       tabindex="0"
@@ -1200,8 +1200,8 @@ exports[`CopyButton > renders correctly with custom class name 1`] = `
     data-testid="testing"
   >
     <div
-      aria-controls="«rc»"
-      aria-describedby="«rc»"
+      aria-controls="«rb»"
+      aria-describedby="«rb»"
       class="emotion-0 emotion-1"
       data-container-full-width="false"
       tabindex="0"
@@ -1233,129 +1233,6 @@ exports[`CopyButton > renders correctly with custom class name 1`] = `
 `;
 
 exports[`CopyButton > renders correctly with custom copied text 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  display: inherit;
-}
-
-.emotion-0[data-container-full-height="true"] {
-  height: 100%;
-}
-
-.emotion-0[data-container-full-width="true"] {
-  width: 100%;
-}
-
-.emotion-2 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  position: relative;
-  height: 2rem;
-  padding: 0 0.5rem;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: 0.5rem;
-  border-radius: 0.25rem;
-  box-sizing: border-box;
-  width: auto;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  outline-offset: 2px;
-  white-space: nowrap;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-size: 0.875rem;
-  font-family: Inter,sans-serif;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 1.25rem;
-  paragraph-spacing: 0;
-  text-case: none;
-  background: none;
-  border: none;
-  color: #641cb3;
-}
-
-.emotion-2:hover {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.emotion-2:active {
-  box-shadow: 0px 0px 0px 3px #8c40ef40;
-}
-
-.emotion-2 .e1y1n78x0 {
-  stroke: transparent;
-}
-
-.emotion-2:hover,
-.emotion-2:active {
-  background: #e5dbfd;
-  color: #521094;
-}
-
-.emotion-4 {
-  vertical-align: middle;
-  fill: currentColor;
-  height: 1rem;
-  width: 1rem;
-  min-width: 1rem;
-  min-height: 1rem;
-}
-
-.emotion-4 .fillStroke {
-  stroke: currentColor;
-  fill: none;
-}
-
-<div
-    data-testid="testing"
-  >
-    <div
-      aria-controls="«rb»"
-      aria-describedby="«rb»"
-      class="emotion-0 emotion-1"
-      data-container-full-width="false"
-      tabindex="0"
-    >
-      <button
-        aria-label="Copy"
-        class="emotion-2 emotion-3"
-        type="button"
-      >
-        <svg
-          class="emotion-4 emotion-5"
-          viewBox="0 0 16 16"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M6.026 5.007A.1.1 0 0 0 6 5.084v8.333a.1.1 0 0 0 .026.076l.008.007h6.765l.008-.007a.1.1 0 0 0 .026-.076V5.084a.1.1 0 0 0-.026-.077L12.799 5H6.034zM4.5 5.084c0-.828.64-1.584 1.531-1.584h6.77c.891 0 1.532.756 1.532 1.584v8.333c0 .828-.64 1.583-1.531 1.583H6.03c-.89 0-1.531-.755-1.531-1.583z"
-            fill-rule="evenodd"
-          />
-          <path
-            clip-rule="evenodd"
-            d="M3.526 2.507a.1.1 0 0 0-.026.076v8.333a.75.75 0 0 1-1.5 0V2.583C2 1.755 2.64 1 3.531 1h6.77c.891 0 1.532.755 1.532 1.583a.75.75 0 0 1-1.5 0 .1.1 0 0 0-.026-.076L10.3 2.5H3.534z"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </button>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`CopyButton > renders correctly with custom copy text 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: inherit;
@@ -1478,7 +1355,7 @@ exports[`CopyButton > renders correctly with custom copy text 1`] = `
 </DocumentFragment>
 `;
 
-exports[`CopyButton > renders correctly with no border 1`] = `
+exports[`CopyButton > renders correctly with custom copy text 1`] = `
 <DocumentFragment>
   .emotion-0 {
   display: inherit;
@@ -1569,8 +1446,8 @@ exports[`CopyButton > renders correctly with no border 1`] = `
     data-testid="testing"
   >
     <div
-      aria-controls="«r7»"
-      aria-describedby="«r7»"
+      aria-controls="«r9»"
+      aria-describedby="«r9»"
       class="emotion-0 emotion-1"
       data-container-full-width="false"
       tabindex="0"

--- a/packages/ui/src/components/CopyButton/__tests__/index.test.tsx
+++ b/packages/ui/src/components/CopyButton/__tests__/index.test.tsx
@@ -30,14 +30,11 @@ describe('CopyButton', () => {
       ))
   })
 
-  test('renders correctly with no border', () =>
-    shouldMatchEmotionSnapshot(<CopyButton value="Test" noBorder />))
+  test('renders correctly with bordered', () =>
+    shouldMatchEmotionSnapshot(<CopyButton value="Test" bordered />))
 
   test('renders correctly with children', () =>
     shouldMatchEmotionSnapshot(<CopyButton value="Test">Copy test</CopyButton>))
-
-  test('renders correctly with bordered', () =>
-    shouldMatchEmotionSnapshot(<CopyButton value="Test" bordered />))
 
   test('renders correctly with custom copy text', () =>
     shouldMatchEmotionSnapshot(<CopyButton value="Test" copyText="Copy me" />))

--- a/packages/ui/src/components/CopyButton/index.tsx
+++ b/packages/ui/src/components/CopyButton/index.tsx
@@ -12,10 +12,6 @@ type CopyButtonProps = {
   copyText?: string
   copiedText?: string
   sentiment?: 'primary' | 'neutral'
-  /**
-   * @deprecated Use `bordered` instead
-   */
-  noBorder?: boolean
   bordered?: boolean
   className?: string
   'data-testid'?: string
@@ -32,7 +28,6 @@ export const CopyButton = ({
   copyText = 'Copy',
   copiedText = 'Copied!',
   sentiment = 'primary',
-  noBorder,
   bordered,
   className,
   children,
@@ -52,7 +47,7 @@ export const CopyButton = ({
       }}
       size={size}
       sentiment={sentiment}
-      variant={noBorder || !bordered ? 'ghost' : 'outlined'}
+      variant={!bordered ? 'ghost' : 'outlined'}
       className={className}
       data-testid={dataTestId}
       aria-label="Copy"

--- a/packages/ui/src/components/LineChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/LineChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`LineChart > renders correctly when data is async 1`] = `
   stroke: #e51963;
 }
 
-.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq6 {
+.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -361,7 +361,7 @@ exports[`LineChart > renders correctly when data is async 1`] = `
   stroke: #e51963;
 }
 
-.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq6 {
+.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1376,7 +1376,7 @@ exports[`LineChart > renders correctly when legend is deselected 1`] = `
   stroke: #e51963;
 }
 
-.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq6 {
+.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1514,7 +1514,7 @@ exports[`LineChart > renders correctly when legend is deselected 1`] = `
   stroke: #e51963;
 }
 
-.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq6 {
+.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -2279,7 +2279,7 @@ exports[`LineChart > renders correctly with detailed legend 1`] = `
   stroke: #e51963;
 }
 
-.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq6 {
+.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -2821,7 +2821,7 @@ exports[`LineChart > renders correctly with multiple series 1`] = `
   stroke: #e51963;
 }
 
-.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq6 {
+.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3587,7 +3587,7 @@ exports[`LineChart > renders correctly with timeline data 1`] = `
   stroke: #e51963;
 }
 
-.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq6 {
+.emotion-21 .emotion-24[aria-checked="mixed"]+.emotion-26 .eqr7bqq5 {
   fill: #ffffff;
 }
 

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -7086,7 +7086,7 @@ exports[`List > Should render correctly with loading with selectable 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -7095,7 +7095,7 @@ exports[`List > Should render correctly with loading with selectable 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -7168,7 +7168,7 @@ exports[`List > Should render correctly with loading with selectable 1`] = `
   stroke: #e51963;
 }
 
-.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -9398,7 +9398,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -9407,7 +9407,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -9480,7 +9480,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   stroke: #e51963;
 }
 
-.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -9756,7 +9756,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-47 .eqr7bqq4 {
+.emotion-47 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -9765,7 +9765,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-47[aria-disabled='true'] .eqr7bqq4 {
+.emotion-47[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -9838,7 +9838,7 @@ exports[`List > Should render correctly with selectable 1`] = `
   stroke: #e51963;
 }
 
-.emotion-47 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-47 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -11005,7 +11005,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -11014,7 +11014,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -11087,7 +11087,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   stroke: #e51963;
 }
 
-.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -11143,7 +11143,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -11152,7 +11152,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -11225,7 +11225,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   stroke: #e51963;
 }
 
-.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -11721,7 +11721,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   gap: 0.5rem;
 }
 
-.emotion-47 .eqr7bqq4 {
+.emotion-47 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -11730,7 +11730,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #b5b7bd;
 }
 
-.emotion-47[aria-disabled='true'] .eqr7bqq4 {
+.emotion-47[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -11803,7 +11803,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   stroke: #e51963;
 }
 
-.emotion-47 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-47 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -11859,7 +11859,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   gap: 0.5rem;
 }
 
-.emotion-47 .eqr7bqq4 {
+.emotion-47 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -11868,7 +11868,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   color: #b5b7bd;
 }
 
-.emotion-47[aria-disabled='true'] .eqr7bqq4 {
+.emotion-47[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -11941,7 +11941,7 @@ exports[`List > Should render correctly with selectable then click on first row 
   stroke: #e51963;
 }
 
-.emotion-47 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-47 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -13115,7 +13115,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -13124,7 +13124,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -13253,7 +13253,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -13262,7 +13262,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -13831,7 +13831,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   gap: 0.5rem;
 }
 
-.emotion-49 .eqr7bqq4 {
+.emotion-49 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -13840,7 +13840,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #b5b7bd;
 }
 
-.emotion-49[aria-disabled='true'] .eqr7bqq4 {
+.emotion-49[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -13969,7 +13969,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   gap: 0.5rem;
 }
 
-.emotion-49 .eqr7bqq4 {
+.emotion-49 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -13978,7 +13978,7 @@ exports[`List > Should render correctly with selectable with shift click for mul
   color: #b5b7bd;
 }
 
-.emotion-49[aria-disabled='true'] .eqr7bqq4 {
+.emotion-49[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`SelectableCard > checkbox > renders correctly with aria label 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -652,7 +652,7 @@ exports[`SelectableCard > checkbox > renders correctly with checked prop 1`] = `
   align-items: start;
 }
 
-.emotion-3 .eqr7bqq4 {
+.emotion-3 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -661,7 +661,7 @@ exports[`SelectableCard > checkbox > renders correctly with checked prop 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
+.emotion-3[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -734,7 +734,7 @@ exports[`SelectableCard > checkbox > renders correctly with checked prop 1`] = `
   stroke: #e51963;
 }
 
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1243,7 +1243,7 @@ exports[`SelectableCard > checkbox > renders correctly with complex children 1`]
   align-items: start;
 }
 
-.emotion-3 .eqr7bqq4 {
+.emotion-3 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1252,7 +1252,7 @@ exports[`SelectableCard > checkbox > renders correctly with complex children 1`]
   color: #b5b7bd;
 }
 
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
+.emotion-3[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1325,7 +1325,7 @@ exports[`SelectableCard > checkbox > renders correctly with complex children 1`]
   stroke: #e51963;
 }
 
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -1805,7 +1805,7 @@ exports[`SelectableCard > checkbox > renders correctly with default props 1`] = 
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1887,7 +1887,7 @@ exports[`SelectableCard > checkbox > renders correctly with default props 1`] = 
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -2611,7 +2611,7 @@ exports[`SelectableCard > checkbox > renders correctly with disabled prop 1`] = 
   align-items: start;
 }
 
-.emotion-3 .eqr7bqq4 {
+.emotion-3 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2620,7 +2620,7 @@ exports[`SelectableCard > checkbox > renders correctly with disabled prop 1`] = 
   color: #b5b7bd;
 }
 
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
+.emotion-3[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2693,7 +2693,7 @@ exports[`SelectableCard > checkbox > renders correctly with disabled prop 1`] = 
   stroke: #e51963;
 }
 
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3255,7 +3255,7 @@ exports[`SelectableCard > checkbox > renders correctly with illustration 1`] = `
   align-items: start;
 }
 
-.emotion-7 .eqr7bqq4 {
+.emotion-7 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -3264,7 +3264,7 @@ exports[`SelectableCard > checkbox > renders correctly with illustration 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-7[aria-disabled='true'] .eqr7bqq4 {
+.emotion-7[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -3337,7 +3337,7 @@ exports[`SelectableCard > checkbox > renders correctly with illustration 1`] = `
   stroke: #e51963;
 }
 
-.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq6 {
+.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3991,7 +3991,7 @@ exports[`SelectableCard > checkbox > renders correctly with isError prop 1`] = `
   align-items: start;
 }
 
-.emotion-3 .eqr7bqq4 {
+.emotion-3 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -4000,7 +4000,7 @@ exports[`SelectableCard > checkbox > renders correctly with isError prop 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
+.emotion-3[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -4073,7 +4073,7 @@ exports[`SelectableCard > checkbox > renders correctly with isError prop 1`] = `
   stroke: #e51963;
 }
 
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -4712,7 +4712,7 @@ exports[`SelectableCard > checkbox > renders correctly with productIcon 1`] = `
   align-items: start;
 }
 
-.emotion-7 .eqr7bqq4 {
+.emotion-7 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -4721,7 +4721,7 @@ exports[`SelectableCard > checkbox > renders correctly with productIcon 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-7[aria-disabled='true'] .eqr7bqq4 {
+.emotion-7[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -4794,7 +4794,7 @@ exports[`SelectableCard > checkbox > renders correctly with productIcon 1`] = `
   stroke: #e51963;
 }
 
-.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq6 {
+.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -5393,7 +5393,7 @@ exports[`SelectableCard > checkbox > renders correctly with showTick 1`] = `
   align-items: start;
 }
 
-.emotion-3 .eqr7bqq4 {
+.emotion-3 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -5402,7 +5402,7 @@ exports[`SelectableCard > checkbox > renders correctly with showTick 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-3[aria-disabled='true'] .eqr7bqq4 {
+.emotion-3[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -5475,7 +5475,7 @@ exports[`SelectableCard > checkbox > renders correctly with showTick 1`] = `
   stroke: #e51963;
 }
 
-.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq6 {
+.emotion-3 .emotion-6[aria-checked="mixed"]+.emotion-8 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -6013,7 +6013,7 @@ exports[`SelectableCard > checkbox > renders correctly with tooltip prop 1`] = `
   align-items: start;
 }
 
-.emotion-7 .eqr7bqq4 {
+.emotion-7 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -6022,7 +6022,7 @@ exports[`SelectableCard > checkbox > renders correctly with tooltip prop 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-7[aria-disabled='true'] .eqr7bqq4 {
+.emotion-7[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -6095,7 +6095,7 @@ exports[`SelectableCard > checkbox > renders correctly with tooltip prop 1`] = `
   stroke: #e51963;
 }
 
-.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq6 {
+.emotion-7 .emotion-10[aria-checked="mixed"]+.emotion-12 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -6583,7 +6583,7 @@ exports[`SelectableCard > radio > renders correctly with aria label 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -6997,7 +6997,7 @@ exports[`SelectableCard > radio > renders correctly with checked prop 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -7412,7 +7412,7 @@ exports[`SelectableCard > radio > renders correctly with complex children 1`] = 
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -7846,7 +7846,7 @@ exports[`SelectableCard > radio > renders correctly with default props 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -8276,7 +8276,7 @@ exports[`SelectableCard > radio > renders correctly with disabled prop 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -8690,7 +8690,7 @@ exports[`SelectableCard > radio > renders correctly with illustration 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-7,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -9245,7 +9245,7 @@ exports[`SelectableCard > radio > renders correctly with isError prop 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -9677,7 +9677,7 @@ exports[`SelectableCard > radio > renders correctly with productIcon 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-7,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -10259,7 +10259,7 @@ exports[`SelectableCard > radio > renders correctly with showTick 1`] = `
 }
 
 .emotion-0[data-has-label='true'] .emotion-3,
-.emotion-0[data-has-label='true'] .eqr7bqq1 {
+.emotion-0[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -10703,7 +10703,7 @@ exports[`SelectableCard > radio > renders correctly with tooltip prop 1`] = `
 }
 
 .emotion-4[data-has-label='true'] .emotion-7,
-.emotion-4[data-has-label='true'] .eqr7bqq1 {
+.emotion-4[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 

--- a/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
   align-items: start;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -193,7 +193,7 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -266,7 +266,7 @@ exports[`SelectableCardGroup > renders correctly 1`] = `
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -836,7 +836,7 @@ exports[`SelectableCardGroup > renders correctly as a radio 1`] = `
 }
 
 .emotion-11[data-has-label='true'] .emotion-14,
-.emotion-11[data-has-label='true'] .eqr7bqq1 {
+.emotion-11[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1468,7 +1468,7 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
   align-items: start;
 }
 
-.emotion-18 .eqr7bqq4 {
+.emotion-18 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -1477,7 +1477,7 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-18[aria-disabled='true'] .eqr7bqq4 {
+.emotion-18[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -1550,7 +1550,7 @@ exports[`SelectableCardGroup > renders correctly required and showTick 1`] = `
   stroke: #e51963;
 }
 
-.emotion-18 .emotion-21[aria-checked="mixed"]+.emotion-23 .eqr7bqq6 {
+.emotion-18 .emotion-21[aria-checked="mixed"]+.emotion-23 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -2150,7 +2150,7 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
   align-items: start;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2159,7 +2159,7 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2232,7 +2232,7 @@ exports[`SelectableCardGroup > renders correctly with direction multiple columns
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -2827,7 +2827,7 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
   align-items: start;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -2836,7 +2836,7 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -2909,7 +2909,7 @@ exports[`SelectableCardGroup > renders correctly with error content 1`] = `
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3523,7 +3523,7 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
   align-items: start;
 }
 
-.emotion-14 .eqr7bqq4 {
+.emotion-14 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -3532,7 +3532,7 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-14[aria-disabled='true'] .eqr7bqq4 {
+.emotion-14[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -3605,7 +3605,7 @@ exports[`SelectableCardGroup > renders correctly with helper content 1`] = `
   stroke: #e51963;
 }
 
-.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq6 {
+.emotion-14 .emotion-17[aria-checked="mixed"]+.emotion-19 .eqr7bqq5 {
   fill: #ffffff;
 }
 

--- a/packages/ui/src/components/SelectableCardOptionGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardOptionGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`SelectableCardOptionGroup > onChange and onChangeOption are being calle
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1353,7 +1353,7 @@ exports[`SelectableCardOptionGroup > renders correctly 1`] = `
 }
 
 .emotion-12[data-has-label='true'] .emotion-15,
-.emotion-12[data-has-label='true'] .eqr7bqq1 {
+.emotion-12[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -2549,7 +2549,7 @@ exports[`SelectableCardOptionGroup > renders correctly 4 columns 1`] = `
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -3740,7 +3740,7 @@ exports[`SelectableCardOptionGroup > renders correctly with all options disabled
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -4934,7 +4934,7 @@ exports[`SelectableCardOptionGroup > renders correctly with aria-label 1`] = `
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -6081,7 +6081,7 @@ exports[`SelectableCardOptionGroup > renders correctly with error as boolean 1`]
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -7316,7 +7316,7 @@ exports[`SelectableCardOptionGroup > renders correctly with error message 1`] = 
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -8568,7 +8568,7 @@ exports[`SelectableCardOptionGroup > renders correctly with helper 1`] = `
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -9776,7 +9776,7 @@ exports[`SelectableCardOptionGroup > renders correctly with id 1`] = `
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -10967,7 +10967,7 @@ exports[`SelectableCardOptionGroup > renders correctly with image as ReactNode 1
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -12144,7 +12144,7 @@ exports[`SelectableCardOptionGroup > renders correctly with medium size 1`] = `
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -13335,7 +13335,7 @@ exports[`SelectableCardOptionGroup > renders correctly with partial disabled 1`]
 }
 
 .emotion-9[data-has-label='true'] .emotion-12,
-.emotion-9[data-has-label='true'] .eqr7bqq1 {
+.emotion-9[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 

--- a/packages/ui/src/components/Skeleton/Slider.tsx
+++ b/packages/ui/src/components/Skeleton/Slider.tsx
@@ -13,7 +13,7 @@ const StyledContainer = styled.div<{ length: number }>`
 const StyledCard = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.neutral.borderWeak};
   border-radius: ${({ theme }) => theme.radii.default};
-  width: 14.875rem
+  width: 14.875rem;
   height: 16.375ren;
   overflow: hidden;
 `

--- a/packages/ui/src/components/Skeleton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Skeleton/__tests__/__snapshots__/index.test.tsx.snap
@@ -997,7 +997,8 @@ exports[`Skeleton > renders correctly with type="slider" 1`] = `
 .emotion-4 {
   border: 1px solid #e9eaeb;
   border-radius: 0.25rem;
-  width:14.875rem height: 16.375ren;
+  width: 14.875rem;
+  height: 16.375ren;
   overflow: hidden;
 }
 

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`SwitchButton > renders correctly 1`] = `
 }
 
 .emotion-5[data-has-label='true'] .emotion-8,
-.emotion-5[data-has-label='true'] .eqr7bqq1 {
+.emotion-5[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -689,7 +689,7 @@ exports[`SwitchButton > renders correctly medium 1`] = `
 }
 
 .emotion-5[data-has-label='true'] .emotion-8,
-.emotion-5[data-has-label='true'] .eqr7bqq1 {
+.emotion-5[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1239,7 +1239,7 @@ exports[`SwitchButton > renders correctly with right value 1`] = `
 }
 
 .emotion-5[data-has-label='true'] .emotion-8,
-.emotion-5[data-has-label='true'] .eqr7bqq1 {
+.emotion-5[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -1789,7 +1789,7 @@ exports[`SwitchButton > renders neutral 1`] = `
 }
 
 .emotion-5[data-has-label='true'] .emotion-8,
-.emotion-5[data-has-label='true'] .eqr7bqq1 {
+.emotion-5[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -2351,7 +2351,7 @@ exports[`SwitchButton > renders with icons 1`] = `
 }
 
 .emotion-7[data-has-label='true'] .emotion-10,
-.emotion-7[data-has-label='true'] .eqr7bqq1 {
+.emotion-7[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 
@@ -2964,7 +2964,7 @@ exports[`SwitchButton > renders with tooltip 1`] = `
 }
 
 .emotion-7[data-has-label='true'] .emotion-10,
-.emotion-7[data-has-label='true'] .eqr7bqq1 {
+.emotion-7[data-has-label='true'] .eqr7bqq0 {
   width: 100%;
 }
 

--- a/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -3643,7 +3643,7 @@ exports[`Table > Should render correctly with selectable and shift click 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -3652,7 +3652,7 @@ exports[`Table > Should render correctly with selectable and shift click 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -3964,7 +3964,7 @@ exports[`Table > Should render correctly with selectable and shift click 1`] = `
   gap: 0.5rem;
 }
 
-.emotion-54 .eqr7bqq4 {
+.emotion-54 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -3973,7 +3973,7 @@ exports[`Table > Should render correctly with selectable and shift click 1`] = `
   color: #b5b7bd;
 }
 
-.emotion-54[aria-disabled='true'] .eqr7bqq4 {
+.emotion-54[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -5179,7 +5179,7 @@ exports[`Table > Should render correctly with selectable then click on first row
   gap: 0.5rem;
 }
 
-.emotion-11 .eqr7bqq4 {
+.emotion-11 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -5188,7 +5188,7 @@ exports[`Table > Should render correctly with selectable then click on first row
   color: #b5b7bd;
 }
 
-.emotion-11[aria-disabled='true'] .eqr7bqq4 {
+.emotion-11[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -5261,7 +5261,7 @@ exports[`Table > Should render correctly with selectable then click on first row
   stroke: #e51963;
 }
 
-.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-11 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -5500,7 +5500,7 @@ exports[`Table > Should render correctly with selectable then click on first row
   gap: 0.5rem;
 }
 
-.emotion-52 .eqr7bqq4 {
+.emotion-52 .eqr7bqq3 {
   cursor: pointer;
 }
 
@@ -5509,7 +5509,7 @@ exports[`Table > Should render correctly with selectable then click on first row
   color: #b5b7bd;
 }
 
-.emotion-52[aria-disabled='true'] .eqr7bqq4 {
+.emotion-52[aria-disabled='true'] .eqr7bqq3 {
   cursor: not-allowed;
 }
 
@@ -5582,7 +5582,7 @@ exports[`Table > Should render correctly with selectable then click on first row
   stroke: #e51963;
 }
 
-.emotion-52 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq6 {
+.emotion-52 .emotion-14[aria-checked="mixed"]+.emotion-16 .eqr7bqq5 {
   fill: #ffffff;
 }
 


### PR DESCRIPTION
## Summary

## Type
- Refactor

### Summarise concisely:
**BREAKING CHANGES**

Deprecated props removed:
- `Card`: prop "isActive" removed -> use "active" instead
- `Checkbox`: props "progress" and "size" removed
- `CopyButton`: prop "noBorder" removed -> use "bordered" instead