### PR TITLE
fix(Menu): menu closes when hover leaves

### DIFF
--- a/.changeset/shaky-kings-deny.md
+++ b/.changeset/shaky-kings-deny.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Menu`: fix hover behavior

--- a/packages/ui/src/components/Menu/MenuContent.tsx
+++ b/packages/ui/src/components/Menu/MenuContent.tsx
@@ -179,7 +179,7 @@ export const Menu = forwardRef(
           handler(true),
         )
         disclosureRef.current.addEventListener('mouseleave', () =>
-          handler(undefined),
+          handler(false),
         )
         disclosureRef.current.addEventListener('keydown', event => {
           if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarise concisely:
Fix `Menu` behavior