### PR TITLE
chore: do not check format on autogenerated files in coverage

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,7 @@
       "**",
       "!**/.turbo/",
       "!**/.next/",
-      "!**/coverage/",
+      "!**/coverage/**",
       "!**/node_modules/",
       "!**/storybook-static",
       "!**/dist",


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:
Fix includes to avoid checking format on coverage files