### PR TITLE
fix(TextArea): height without prop value

### DIFF
--- a/.changeset/heavy-toys-tap.md
+++ b/.changeset/heavy-toys-tap.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`TextArea`: height should adapt even without prop value

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -221,7 +221,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           textArea.style.minHeight = `calc(${minHeight}px + 2*${padding})`
         }
       }
-    }, [value, rows, theme, maxRows])
+    }, [value, rows, theme, maxRows, textAreaRef.current?.value])
 
     const sentiment = useMemo(() => {
       if (error) {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?
`TextArea`: height should adapt even without prop value
