### PR TITLE
fix(checkbox): add missing tooltip prop

### DIFF
--- a/.changeset/whole-wasps-cough.md
+++ b/.changeset/whole-wasps-cough.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix add missing `tooltip` prop on `CheckboxGroup.Checkbox`

--- a/packages/ui/src/components/CheckboxGroup/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/CheckboxGroup/__stories__/Template.stories.tsx
@@ -9,7 +9,7 @@ export const Template: StoryFn<typeof CheckboxGroup> = args => (
     >
       Accept terms and conditions
     </CheckboxGroup.Checkbox>
-    <CheckboxGroup.Checkbox name="newsletter" value="newsletter">
+    <CheckboxGroup.Checkbox name="newsletter" value="newsletter" tooltip="keke">
       Accept to receive newsletter
     </CheckboxGroup.Checkbox>
   </CheckboxGroup>

--- a/packages/ui/src/components/CheckboxGroup/index.tsx
+++ b/packages/ui/src/components/CheckboxGroup/index.tsx
@@ -45,6 +45,7 @@ export const CheckboxGroupCheckbox = ({
   autoFocus,
   'data-testid': dataTestId,
   required,
+  tooltip,
 }: CheckboxGroupCheckboxProps) => {
   const context = useContext(CheckboxGroupContext)
 
@@ -74,6 +75,7 @@ export const CheckboxGroupCheckbox = ({
       autoFocus={autoFocus}
       data-testid={dataTestId}
       required={required}
+      tooltip={tooltip}
     >
       {children}
     </StyledCheckbox>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix add missing `tooltip` prop on `CheckboxGroup.Checkbox`
