### PR TITLE
fix(Modal): disclosure onClick

### DIFF
--- a/.changeset/fast-results-run.md
+++ b/.changeset/fast-results-run.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Modal`: disclosure onClick should work even when it changes

--- a/packages/ui/src/components/Modal/components/Disclosure.tsx
+++ b/packages/ui/src/components/Modal/components/Disclosure.tsx
@@ -20,7 +20,7 @@ export const Disclosure = ({
     return () => {
       element?.removeEventListener('click', handleOpen)
     }
-  }, [handleOpen, ref])
+  }, [handleOpen, ref, disclosure])
 
   const finalDisclosure = useMemo(() => {
     if (typeof disclosure === 'function') {


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarise concisely:
`Modal`: disclosure onClick should work even when it changes
Before: 

https://github.com/user-attachments/assets/03d49b79-6bb5-47dd-a506-931fa2e789c9


After: 

https://github.com/user-attachments/assets/d98fd8b0-becd-48cb-9869-d55d243f6013

