### PR TITLE
Revert "fix(deps): update dependency react-hook-form to v7.56.3 (#5097)"

### DIFF
--- a/.changeset/eighty-walls-greet.md
+++ b/.changeset/eighty-walls-greet.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Fix update react-hook-form issue

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -83,7 +83,7 @@
     "@babel/runtime": "7.27.6",
     "@ultraviolet/themes": "workspace:*",
     "@ultraviolet/ui": "workspace:*",
-    "react-hook-form": "7.56.3",
+    "react-hook-form": "7.55.0",
     "react-select": "5.10.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,8 +567,8 @@ importers:
         specifier: workspace:*
         version: link:../ui
       react-hook-form:
-        specifier: 7.56.3
-        version: 7.56.3(react@19.1.0)
+        specifier: 7.55.0
+        version: 7.55.0(react@19.1.0)
       react-select:
         specifier: 5.10.0
         version: 5.10.0(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -7002,8 +7002,8 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
-  react-hook-form@7.56.3:
-    resolution: {integrity: sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw==}
+  react-hook-form@7.55.0:
+    resolution: {integrity: sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -15858,7 +15858,7 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-hook-form@7.56.3(react@19.1.0):
+  react-hook-form@7.55.0(react@19.1.0):
     dependencies:
       react: 19.1.0
 


### PR DESCRIPTION
This reverts commit ce31fd7bca3b9243b6254e0d60999d26cf51c8f5.

The update of react hook form create issues.