### PR TITLE
fix(Banner): wrong style on link

### DIFF
--- a/.changeset/petite-jeans-dig.md
+++ b/.changeset/petite-jeans-dig.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Banner />` wrong sentiment on dark color

--- a/packages/ui/src/components/Banner/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Banner/__tests__/__snapshots__/index.test.tsx.snap
@@ -1737,7 +1737,7 @@ exports[`Banner > should render correctly with dark theme 1`] = `
 
 .emotion-14:hover::after,
 .emotion-14:focus::after {
-  background-color: #34a8ff;
+  background-color: #bf96f8;
 }
 
 .emotion-14:active {

--- a/packages/ui/src/components/Banner/index.tsx
+++ b/packages/ui/src/components/Banner/index.tsx
@@ -218,11 +218,7 @@ export const Banner = ({
             ) : null}
             {linkText ? (
               <Link
-                sentiment={
-                  theme === 'light' && variant !== 'promotional'
-                    ? 'primary'
-                    : undefined
-                }
+                sentiment="primary"
                 prominence={prominence}
                 size="small"
                 target="_blank"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Bug on banner link has wrong sentiment and prominence

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1030" height="614" alt="Screenshot 2025-07-25 at 10 30 01" src="https://github.com/user-attachments/assets/3e91d0d5-ac10-4b9a-9a23-8c140a1fbfc6" /> | <img width="1041" height="606" alt="Screenshot 2025-07-25 at 10 30 08" src="https://github.com/user-attachments/assets/54785465-d0a3-4212-8245-fc9693bfbf6e" /> |
