### PR TITLE
fix(SelectInput): handle better tag display

### DIFF
--- a/.changeset/two-goats-doubt.md
+++ b/.changeset/two-goats-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInput />` to handle better tag display

--- a/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -373,6 +373,10 @@ exports[`SelectInputField > should display right value on grouped options 1`] = 
   padding-right: 1rem;
   padding-left: 1rem;
   height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
   margin-bottom: 0.125rem;
 }

--- a/packages/ui/src/components/SelectInput/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInput/Dropdown.tsx
@@ -107,6 +107,7 @@ const DropdownGroup = styled.button<{ 'data-selectgroup': boolean }>`
   padding-right: ${({ theme }) => theme.space[2]};
   padding-left: ${({ theme }) => theme.space[2]};
   height: ${({ theme }) => theme.space[4]};
+  display: flex;
   text-align: left;
   margin-bottom: ${({ theme }) => theme.space['0.25']};
 

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`SelectInputV2 > renders correctly 1`] = `
+exports[`SelectInput > renders correctly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -8,6 +8,10 @@ exports[`SelectInputV2 > renders correctly 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -19,175 +23,137 @@ exports[`SelectInputV2 > renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  gap: 0.25rem;
 }
 
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-8 {
-  color: #222638;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-7 {
+  color: #3f4250;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
 }
 
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+.emotion-9 {
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
-.emotion-10[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+.emotion-9[data-size='small'] {
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
-.emotion-10[data-size='medium'] {
-  height: 40px;
+.emotion-9[data-size='medium'] {
+  height: 2.5rem;
 }
 
-.emotion-10[data-size='large'] {
-  height: 48px;
+.emotion-9[data-size='large'] {
+  height: 3rem;
 }
 
-.emotion-10[data-state='neutral'] {
+.emotion-9[data-state='neutral'] {
   border: 1px solid #d9dadd;
 }
 
-.emotion-10[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-9[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #792dd4;
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-10[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-10[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-9[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
 }
 
-.emotion-10[data-state='neutral'][data-dropdownvisible='true'] {
+.emotion-9[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.emotion-9[data-state='neutral'][data-dropdownvisible='true'] {
   border-color: #792dd4;
 }
 
-.emotion-10[data-state='success'] {
+.emotion-9[data-state='success'] {
   border: 1px solid #22674e;
 }
 
-.emotion-10[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-9[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #1b533f;
   box-shadow: 0px 0px 0px 3px #45d19f40;
 }
 
-.emotion-10[data-state='success'][data-dropdownvisible='true'] {
+.emotion-9[data-state='success'][data-dropdownvisible='true'] {
   border-color: #1b533f;
 }
 
-.emotion-10[data-state='danger'] {
+.emotion-9[data-state='danger'] {
   border: 1px solid #b3144d;
 }
 
-.emotion-10[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-9[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #92103f;
   box-shadow: 0px 0px 0px 3px #f91b6c40;
 }
 
-.emotion-10[data-state='danger'][data-dropdownvisible='true'] {
+.emotion-9[data-state='danger'][data-dropdownvisible='true'] {
   border-color: #92103f;
 }
 
-.emotion-10:not([data-disabled='true']):not([data-readonly]):hover {
+.emotion-9:not([data-disabled='true']):not([data-readonly]):hover {
   border-color: #8c40ef;
 }
 
-.emotion-10[data-readonly='true'] {
+.emotion-9[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
   cursor: default;
 }
 
-.emotion-10[data-disabled='true'] {
+.emotion-9[data-disabled='true'] {
   background: #f3f3f4;
   border-color: #e9eaeb;
   cursor: not-allowed;
 }
 
-.emotion-13 {
+.emotion-12 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -195,17 +161,20 @@ exports[`SelectInputV2 > renders correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
-.emotion-15 {
+.emotion-14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -214,27 +183,27 @@ exports[`SelectInputV2 > renders correctly 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-17 {
+.emotion-16 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
-.emotion-17 .fillStroke {
+.emotion-16 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
@@ -247,55 +216,52 @@ exports[`SelectInputV2 > renders correctly 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r1:"
-        aria-describedby=":r1:"
+        aria-controls="«r1»"
+        aria-describedby="«r1»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
-          <div
-            class="emotion-6 emotion-5"
+          <label
+            class="emotion-6 emotion-7 emotion-8"
+            for="«r0»"
           >
-            <label
-              class="emotion-8 emotion-9"
-            >
-              label
-            </label>
-          </div>
+            label
+          </label>
           <div
+            aria-controls="«r1»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             aria-label="label"
-            class="emotion-10 emotion-11"
+            class="emotion-9 emotion-10"
             data-disabled="false"
             data-dropdownvisible="false"
             data-readonly="false"
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r0:"
+            id="«r0»"
             role="combobox"
             tabindex="0"
           >
             <p
-              class="emotion-12 emotion-13 emotion-9"
+              class="emotion-11 emotion-12 emotion-8"
             >
               Select item
             </p>
             <div
-              class="emotion-15 emotion-16"
+              class="emotion-14 emotion-15"
             >
               <svg
                 aria-label="show dropdown"
-                class="emotion-17 emotion-18"
-                viewBox="0 0 20 20"
+                class="emotion-16 emotion-17"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -308,7 +274,7 @@ exports[`SelectInputV2 > renders correctly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly disabled 1`] = `
+exports[`SelectInput > renders correctly disabled 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -316,6 +282,10 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -327,10 +297,10 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -339,58 +309,38 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -402,10 +352,14 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -456,11 +410,11 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
 
 .emotion-9 {
   color: #b5b7bd;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -468,6 +422,9 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -475,10 +432,10 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -487,11 +444,11 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -501,10 +458,10 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #b5b7bd;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -520,18 +477,18 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rai:"
-        aria-describedby=":rai:"
+        aria-controls="«rb5»"
+        aria-describedby="«rb5»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rb5»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="true"
             data-dropdownvisible="false"
@@ -539,7 +496,7 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":rah:"
+            id="«rb4»"
             role="combobox"
             tabindex="0"
           >
@@ -554,11 +511,11 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -571,7 +528,7 @@ exports[`SelectInputV2 > renders correctly disabled 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly grouped 1`] = `
+exports[`SelectInput > renders correctly grouped 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -599,6 +556,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -608,10 +569,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -620,58 +581,38 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -683,10 +624,14 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -737,11 +682,11 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -749,6 +694,9 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -756,10 +704,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -768,11 +716,11 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -782,10 +730,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -796,8 +744,8 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -813,11 +761,12 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -850,10 +799,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -862,10 +811,9 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -873,10 +821,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -885,14 +833,14 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -903,10 +851,12 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -976,10 +926,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -988,17 +938,16 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -1009,17 +958,17 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -1027,10 +976,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -1039,19 +988,18 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -1059,10 +1007,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -1071,16 +1019,16 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-37 {
@@ -1101,12 +1049,16 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-37:focus {
@@ -1115,8 +1067,8 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
 }
 
 .emotion-37[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-37[data-selectgroup='true']:focus {
@@ -1125,11 +1077,11 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
 
 .emotion-39 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1140,11 +1092,12 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-43:hover,
@@ -1152,20 +1105,19 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-43[data-selected='true'] {
+.emotion-43[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-43[disabled] {
+.emotion-43[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-43[disabled]:hover,
-.emotion-43 [disabled]:focus {
+.emotion-43[aria-disabled="true"]:hover,
+.emotion-43 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -1177,10 +1129,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -1188,19 +1140,19 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-50 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1217,39 +1169,40 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   max-width: 100%;
 }
 
-.emotion-70 {
+.emotion-52 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: left;
 }
 
-.emotion-140 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-81 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-143 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-84 {
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1262,14 +1215,13 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -1284,18 +1236,18 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r1j:"
-        aria-describedby=":r1j:"
+        aria-controls="«r1q»"
+        aria-describedby="«r1q»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r1q»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -1303,7 +1255,7 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r1i:"
+            id="«r1p»"
             role="combobox"
             tabindex="0"
           >
@@ -1318,11 +1270,11 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -1333,7 +1285,7 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r1j:"
+          id="«r1q»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -1357,11 +1309,11 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -1372,7 +1324,7 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r1m:"
+                    id="«r1u»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -1403,164 +1355,6 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      TERRESTRIAL PLANETS
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="emotion-33 emotion-5"
-                  id="items"
-                >
-                  <div
-                    aria-label="mercury"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mercury"
-                    id="option-0"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-mercury"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Mercury
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="venus"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-venus"
-                    id="option-1"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-venus"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Venus
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="earth"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-earth"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-earth"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Earth
-                        </span>
-                      </div>
-                      <span
-                        class="emotion-70 emotion-10"
-                      >
-                        Our home planet
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="mars"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mars"
-                    disabled=""
-                    id="option-3"
-                    role="option"
-                    tabindex="-1"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-mars"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Mars
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="pluto"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-pluto"
-                    id="option-4"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-pluto"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Pluto
-                        </span>
-                      </div>
-                      <span
-                        class="emotion-70 emotion-10"
-                      >
-                        Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="emotion-33 emotion-5"
-              >
-                <div
-                  class="emotion-35 emotion-36"
-                >
-                  <button
-                    class="emotion-37 emotion-38"
-                    data-selectgroup="false"
-                    data-testid="group-1"
-                    role="group"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <span
-                      class="emotion-39 emotion-10"
-                    >
                       JOVIAN PLANETS
                     </span>
                   </button>
@@ -1570,9 +1364,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                   id="items"
                 >
                   <div
+                    aria-disabled="false"
                     aria-label="jupiter"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-jupiter"
                     id="option-0"
                     role="option"
@@ -1592,16 +1387,17 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                         </span>
                       </div>
                       <span
-                        class="emotion-70 emotion-10"
+                        class="emotion-52 emotion-10"
                       >
                         Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
                       </span>
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="saturn"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-saturn"
                     id="option-1"
                     role="option"
@@ -1623,9 +1419,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="uranus"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-uranus"
                     id="option-2"
                     role="option"
@@ -1647,9 +1444,10 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="neptune"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-neptune"
                     id="option-3"
                     role="option"
@@ -1666,17 +1464,179 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
                           class="emotion-49 emotion-50 emotion-10"
                         >
                           <div
-                            class="emotion-140 emotion-10"
+                            class="emotion-81 emotion-10"
                           >
                             Neptune 
                             <span
-                              class="emotion-142 emotion-143 emotion-10"
+                              class="emotion-83 emotion-84 emotion-10"
                             >
                               Label
                             </span>
                           </div>
                         </span>
                       </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-33 emotion-5"
+              >
+                <div
+                  class="emotion-35 emotion-36"
+                >
+                  <button
+                    class="emotion-37 emotion-38"
+                    data-selectgroup="false"
+                    data-testid="group-1"
+                    role="group"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-39 emotion-10"
+                    >
+                      TERRESTRIAL PLANETS
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="emotion-33 emotion-5"
+                  id="items"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-label="mercury"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mercury"
+                    id="option-0"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-mercury"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mercury
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="venus"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-venus"
+                    id="option-1"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-venus"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Venus
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="earth"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-earth"
+                    id="option-2"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-earth"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Earth
+                        </span>
+                      </div>
+                      <span
+                        class="emotion-52 emotion-10"
+                      >
+                        Our home planet
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="mars"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mars"
+                    id="option-3"
+                    role="option"
+                    tabindex="-1"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-mars"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mars
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="pluto"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-pluto"
+                    id="option-4"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-pluto"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Pluto
+                        </span>
+                      </div>
+                      <span
+                        class="emotion-52 emotion-10"
+                      >
+                        Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -1690,7 +1650,7 @@ exports[`SelectInputV2 > renders correctly grouped 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly loadMore 1`] = `
+exports[`SelectInput > renders correctly loadMore 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -1698,6 +1658,10 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -1709,10 +1673,10 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -1721,58 +1685,38 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -1784,10 +1728,14 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -1838,11 +1786,11 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -1850,6 +1798,9 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -1857,10 +1808,10 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1869,11 +1820,11 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1883,10 +1834,10 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -1902,18 +1853,18 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":raa:"
-        aria-describedby=":raa:"
+        aria-controls="«rar»"
+        aria-describedby="«rar»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rar»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="false"
@@ -1921,7 +1872,7 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":ra9:"
+            id="«raq»"
             role="combobox"
             tabindex="0"
           >
@@ -1936,11 +1887,11 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -1953,7 +1904,7 @@ exports[`SelectInputV2 > renders correctly loadMore 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
+exports[`SelectInput > renders correctly loading - grouped data 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -1991,6 +1942,10 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -2000,10 +1955,10 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -2012,58 +1967,38 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -2075,10 +2010,14 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -2129,11 +2068,11 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2141,6 +2080,9 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -2148,10 +2090,10 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2160,11 +2102,11 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2174,10 +2116,10 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -2188,8 +2130,8 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -2205,11 +2147,12 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -2242,10 +2185,10 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -2254,10 +2197,9 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-20 {
@@ -2265,10 +2207,10 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -2277,19 +2219,18 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-20[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-22 {
@@ -2309,12 +2250,12 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
 }
 
 .emotion-24 {
-  min-height: 200px;
+  min-height: 12.5rem;
   width: 100%;
   height: 100%;
-  padding: 16px;
+  padding: 1rem;
   border: 1px solid #e9eaeb;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   margin: 0;
 }
 
@@ -2331,23 +2272,23 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 24px 16px;
+  padding: 1.5rem 1rem;
 }
 
 .emotion-28 {
-  margin-right: 8px;
-  width: 32px;
-  height: 32px;
-  min-width: 32px;
-  border-radius: 8px;
+  margin-right: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  min-width: 2rem;
+  border-radius: 0.5rem;
   background-color: #e9eaeb;
 }
 
 .emotion-30 {
-  height: 12px;
-  width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background-color: #e9eaeb;
 }
 
@@ -2386,18 +2327,18 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r1sl:"
-        aria-describedby=":r1sl:"
+        aria-controls="«r24b»"
+        aria-describedby="«r24b»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r24b»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -2405,7 +2346,7 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r1sk:"
+            id="«r24a»"
             role="combobox"
             tabindex="0"
           >
@@ -2420,11 +2361,11 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -2435,7 +2376,7 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r1sl:"
+          id="«r24b»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -2500,7 +2441,7 @@ exports[`SelectInputV2 > renders correctly loading - grouped data 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
+exports[`SelectInput > renders correctly loading - ungrouped data 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -2538,6 +2479,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -2547,10 +2492,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -2559,58 +2504,38 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -2622,10 +2547,14 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -2676,11 +2605,11 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -2688,6 +2617,9 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -2695,10 +2627,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2707,11 +2639,11 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2721,10 +2653,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -2735,8 +2667,8 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -2752,11 +2684,12 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -2789,10 +2722,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -2801,10 +2734,9 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-20 {
@@ -2812,10 +2744,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -2824,19 +2756,19 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-20[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-22 {
@@ -2844,10 +2776,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -2856,10 +2788,10 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-24 {
@@ -2879,12 +2811,12 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
 }
 
 .emotion-26 {
-  min-height: 200px;
+  min-height: 12.5rem;
   width: 100%;
   height: 100%;
-  padding: 16px;
+  padding: 1rem;
   border: 1px solid #e9eaeb;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   margin: 0;
 }
 
@@ -2901,23 +2833,23 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 24px 16px;
+  padding: 1.5rem 1rem;
 }
 
 .emotion-30 {
-  margin-right: 8px;
-  width: 32px;
-  height: 32px;
-  min-width: 32px;
-  border-radius: 8px;
+  margin-right: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  min-width: 2rem;
+  border-radius: 0.5rem;
   background-color: #e9eaeb;
 }
 
 .emotion-32 {
-  height: 12px;
-  width: 120px;
+  height: 0.75rem;
+  width: 7.5rem;
   max-width: 100%;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   background-color: #e9eaeb;
 }
 
@@ -2956,18 +2888,18 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r1sp:"
-        aria-describedby=":r1sp:"
+        aria-controls="«r24g»"
+        aria-describedby="«r24g»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r24g»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -2975,7 +2907,7 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r1so:"
+            id="«r24f»"
             role="combobox"
             tabindex="0"
           >
@@ -2990,11 +2922,11 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -3005,7 +2937,7 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r1sp:"
+          id="«r24g»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -3017,7 +2949,6 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
               data-grouped="false"
               id="select-dropdown"
               role="listbox"
-              tabindex="-1"
             >
               <div
                 class="emotion-22 emotion-5"
@@ -3076,7 +3007,7 @@ exports[`SelectInputV2 > renders correctly loading - ungrouped data 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly multiselect 1`] = `
+exports[`SelectInput > renders correctly multiselect 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -3104,6 +3035,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -3113,10 +3048,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -3125,58 +3060,38 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -3188,10 +3103,14 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -3245,10 +3164,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3257,10 +3176,13 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  overflow: hidden;
+  max-width: 100%;
+  height: 100%;
 }
 
 .emotion-11 {
@@ -3277,37 +3199,45 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -webkit-justify-content: center;
   justify-content: center;
   white-space: nowrap;
-  border-radius: 4px;
-  padding: 0 8px;
-  gap: 8px;
+  border-radius: 0.25rem;
+  padding: 0 0.5rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   color: #3f4250;
   background: #ffffff;
   border: solid 1px #d9dadd;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
+  height: -webkit-max-content;
+  height: -moz-max-content;
+  height: max-content;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
+  min-width: auto;
+  max-width: 500px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.emotion-11>.emotion-3 {
+  overflow: hidden;
 }
 
 .emotion-14 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  max-width: 232px;
+  max-width: 14.5rem;
 }
 
 .emotion-17 {
@@ -3315,15 +3245,16 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  height: 32px;
-  padding: 0 8px;
+  position: relative;
+  height: 2rem;
+  padding: 0 0.5rem;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  gap: 8px;
-  border-radius: 4px;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
   box-sizing: border-box;
-  width: 32px;
+  width: auto;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3337,11 +3268,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   white-space: nowrap;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   paragraph-spacing: 0;
   text-case: none;
   background: none;
@@ -3353,7 +3284,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   height: -webkit-fit-content;
   height: -moz-fit-content;
   height: fit-content;
-  padding: 2px;
+  padding: 0.125rem;
 }
 
 .emotion-17:hover {
@@ -3365,6 +3296,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   box-shadow: 0px 0px 0px 3px #151a2d5c;
 }
 
+.emotion-17 .e1y1n78x0 {
+  stroke: transparent;
+}
+
 .emotion-17:hover,
 .emotion-17:active {
   background: #e9eaeb;
@@ -3374,10 +3309,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 .emotion-19 {
   vertical-align: middle;
   fill: currentColor;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-19 .fillStroke {
@@ -3390,10 +3325,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3402,11 +3337,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3416,10 +3351,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 .emotion-23 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-23 .fillStroke {
@@ -3430,8 +3365,8 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 .emotion-26 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -3447,11 +3382,12 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-26[data-animated="true"] {
@@ -3484,10 +3420,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -3496,10 +3432,9 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-31 {
@@ -3507,10 +3442,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -3519,14 +3454,14 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-33 {
@@ -3537,10 +3472,12 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-33>.emotion-40 {
@@ -3610,10 +3547,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3622,17 +3559,16 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-35[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-39 {
@@ -3643,17 +3579,17 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-39[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-39[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-41 {
@@ -3661,10 +3597,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -3673,19 +3609,18 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-41[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-43 {
@@ -3693,10 +3628,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -3705,16 +3640,16 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-45 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-47 {
@@ -3735,12 +3670,16 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-47:focus {
@@ -3749,8 +3688,8 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 }
 
 .emotion-47[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-47[data-selectgroup='true']:focus {
@@ -3759,11 +3698,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 
 .emotion-49 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -3774,11 +3713,12 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-53:hover,
@@ -3786,20 +3726,19 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-53[data-selected='true'] {
+.emotion-53[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-53[disabled] {
+.emotion-53[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-53[disabled]:hover,
-.emotion-53 [disabled]:focus {
+.emotion-53[aria-disabled="true"]:hover,
+.emotion-53 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -3812,11 +3751,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  gap: 8px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 0.5rem;
   width: 100%;
   position: static;
   text-align: left;
@@ -3909,7 +3848,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   stroke: #e51963;
 }
 
-.emotion-56 .emotion-59[aria-checked="mixed"]+.emotion-61 .eqr7bqq6 {
+.emotion-56 .emotion-59[aria-checked="mixed"]+.emotion-61 .eqr7bqq5 {
   fill: #ffffff;
 }
 
@@ -3955,8 +3894,8 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 .emotion-58 {
   position: absolute;
   white-space: nowrap;
-  height: 24px;
-  width: 24px;
+  height: 1.5rem;
+  width: 1.5rem;
   opacity: 0;
   border-width: 0;
 }
@@ -4012,11 +3951,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 }
 
 .emotion-60 {
-  border-radius: 4px;
-  height: 24px;
-  width: 24px;
-  min-width: 24px;
-  min-height: 24px;
+  border-radius: 0.25rem;
+  height: 1.5rem;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  min-height: 1.5rem;
 }
 
 .emotion-60 path {
@@ -4041,10 +3980,13 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -4053,13 +3995,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-66 {
@@ -4067,10 +4006,13 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4079,13 +4021,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
 }
 
 .emotion-68 {
@@ -4098,10 +4037,10 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -4109,19 +4048,19 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-75 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -4138,39 +4077,40 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   max-width: 100%;
 }
 
-.emotion-125 {
+.emotion-77 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: left;
 }
 
-.emotion-285 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-151 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-288 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-154 {
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4183,14 +4123,13 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -4205,18 +4144,18 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r4g:"
-        aria-describedby=":r4g:"
+        aria-controls="«r4q»"
+        aria-describedby="«r4q»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r4q»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -4224,22 +4163,22 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r4f:"
+            id="«r4p»"
             role="combobox"
             tabindex="0"
           >
             <div
-              class="emotion-8 emotion-5"
+              class="emotion-8 emotion-9"
             >
               <span
                 class="emotion-10 emotion-11 emotion-12"
                 data-testid="selected-options-tags"
               >
-                <span
+                <div
                   class="emotion-13 emotion-14 emotion-15"
                 >
                   Pluto
-                </span>
+                </div>
                 <button
                   aria-label="Close tag"
                   class="emotion-16 emotion-17 emotion-18"
@@ -4249,7 +4188,6 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                   <svg
                     class="emotion-19 emotion-20"
                     viewBox="0 0 16 16"
-                    xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
                       d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94z"
@@ -4263,12 +4201,12 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
             >
               <svg
                 aria-label="show dropdown"
-                class="emotion-23 emotion-24"
-                viewBox="0 0 20 20"
+                class="emotion-23 emotion-20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -4279,7 +4217,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
           class="emotion-25 emotion-26 emotion-27"
           data-animated="false"
           data-has-arrow="false"
-          id=":r4g:"
+          id="«r4q»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -4302,12 +4240,12 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     data-size="medium"
                   >
                     <svg
-                      class="emotion-23 emotion-24"
-                      viewBox="0 0 20 20"
+                      class="emotion-23 emotion-20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -4318,7 +4256,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     class="emotion-39 emotion-40"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r4k:"
+                    id="«r51»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -4349,7 +4287,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     <span
                       class="emotion-49 emotion-15"
                     >
-                      TERRESTRIAL PLANETS
+                      JOVIAN PLANETS
                     </span>
                   </button>
                 </div>
@@ -4358,10 +4296,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                   id="items"
                 >
                   <div
-                    aria-label="mercury"
+                    aria-disabled="false"
+                    aria-label="jupiter"
+                    aria-selected="false"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-mercury"
+                    data-testid="option-jupiter"
                     id="option-0"
                     role="option"
                     tabindex="0"
@@ -4376,22 +4315,21 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         aria-checked="false"
                         aria-invalid="false"
                         class="emotion-58 emotion-59"
-                        id=":r4n:"
+                        id="«r54»"
                         tabindex="-1"
                         type="checkbox"
-                        value="mercury"
+                        value="jupiter"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -4417,11 +4355,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r4n:"
+                            for="«r54»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-mercury"
+                              data-testid="option-stack-jupiter"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -4429,9 +4367,14 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  Mercury
+                                  Jupiter
                                 </span>
                               </div>
+                              <span
+                                class="emotion-77 emotion-15"
+                              >
+                                Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
+                              </span>
                             </div>
                           </label>
                         </div>
@@ -4439,10 +4382,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     </div>
                   </div>
                   <div
-                    aria-label="venus"
+                    aria-disabled="false"
+                    aria-label="saturn"
+                    aria-selected="false"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-venus"
+                    data-testid="option-saturn"
                     id="option-1"
                     role="option"
                     tabindex="0"
@@ -4457,22 +4401,21 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         aria-checked="false"
                         aria-invalid="false"
                         class="emotion-58 emotion-59"
-                        id=":r4r:"
+                        id="«r59»"
                         tabindex="-1"
                         type="checkbox"
-                        value="venus"
+                        value="saturn"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -4498,11 +4441,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r4r:"
+                            for="«r59»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-venus"
+                              data-testid="option-stack-saturn"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -4510,7 +4453,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  Venus
+                                  Saturn
                                 </span>
                               </div>
                             </div>
@@ -4520,10 +4463,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     </div>
                   </div>
                   <div
-                    aria-label="earth"
+                    aria-disabled="false"
+                    aria-label="uranus"
+                    aria-selected="false"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-earth"
+                    data-testid="option-uranus"
                     id="option-2"
                     role="option"
                     tabindex="0"
@@ -4538,22 +4482,21 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         aria-checked="false"
                         aria-invalid="false"
                         class="emotion-58 emotion-59"
-                        id=":r4v:"
+                        id="«r5d»"
                         tabindex="-1"
                         type="checkbox"
-                        value="earth"
+                        value="uranus"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -4579,11 +4522,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r4v:"
+                            for="«r5d»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-earth"
+                              data-testid="option-stack-uranus"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -4591,14 +4534,9 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  Earth
+                                  Uranus
                                 </span>
                               </div>
-                              <span
-                                class="emotion-125 emotion-15"
-                              >
-                                Our home planet
-                              </span>
                             </div>
                           </label>
                         </div>
@@ -4606,17 +4544,17 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     </div>
                   </div>
                   <div
-                    aria-label="mars"
+                    aria-disabled="false"
+                    aria-label="neptune"
+                    aria-selected="false"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-mars"
-                    disabled=""
+                    data-testid="option-neptune"
                     id="option-3"
                     role="option"
-                    tabindex="-1"
+                    tabindex="0"
                   >
                     <div
-                      aria-disabled="true"
+                      aria-disabled="false"
                       class="emotion-55 emotion-56 emotion-57"
                       data-checked="false"
                       data-error="false"
@@ -4625,23 +4563,21 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         aria-checked="false"
                         aria-invalid="false"
                         class="emotion-58 emotion-59"
-                        disabled=""
-                        id=":r54:"
+                        id="«r5h»"
                         tabindex="-1"
                         type="checkbox"
-                        value="mars"
+                        value="neptune"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -4667,11 +4603,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r54:"
+                            for="«r5h»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-mars"
+                              data-testid="option-stack-neptune"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -4679,96 +4615,18 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  Mars
+                                  <div
+                                    class="emotion-151 emotion-15"
+                                  >
+                                    Neptune 
+                                    <span
+                                      class="emotion-153 emotion-154 emotion-15"
+                                    >
+                                      Label
+                                    </span>
+                                  </div>
                                 </span>
                               </div>
-                            </div>
-                          </label>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="pluto"
-                    class="emotion-53 emotion-54"
-                    data-selected="true"
-                    data-testid="option-pluto"
-                    id="option-4"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      aria-disabled="false"
-                      class="emotion-55 emotion-56 emotion-57"
-                      data-checked="true"
-                      data-error="false"
-                    >
-                      <input
-                        aria-checked="true"
-                        aria-invalid="false"
-                        checked=""
-                        class="emotion-58 emotion-59"
-                        id=":r58:"
-                        tabindex="-1"
-                        type="checkbox"
-                        value="pluto"
-                      />
-                      <svg
-                        class="emotion-60 emotion-61"
-                        fill="none"
-                        size="24"
-                        viewBox="0 0 24 24"
-                      >
-                        <g>
-                          <rect
-                            class="emotion-62 emotion-63"
-                            height="16"
-                            rx="2px"
-                            stroke-width="2"
-                            width="16"
-                            x="4"
-                            y="4"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
-                            fill="white"
-                            fill-rule="evenodd"
-                            height="9"
-                            width="12"
-                            x="5"
-                            y="4"
-                          />
-                        </g>
-                      </svg>
-                      <div
-                        class="emotion-64 emotion-5"
-                      >
-                        <div
-                          class="emotion-66 emotion-5"
-                        >
-                          <label
-                            class="emotion-68 emotion-69"
-                            for=":r58:"
-                          >
-                            <div
-                              class="emotion-4 emotion-5"
-                              data-testid="option-stack-pluto"
-                            >
-                              <div
-                                class="emotion-72 emotion-73"
-                              >
-                                <span
-                                  class="emotion-74 emotion-75 emotion-15"
-                                >
-                                  Pluto
-                                </span>
-                              </div>
-                              <span
-                                class="emotion-125 emotion-15"
-                              >
-                                Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
-                              </span>
                             </div>
                           </label>
                         </div>
@@ -4794,7 +4652,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     <span
                       class="emotion-49 emotion-15"
                     >
-                      JOVIAN PLANETS
+                      TERRESTRIAL PLANETS
                     </span>
                   </button>
                 </div>
@@ -4803,10 +4661,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                   id="items"
                 >
                   <div
-                    aria-label="jupiter"
+                    aria-disabled="false"
+                    aria-label="mercury"
+                    aria-selected="false"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-jupiter"
+                    data-testid="option-mercury"
                     id="option-0"
                     role="option"
                     tabindex="0"
@@ -4821,22 +4680,21 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         aria-checked="false"
                         aria-invalid="false"
                         class="emotion-58 emotion-59"
-                        id=":r5e:"
+                        id="«r5o»"
                         tabindex="-1"
                         type="checkbox"
-                        value="jupiter"
+                        value="mercury"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -4862,11 +4720,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r5e:"
+                            for="«r5o»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-jupiter"
+                              data-testid="option-stack-mercury"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -4874,14 +4732,9 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  Jupiter
+                                  Mercury
                                 </span>
                               </div>
-                              <span
-                                class="emotion-125 emotion-15"
-                              >
-                                Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
-                              </span>
                             </div>
                           </label>
                         </div>
@@ -4889,10 +4742,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     </div>
                   </div>
                   <div
-                    aria-label="saturn"
+                    aria-disabled="false"
+                    aria-label="venus"
+                    aria-selected="false"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-saturn"
+                    data-testid="option-venus"
                     id="option-1"
                     role="option"
                     tabindex="0"
@@ -4907,22 +4761,21 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         aria-checked="false"
                         aria-invalid="false"
                         class="emotion-58 emotion-59"
-                        id=":r5j:"
+                        id="«r5s»"
                         tabindex="-1"
                         type="checkbox"
-                        value="saturn"
+                        value="venus"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -4948,11 +4801,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r5j:"
+                            for="«r5s»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-saturn"
+                              data-testid="option-stack-venus"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -4960,7 +4813,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  Saturn
+                                  Venus
                                 </span>
                               </div>
                             </div>
@@ -4970,10 +4823,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     </div>
                   </div>
                   <div
-                    aria-label="uranus"
+                    aria-disabled="false"
+                    aria-label="earth"
+                    aria-selected="false"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-uranus"
+                    data-testid="option-earth"
                     id="option-2"
                     role="option"
                     tabindex="0"
@@ -4988,22 +4842,21 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         aria-checked="false"
                         aria-invalid="false"
                         class="emotion-58 emotion-59"
-                        id=":r5n:"
+                        id="«r60»"
                         tabindex="-1"
                         type="checkbox"
-                        value="uranus"
+                        value="earth"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -5029,11 +4882,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r5n:"
+                            for="«r60»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-uranus"
+                              data-testid="option-stack-earth"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -5041,7 +4894,94 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  Uranus
+                                  Earth
+                                </span>
+                              </div>
+                              <span
+                                class="emotion-77 emotion-15"
+                              >
+                                Our home planet
+                              </span>
+                            </div>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="mars"
+                    aria-selected="false"
+                    class="emotion-53 emotion-54"
+                    data-testid="option-mars"
+                    id="option-3"
+                    role="option"
+                    tabindex="-1"
+                  >
+                    <div
+                      aria-disabled="true"
+                      class="emotion-55 emotion-56 emotion-57"
+                      data-checked="false"
+                      data-error="false"
+                    >
+                      <input
+                        aria-checked="false"
+                        aria-invalid="false"
+                        class="emotion-58 emotion-59"
+                        disabled=""
+                        id="«r65»"
+                        tabindex="-1"
+                        type="checkbox"
+                        value="mars"
+                      />
+                      <svg
+                        class="emotion-60 emotion-61"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <g>
+                          <rect
+                            class="emotion-62 emotion-63"
+                            height="16"
+                            rx="0.125rem"
+                            stroke-width="2"
+                            width="16"
+                            x="4"
+                            y="4"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M15.6678 5.26709C16.0849 5.6463 16.113 6.28907 15.7307 6.70276L9.29172 13.6705C9.10291 13.8748 8.83818 13.9937 8.55884 13.9998C8.2795 14.0058 8.0098 13.8984 7.81223 13.7024L4.30004 10.2185C3.89999 9.82169 3.89999 9.17831 4.30004 8.78149C4.70009 8.38467 5.34869 8.38467 5.74874 8.78149L8.50441 11.5149L14.2205 5.32951C14.6028 4.91583 15.2508 4.88788 15.6678 5.26709Z"
+                            fill="white"
+                            fill-rule="evenodd"
+                            height="9"
+                            width="12"
+                            x="5"
+                            y="4"
+                          />
+                        </g>
+                      </svg>
+                      <div
+                        class="emotion-64 emotion-5"
+                      >
+                        <div
+                          class="emotion-66 emotion-5"
+                        >
+                          <label
+                            class="emotion-68 emotion-69"
+                            for="«r65»"
+                          >
+                            <div
+                              class="emotion-4 emotion-5"
+                              data-testid="option-stack-mars"
+                            >
+                              <div
+                                class="emotion-72 emotion-73"
+                              >
+                                <span
+                                  class="emotion-74 emotion-75 emotion-15"
+                                >
+                                  Mars
                                 </span>
                               </div>
                             </div>
@@ -5051,40 +4991,41 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                     </div>
                   </div>
                   <div
-                    aria-label="neptune"
+                    aria-disabled="false"
+                    aria-label="pluto"
+                    aria-selected="true"
                     class="emotion-53 emotion-54"
-                    data-selected="false"
-                    data-testid="option-neptune"
-                    id="option-3"
+                    data-testid="option-pluto"
+                    id="option-4"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       aria-disabled="false"
                       class="emotion-55 emotion-56 emotion-57"
-                      data-checked="false"
+                      data-checked="true"
                       data-error="false"
                     >
                       <input
-                        aria-checked="false"
+                        aria-checked="true"
                         aria-invalid="false"
+                        checked=""
                         class="emotion-58 emotion-59"
-                        id=":r5r:"
+                        id="«r69»"
                         tabindex="-1"
                         type="checkbox"
-                        value="neptune"
+                        value="pluto"
                       />
                       <svg
                         class="emotion-60 emotion-61"
                         fill="none"
-                        size="24"
                         viewBox="0 0 24 24"
                       >
                         <g>
                           <rect
                             class="emotion-62 emotion-63"
                             height="16"
-                            rx="2px"
+                            rx="0.125rem"
                             stroke-width="2"
                             width="16"
                             x="4"
@@ -5110,11 +5051,11 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                         >
                           <label
                             class="emotion-68 emotion-69"
-                            for=":r5r:"
+                            for="«r69»"
                           >
                             <div
                               class="emotion-4 emotion-5"
-                              data-testid="option-stack-neptune"
+                              data-testid="option-stack-pluto"
                             >
                               <div
                                 class="emotion-72 emotion-73"
@@ -5122,18 +5063,14 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
                                 <span
                                   class="emotion-74 emotion-75 emotion-15"
                                 >
-                                  <div
-                                    class="emotion-285 emotion-15"
-                                  >
-                                    Neptune 
-                                    <span
-                                      class="emotion-287 emotion-288 emotion-15"
-                                    >
-                                      Label
-                                    </span>
-                                  </div>
+                                  Pluto
                                 </span>
                               </div>
+                              <span
+                                class="emotion-77 emotion-15"
+                              >
+                                Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
+                              </span>
                             </div>
                           </label>
                         </div>
@@ -5151,7 +5088,7 @@ exports[`SelectInputV2 > renders correctly multiselect 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly not clearable 1`] = `
+exports[`SelectInput > renders correctly not clearable 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -5159,6 +5096,10 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -5170,10 +5111,10 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -5182,58 +5123,38 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -5245,10 +5166,14 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -5299,16 +5224,20 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
 
 .emotion-9 {
   color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -5316,10 +5245,10 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5328,11 +5257,11 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5342,10 +5271,10 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -5361,18 +5290,18 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rl:"
-        aria-describedby=":rl:"
+        aria-controls="«rq»"
+        aria-describedby="«rq»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rq»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="false"
@@ -5380,7 +5309,7 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":rk:"
+            id="«rp»"
             role="combobox"
             tabindex="0"
           >
@@ -5395,11 +5324,11 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -5412,7 +5341,7 @@ exports[`SelectInputV2 > renders correctly not clearable 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly readOnly 1`] = `
+exports[`SelectInput > renders correctly readOnly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -5420,6 +5349,10 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -5431,10 +5364,10 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -5443,58 +5376,38 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -5506,10 +5419,14 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -5560,11 +5477,11 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5572,6 +5489,9 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -5579,10 +5499,10 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5591,11 +5511,11 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5605,10 +5525,10 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #b5b7bd;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -5624,18 +5544,18 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rbg:"
-        aria-describedby=":rbg:"
+        aria-controls="«rd0»"
+        aria-describedby="«rd0»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rd0»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="false"
@@ -5643,7 +5563,7 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":rbf:"
+            id="«rcv»"
             role="combobox"
             tabindex="0"
           >
@@ -5658,11 +5578,11 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -5675,7 +5595,7 @@ exports[`SelectInputV2 > renders correctly readOnly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly required 1`] = `
+exports[`SelectInput > renders correctly required 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -5683,6 +5603,10 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -5694,10 +5618,10 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -5706,10 +5630,10 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
@@ -5717,166 +5641,149 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
 }
 
-.emotion-8 {
-  color: #222638;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-9 {
+  color: #3f4250;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.emotion-11 {
+  color: #b3144d;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-10 {
-  vertical-align: middle;
-  fill: #b3144d;
-  height: 8px;
-  width: 8px;
-  min-width: 8px;
-  min-height: 8px;
-}
-
-.emotion-10 .fillStroke {
-  stroke: #b3144d;
-  fill: none;
-}
-
-.emotion-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+.emotion-13 {
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
-.emotion-12[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+.emotion-13[data-size='small'] {
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
-.emotion-12[data-size='medium'] {
-  height: 40px;
+.emotion-13[data-size='medium'] {
+  height: 2.5rem;
 }
 
-.emotion-12[data-size='large'] {
-  height: 48px;
+.emotion-13[data-size='large'] {
+  height: 3rem;
 }
 
-.emotion-12[data-state='neutral'] {
+.emotion-13[data-state='neutral'] {
   border: 1px solid #d9dadd;
 }
 
-.emotion-12[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-13[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #792dd4;
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-12[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-12[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-13[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
 }
 
-.emotion-12[data-state='neutral'][data-dropdownvisible='true'] {
+.emotion-13[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.emotion-13[data-state='neutral'][data-dropdownvisible='true'] {
   border-color: #792dd4;
 }
 
-.emotion-12[data-state='success'] {
+.emotion-13[data-state='success'] {
   border: 1px solid #22674e;
 }
 
-.emotion-12[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-13[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #1b533f;
   box-shadow: 0px 0px 0px 3px #45d19f40;
 }
 
-.emotion-12[data-state='success'][data-dropdownvisible='true'] {
+.emotion-13[data-state='success'][data-dropdownvisible='true'] {
   border-color: #1b533f;
 }
 
-.emotion-12[data-state='danger'] {
+.emotion-13[data-state='danger'] {
   border: 1px solid #b3144d;
 }
 
-.emotion-12[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-13[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #92103f;
   box-shadow: 0px 0px 0px 3px #f91b6c40;
 }
 
-.emotion-12[data-state='danger'][data-dropdownvisible='true'] {
+.emotion-13[data-state='danger'][data-dropdownvisible='true'] {
   border-color: #92103f;
 }
 
-.emotion-12:not([data-disabled='true']):not([data-readonly]):hover {
+.emotion-13:not([data-disabled='true']):not([data-readonly]):hover {
   border-color: #8c40ef;
 }
 
-.emotion-12[data-readonly='true'] {
+.emotion-13[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
   cursor: default;
 }
 
-.emotion-12[data-disabled='true'] {
+.emotion-13[data-disabled='true'] {
   background: #f3f3f4;
   border-color: #e9eaeb;
   cursor: not-allowed;
 }
 
-.emotion-15 {
+.emotion-16 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -5884,17 +5791,20 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
-.emotion-17 {
+.emotion-18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5903,27 +5813,27 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-19 {
+.emotion-20 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
-.emotion-19 .fillStroke {
+.emotion-20 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
@@ -5936,11 +5846,11 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rg:"
-        aria-describedby=":rg:"
+        aria-controls="«rj»"
+        aria-describedby="«rj»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
@@ -5949,50 +5859,48 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
             class="emotion-6 emotion-5"
           >
             <label
-              class="emotion-8 emotion-9"
+              class="emotion-8 emotion-9 emotion-10"
+              for="«ri»"
             >
               label
             </label>
-            <svg
-              class="emotion-10 emotion-11"
-              viewBox="0 0 20 20"
+            <span
+              class="emotion-11 emotion-10"
             >
-              <path
-                d="M10 2h4l-.79 7.91 6.45-4.64 2 3.46L14.42 12l7.24 3.27-2 3.46-6.45-4.64L14 22h-4l.79-7.91-6.45 4.64-2-3.46L9.58 12 2.34 8.73l2-3.46 6.45 4.64z"
-              />
-            </svg>
+              *
+            </span>
           </div>
           <div
+            aria-controls="«rj»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             aria-label="label"
-            class="emotion-12 emotion-13"
+            class="emotion-13 emotion-14"
             data-disabled="false"
             data-dropdownvisible="false"
             data-readonly="false"
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":rf:"
+            id="«ri»"
             role="combobox"
             tabindex="0"
           >
             <p
-              class="emotion-14 emotion-15 emotion-9"
+              class="emotion-15 emotion-16 emotion-10"
             >
               Select item
             </p>
             <div
-              class="emotion-17 emotion-18"
+              class="emotion-18 emotion-19"
             >
               <svg
                 aria-label="show dropdown"
-                class="emotion-19 emotion-11"
-                viewBox="0 0 20 20"
+                class="emotion-20 emotion-21"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -6005,7 +5913,7 @@ exports[`SelectInputV2 > renders correctly required 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly required 2`] = `
+exports[`SelectInput > renders correctly required 2`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -6033,6 +5941,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -6042,10 +5954,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -6054,58 +5966,38 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -6117,10 +6009,14 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -6171,11 +6067,11 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6183,6 +6079,9 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -6190,10 +6089,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6202,11 +6101,11 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6216,10 +6115,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -6230,8 +6129,8 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -6247,11 +6146,12 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -6284,10 +6184,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -6296,10 +6196,9 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -6307,10 +6206,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -6319,14 +6218,14 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -6337,10 +6236,12 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -6410,10 +6311,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6422,17 +6323,16 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -6443,17 +6343,17 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -6461,10 +6361,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -6473,19 +6373,19 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -6493,10 +6393,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -6505,21 +6405,22 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-35:hover,
@@ -6527,20 +6428,19 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-35[data-selected='true'] {
+.emotion-35[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-35[disabled] {
+.emotion-35[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-35[disabled]:hover,
-.emotion-35 [disabled]:focus {
+.emotion-35[aria-disabled="true"]:hover,
+.emotion-35 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -6552,10 +6452,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -6563,19 +6463,19 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-42 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6594,11 +6494,11 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
 
 .emotion-62 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -6606,25 +6506,26 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
 }
 
 .emotion-113 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .emotion-116 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6637,14 +6538,13 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -6659,18 +6559,18 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":ram:"
-        aria-describedby=":ram:"
+        aria-controls="«rba»"
+        aria-describedby="«rba»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rba»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -6678,7 +6578,7 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":ral:"
+            id="«rb9»"
             role="combobox"
             tabindex="0"
           >
@@ -6693,11 +6593,11 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -6708,7 +6608,7 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":ram:"
+          id="«rba»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -6732,11 +6632,11 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -6747,7 +6647,7 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":rap:"
+                    id="«rbe»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -6760,16 +6660,16 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
               data-grouped="false"
               id="select-dropdown"
               role="listbox"
-              tabindex="-1"
             >
               <div
                 class="emotion-33 emotion-5"
                 id="items"
               >
                 <div
+                  aria-disabled="false"
                   aria-label="mercury"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-mercury"
                   id="option-0"
                   role="option"
@@ -6791,9 +6691,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="venus"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-venus"
                   id="option-1"
                   role="option"
@@ -6815,9 +6716,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="earth"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-earth"
                   id="option-2"
                   role="option"
@@ -6844,18 +6746,18 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="true"
                   aria-label="mars"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-mars"
-                  disabled=""
                   id="option-3"
                   role="option"
                   tabindex="-1"
                 >
                   <div
-                    aria-controls=":rb2:"
-                    aria-describedby=":rb2:"
+                    aria-controls="«rbn»"
+                    aria-describedby="«rbn»"
                     class="emotion-2 emotion-3"
                     tabindex="0"
                   >
@@ -6876,9 +6778,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="jupiter"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-jupiter"
                   id="option-4"
                   role="option"
@@ -6905,9 +6808,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="saturn"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-saturn"
                   id="option-5"
                   role="option"
@@ -6929,9 +6833,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="uranus"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-uranus"
                   id="option-6"
                   role="option"
@@ -6953,9 +6858,10 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="neptune"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-neptune"
                   id="option-7"
                   role="option"
@@ -6995,7 +6901,7 @@ exports[`SelectInputV2 > renders correctly required 2`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly small 1`] = `
+exports[`SelectInput > renders correctly small 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -7003,6 +6909,10 @@ exports[`SelectInputV2 > renders correctly small 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -7014,175 +6924,137 @@ exports[`SelectInputV2 > renders correctly small 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  gap: 0.25rem;
 }
 
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-8 {
-  color: #222638;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-7 {
+  color: #3f4250;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
 }
 
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+.emotion-9 {
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
-.emotion-10[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+.emotion-9[data-size='small'] {
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
-.emotion-10[data-size='medium'] {
-  height: 40px;
+.emotion-9[data-size='medium'] {
+  height: 2.5rem;
 }
 
-.emotion-10[data-size='large'] {
-  height: 48px;
+.emotion-9[data-size='large'] {
+  height: 3rem;
 }
 
-.emotion-10[data-state='neutral'] {
+.emotion-9[data-state='neutral'] {
   border: 1px solid #d9dadd;
 }
 
-.emotion-10[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-9[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #792dd4;
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-10[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-10[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-9[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
 }
 
-.emotion-10[data-state='neutral'][data-dropdownvisible='true'] {
+.emotion-9[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.emotion-9[data-state='neutral'][data-dropdownvisible='true'] {
   border-color: #792dd4;
 }
 
-.emotion-10[data-state='success'] {
+.emotion-9[data-state='success'] {
   border: 1px solid #22674e;
 }
 
-.emotion-10[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-9[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #1b533f;
   box-shadow: 0px 0px 0px 3px #45d19f40;
 }
 
-.emotion-10[data-state='success'][data-dropdownvisible='true'] {
+.emotion-9[data-state='success'][data-dropdownvisible='true'] {
   border-color: #1b533f;
 }
 
-.emotion-10[data-state='danger'] {
+.emotion-9[data-state='danger'] {
   border: 1px solid #b3144d;
 }
 
-.emotion-10[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-9[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #92103f;
   box-shadow: 0px 0px 0px 3px #f91b6c40;
 }
 
-.emotion-10[data-state='danger'][data-dropdownvisible='true'] {
+.emotion-9[data-state='danger'][data-dropdownvisible='true'] {
   border-color: #92103f;
 }
 
-.emotion-10:not([data-disabled='true']):not([data-readonly]):hover {
+.emotion-9:not([data-disabled='true']):not([data-readonly]):hover {
   border-color: #8c40ef;
 }
 
-.emotion-10[data-readonly='true'] {
+.emotion-9[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
   cursor: default;
 }
 
-.emotion-10[data-disabled='true'] {
+.emotion-9[data-disabled='true'] {
   background: #f3f3f4;
   border-color: #e9eaeb;
   cursor: not-allowed;
 }
 
-.emotion-13 {
+.emotion-12 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7190,17 +7062,20 @@ exports[`SelectInputV2 > renders correctly small 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
-.emotion-15 {
+.emotion-14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7209,27 +7084,27 @@ exports[`SelectInputV2 > renders correctly small 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-17 {
+.emotion-16 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
-.emotion-17 .fillStroke {
+.emotion-16 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
@@ -7242,55 +7117,52 @@ exports[`SelectInputV2 > renders correctly small 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r6:"
-        aria-describedby=":r6:"
+        aria-controls="«r7»"
+        aria-describedby="«r7»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
-          <div
-            class="emotion-6 emotion-5"
+          <label
+            class="emotion-6 emotion-7 emotion-8"
+            for="«r6»"
           >
-            <label
-              class="emotion-8 emotion-9"
-            >
-              label
-            </label>
-          </div>
+            label
+          </label>
           <div
+            aria-controls="«r7»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             aria-label="label"
-            class="emotion-10 emotion-11"
+            class="emotion-9 emotion-10"
             data-disabled="false"
             data-dropdownvisible="false"
             data-readonly="false"
             data-size="small"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r5:"
+            id="«r6»"
             role="combobox"
             tabindex="0"
           >
             <p
-              class="emotion-12 emotion-13 emotion-9"
+              class="emotion-11 emotion-12 emotion-8"
             >
               Select item
             </p>
             <div
-              class="emotion-15 emotion-16"
+              class="emotion-14 emotion-15"
             >
               <svg
                 aria-label="show dropdown"
-                class="emotion-17 emotion-18"
-                viewBox="0 0 20 20"
+                class="emotion-16 emotion-17"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -7303,7 +7175,7 @@ exports[`SelectInputV2 > renders correctly small 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
+exports[`SelectInput > renders correctly unclosable tags when readonly 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -7311,6 +7183,10 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -7322,10 +7198,10 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -7334,58 +7210,38 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -7397,10 +7253,14 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -7454,10 +7314,10 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7466,10 +7326,13 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  overflow: hidden;
+  max-width: 100%;
+  height: 100%;
 }
 
 .emotion-11 {
@@ -7486,37 +7349,45 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   -webkit-justify-content: center;
   justify-content: center;
   white-space: nowrap;
-  border-radius: 4px;
-  padding: 0 8px;
-  gap: 8px;
+  border-radius: 0.25rem;
+  padding: 0 0.5rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   color: #3f4250;
   background: #ffffff;
   border: solid 1px #d9dadd;
-  height: -webkit-fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
+  height: -webkit-max-content;
+  height: -moz-max-content;
+  height: max-content;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
+  min-width: auto;
+  max-width: 500px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.emotion-11>.emotion-3 {
+  overflow: hidden;
 }
 
 .emotion-14 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  max-width: 232px;
+  max-width: 14.5rem;
 }
 
 .emotion-16 {
@@ -7524,10 +7395,10 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7536,11 +7407,11 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7550,10 +7421,10 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
 .emotion-18 {
   vertical-align: middle;
   fill: #b5b7bd;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-18 .fillStroke {
@@ -7569,18 +7440,18 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rjs:"
-        aria-describedby=":rjs:"
+        aria-controls="«rll»"
+        aria-describedby="«rll»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rll»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="false"
@@ -7588,22 +7459,22 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":rjr:"
+            id="«rlk»"
             role="combobox"
             tabindex="0"
           >
             <div
-              class="emotion-8 emotion-5"
+              class="emotion-8 emotion-9"
             >
               <span
                 class="emotion-10 emotion-11 emotion-12"
                 data-testid="selected-options-tags"
               >
-                <span
+                <div
                   class="emotion-13 emotion-14 emotion-15"
                 >
                   Venus
-                </span>
+                </div>
               </span>
             </div>
             <div
@@ -7612,11 +7483,11 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-18 emotion-19"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -7629,7 +7500,7 @@ exports[`SelectInputV2 > renders correctly unclosable tags when readonly 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
+exports[`SelectInput > renders correctly ungrouped 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -7657,6 +7528,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -7666,10 +7541,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -7678,58 +7553,38 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -7741,10 +7596,14 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -7795,11 +7654,11 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -7807,6 +7666,9 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -7814,10 +7676,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7826,11 +7688,11 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7840,10 +7702,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -7854,8 +7716,8 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -7871,11 +7733,12 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -7908,10 +7771,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -7920,10 +7783,9 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -7931,10 +7793,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -7943,14 +7805,14 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -7961,10 +7823,12 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -8034,10 +7898,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -8046,17 +7910,16 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -8067,17 +7930,17 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -8085,10 +7948,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -8097,19 +7960,19 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -8117,10 +7980,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -8129,21 +7992,22 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-35:hover,
@@ -8151,20 +8015,19 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-35[data-selected='true'] {
+.emotion-35[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-35[disabled] {
+.emotion-35[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-35[disabled]:hover,
-.emotion-35 [disabled]:focus {
+.emotion-35[aria-disabled="true"]:hover,
+.emotion-35 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -8176,10 +8039,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -8187,19 +8050,19 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-42 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8218,11 +8081,11 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
 
 .emotion-62 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -8230,25 +8093,26 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
 }
 
 .emotion-113 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .emotion-116 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8261,14 +8125,13 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -8283,18 +8146,18 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rp:"
-        aria-describedby=":rp:"
+        aria-controls="«rv»"
+        aria-describedby="«rv»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rv»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -8302,7 +8165,7 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":ro:"
+            id="«ru»"
             role="combobox"
             tabindex="0"
           >
@@ -8317,11 +8180,11 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -8332,7 +8195,7 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":rp:"
+          id="«rv»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -8356,11 +8219,11 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -8371,7 +8234,7 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":rs:"
+                    id="«r13»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -8384,16 +8247,16 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
               data-grouped="false"
               id="select-dropdown"
               role="listbox"
-              tabindex="-1"
             >
               <div
                 class="emotion-33 emotion-5"
                 id="items"
               >
                 <div
+                  aria-disabled="false"
                   aria-label="mercury"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-mercury"
                   id="option-0"
                   role="option"
@@ -8415,9 +8278,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="venus"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-venus"
                   id="option-1"
                   role="option"
@@ -8439,9 +8303,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="earth"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-earth"
                   id="option-2"
                   role="option"
@@ -8468,18 +8333,18 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="true"
                   aria-label="mars"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-mars"
-                  disabled=""
                   id="option-3"
                   role="option"
                   tabindex="-1"
                 >
                   <div
-                    aria-controls=":r15:"
-                    aria-describedby=":r15:"
+                    aria-controls="«r1c»"
+                    aria-describedby="«r1c»"
                     class="emotion-2 emotion-3"
                     tabindex="0"
                   >
@@ -8500,9 +8365,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="jupiter"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-jupiter"
                   id="option-4"
                   role="option"
@@ -8529,9 +8395,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="saturn"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-saturn"
                   id="option-5"
                   role="option"
@@ -8553,9 +8420,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="uranus"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-uranus"
                   id="option-6"
                   role="option"
@@ -8577,9 +8445,10 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="neptune"
+                  aria-selected="false"
                   class="emotion-35 emotion-36"
-                  data-selected="false"
                   data-testid="option-neptune"
                   id="option-7"
                   role="option"
@@ -8619,7 +8488,7 @@ exports[`SelectInputV2 > renders correctly ungrouped 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with default value 1`] = `
+exports[`SelectInput > renders correctly with default value 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -8647,6 +8516,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -8656,10 +8529,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -8668,58 +8541,38 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -8731,10 +8584,14 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -8785,16 +8642,20 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
 
 .emotion-9 {
   color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -8802,10 +8663,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -8814,11 +8675,11 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8828,10 +8689,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -8842,8 +8703,8 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -8859,11 +8720,12 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -8896,10 +8758,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -8908,10 +8770,9 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -8919,10 +8780,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -8931,14 +8792,14 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -8949,10 +8810,12 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -9022,10 +8885,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9034,17 +8897,16 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -9055,17 +8917,17 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -9073,10 +8935,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -9085,19 +8947,18 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -9105,10 +8966,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -9117,16 +8978,16 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-37 {
@@ -9147,12 +9008,16 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-37:focus {
@@ -9161,8 +9026,8 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
 }
 
 .emotion-37[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-37[data-selectgroup='true']:focus {
@@ -9171,11 +9036,11 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
 
 .emotion-39 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9186,11 +9051,12 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-43:hover,
@@ -9198,20 +9064,19 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-43[data-selected='true'] {
+.emotion-43[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-43[disabled] {
+.emotion-43[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-43[disabled]:hover,
-.emotion-43 [disabled]:focus {
+.emotion-43[aria-disabled="true"]:hover,
+.emotion-43 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -9223,10 +9088,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -9234,19 +9099,19 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-50 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9263,39 +9128,40 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   max-width: 100%;
 }
 
-.emotion-70 {
+.emotion-52 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: left;
 }
 
-.emotion-140 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-81 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-143 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-84 {
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9308,14 +9174,13 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -9330,18 +9195,18 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r2i:"
-        aria-describedby=":r2i:"
+        aria-controls="«r2q»"
+        aria-describedby="«r2q»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r2q»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -9349,7 +9214,7 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r2h:"
+            id="«r2p»"
             role="combobox"
             tabindex="0"
           >
@@ -9364,11 +9229,11 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -9379,7 +9244,7 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r2i:"
+          id="«r2q»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -9403,11 +9268,11 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -9418,7 +9283,7 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r2l:"
+                    id="«r2u»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -9449,164 +9314,6 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      TERRESTRIAL PLANETS
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="emotion-33 emotion-5"
-                  id="items"
-                >
-                  <div
-                    aria-label="mercury"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mercury"
-                    id="option-0"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-mercury"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Mercury
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="venus"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-venus"
-                    id="option-1"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-venus"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Venus
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="earth"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-earth"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-earth"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Earth
-                        </span>
-                      </div>
-                      <span
-                        class="emotion-70 emotion-10"
-                      >
-                        Our home planet
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="mars"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mars"
-                    disabled=""
-                    id="option-3"
-                    role="option"
-                    tabindex="-1"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-mars"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Mars
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="pluto"
-                    class="emotion-43 emotion-44"
-                    data-selected="true"
-                    data-testid="option-pluto"
-                    id="option-4"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-pluto"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Pluto
-                        </span>
-                      </div>
-                      <span
-                        class="emotion-70 emotion-10"
-                      >
-                        Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="emotion-33 emotion-5"
-              >
-                <div
-                  class="emotion-35 emotion-36"
-                >
-                  <button
-                    class="emotion-37 emotion-38"
-                    data-selectgroup="false"
-                    data-testid="group-1"
-                    role="group"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <span
-                      class="emotion-39 emotion-10"
-                    >
                       JOVIAN PLANETS
                     </span>
                   </button>
@@ -9616,9 +9323,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                   id="items"
                 >
                   <div
+                    aria-disabled="false"
                     aria-label="jupiter"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-jupiter"
                     id="option-0"
                     role="option"
@@ -9638,16 +9346,17 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                         </span>
                       </div>
                       <span
-                        class="emotion-70 emotion-10"
+                        class="emotion-52 emotion-10"
                       >
                         Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
                       </span>
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="saturn"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-saturn"
                     id="option-1"
                     role="option"
@@ -9669,9 +9378,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="uranus"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-uranus"
                     id="option-2"
                     role="option"
@@ -9693,9 +9403,10 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="neptune"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-neptune"
                     id="option-3"
                     role="option"
@@ -9712,17 +9423,179 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
                           class="emotion-49 emotion-50 emotion-10"
                         >
                           <div
-                            class="emotion-140 emotion-10"
+                            class="emotion-81 emotion-10"
                           >
                             Neptune 
                             <span
-                              class="emotion-142 emotion-143 emotion-10"
+                              class="emotion-83 emotion-84 emotion-10"
                             >
                               Label
                             </span>
                           </div>
                         </span>
                       </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-33 emotion-5"
+              >
+                <div
+                  class="emotion-35 emotion-36"
+                >
+                  <button
+                    class="emotion-37 emotion-38"
+                    data-selectgroup="false"
+                    data-testid="group-1"
+                    role="group"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-39 emotion-10"
+                    >
+                      TERRESTRIAL PLANETS
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="emotion-33 emotion-5"
+                  id="items"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-label="mercury"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mercury"
+                    id="option-0"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-mercury"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mercury
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="venus"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-venus"
+                    id="option-1"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-venus"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Venus
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="earth"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-earth"
+                    id="option-2"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-earth"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Earth
+                        </span>
+                      </div>
+                      <span
+                        class="emotion-52 emotion-10"
+                      >
+                        Our home planet
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="mars"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mars"
+                    id="option-3"
+                    role="option"
+                    tabindex="-1"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-mars"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mars
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="pluto"
+                    aria-selected="true"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-pluto"
+                    id="option-4"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-pluto"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Pluto
+                        </span>
+                      </div>
+                      <span
+                        class="emotion-52 emotion-10"
+                      >
+                        Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -9736,7 +9609,7 @@ exports[`SelectInputV2 > renders correctly with default value 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
+exports[`SelectInput > renders correctly with dropdownAlign 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -9764,6 +9637,10 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -9773,10 +9650,10 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -9785,58 +9662,38 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -9848,10 +9705,14 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -9902,11 +9763,11 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -9914,6 +9775,9 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -9921,10 +9785,10 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9933,11 +9797,11 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9947,10 +9811,10 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -9961,8 +9825,8 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -9978,11 +9842,12 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -10015,10 +9880,10 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -10027,21 +9892,125 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
-.emotion-20 {
+.emotion-21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 16px;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  height: 2.5rem;
+  background: #ffffff;
+  border: 1px solid #d9dadd;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
+}
+
+.emotion-23>.emotion-30 {
+  color: #3f4250;
+}
+
+.emotion-23>.emotion-30::-webkit-input-placeholder {
+  color: #727683;
+}
+
+.emotion-23>.emotion-30::-moz-placeholder {
+  color: #727683;
+}
+
+.emotion-23>.emotion-30:-ms-input-placeholder {
+  color: #727683;
+}
+
+.emotion-23>.emotion-30::placeholder {
+  color: #727683;
+}
+
+.emotion-23[data-success='true'] {
+  border-color: #22674e;
+}
+
+.emotion-23[data-error='true'] {
+  border-color: #b3144d;
+}
+
+.emotion-23[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+}
+
+.emotion-23[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+}
+
+.emotion-23[data-disabled='true']>.emotion-30 {
+  color: #b5b7bd;
+}
+
+.emotion-23[data-disabled='true']>.emotion-30::-webkit-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-23[data-disabled='true']>.emotion-30::-moz-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-23[data-disabled='true']>.emotion-30:-ms-input-placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-23[data-disabled='true']>.emotion-30::placeholder {
+  color: #b5b7bd;
+}
+
+.emotion-23:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10050,41 +10019,262 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
+  border-right: 1px solid;
+  border-color: inherit;
+}
+
+.emotion-25[data-size="small"] {
+  padding: 0.5rem;
+}
+
+.emotion-29 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  border: none;
+  outline: none;
+  height: 100%;
+  width: 100%;
+  padding-left: 1rem;
+  background: transparent;
+  font-size: 0.875rem;
+}
+
+.emotion-29[data-size='large'] {
+  font-size: 1rem;
+}
+
+.emotion-29[data-size='small'] {
+  padding-left: 0.5rem;
+}
+
+.emotion-31 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
+  max-height: 256px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
+}
+
+.emotion-31[data-grouped="true"] {
+  padding-top: 0rem;
+}
+
+.emotion-33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.emotion-35 {
+  text-align: left;
+  border: none;
+  background-color: #ffffff;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  color: #3f4250;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
+}
+
+.emotion-35:hover,
+.emotion-35:focus {
+  background-color: #f1eefc;
+  color: #641cb3;
+  cursor: pointer;
+}
+
+.emotion-35[aria-selected='true'] {
+  background-color: #f1eefc;
+}
+
+.emotion-35[aria-disabled="true"] {
+  background-color: #f3f3f4;
+  color: #b5b7bd;
+}
+
+.emotion-35[aria-disabled="true"]:hover,
+.emotion-35 [aria-disabled="true"]:focus {
+  background-color: #f3f3f4;
+  color: #b5b7bd;
+  cursor: not-allowed;
+  outline: none;
+}
+
+.emotion-39 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
+  overflow: hidden;
+}
+
+.emotion-42 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: left;
+  overflow: auto;
+  text-overflow: ellipsis;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  max-width: 100%;
+}
+
+.emotion-62 {
+  color: #727683;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.25rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: left;
+}
+
+.emotion-113 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-116 {
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: 1.5rem;
+  text-transform: uppercase;
+  color: #3f4250;
+  background: #f9f9fa;
+  border: 1px solid #d9dadd;
 }
 
 <div
     data-testid="testing"
   >
     <div
-      aria-label="emptystate"
+      aria-label="test"
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rae:"
-        aria-describedby=":rae:"
+        aria-controls="«rc5»"
+        aria-describedby="«rc5»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rc5»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
             data-readonly="false"
             data-size="large"
             data-state="neutral"
-            data-testid="select-input-emptystate"
-            id=":rad:"
+            data-testid="select-input-test"
+            id="«rc4»"
             role="combobox"
             tabindex="0"
           >
@@ -10099,11 +10289,11 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -10114,7 +10304,7 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":rae:"
+          id="«rc5»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -10122,9 +10312,282 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
             class="emotion-18 emotion-5"
           >
             <div
-              class="emotion-20 emotion-21"
+              class="emotion-20 emotion-21 emotion-5"
             >
-              no option
+              <div>
+                <div
+                  class="emotion-23 emotion-24"
+                  data-disabled="false"
+                  data-error="false"
+                  data-readonly="false"
+                  data-success="false"
+                >
+                  <div
+                    class="emotion-25 emotion-26"
+                    data-size="medium"
+                  >
+                    <svg
+                      class="emotion-13 emotion-14"
+                      viewBox="0 0 16 16"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-invalid="false"
+                    aria-label="search-bar"
+                    class="emotion-29 emotion-30"
+                    data-size="medium"
+                    data-testid="search-bar"
+                    id="«rc9»"
+                    placeholder="placeholdersearch"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="emotion-31 emotion-32"
+              data-grouped="false"
+              id="select-dropdown"
+              role="listbox"
+            >
+              <div
+                class="emotion-33 emotion-5"
+                id="items"
+              >
+                <div
+                  aria-disabled="false"
+                  aria-label="mercury"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-mercury"
+                  id="option-0"
+                  role="option"
+                  tabindex="0"
+                >
+                  <div
+                    class="emotion-4 emotion-5"
+                    data-testid="option-stack-mercury"
+                  >
+                    <div
+                      class="emotion-39 emotion-40"
+                    >
+                      <span
+                        class="emotion-41 emotion-42 emotion-10"
+                      >
+                        Mercury
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="venus"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-venus"
+                  id="option-1"
+                  role="option"
+                  tabindex="0"
+                >
+                  <div
+                    class="emotion-4 emotion-5"
+                    data-testid="option-stack-venus"
+                  >
+                    <div
+                      class="emotion-39 emotion-40"
+                    >
+                      <span
+                        class="emotion-41 emotion-42 emotion-10"
+                      >
+                        Venus
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="earth"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-earth"
+                  id="option-2"
+                  role="option"
+                  tabindex="0"
+                >
+                  <div
+                    class="emotion-4 emotion-5"
+                    data-testid="option-stack-earth"
+                  >
+                    <div
+                      class="emotion-39 emotion-40"
+                    >
+                      <span
+                        class="emotion-41 emotion-42 emotion-10"
+                      >
+                        Earth
+                      </span>
+                    </div>
+                    <span
+                      class="emotion-62 emotion-10"
+                    >
+                      Our home planet
+                    </span>
+                  </div>
+                </div>
+                <div
+                  aria-disabled="true"
+                  aria-label="mars"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-mars"
+                  id="option-3"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <div
+                    aria-controls="«rci»"
+                    aria-describedby="«rci»"
+                    class="emotion-2 emotion-3"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-mars"
+                    >
+                      <div
+                        class="emotion-39 emotion-40"
+                      >
+                        <span
+                          class="emotion-41 emotion-42 emotion-10"
+                        >
+                          Mars
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="jupiter"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-jupiter"
+                  id="option-4"
+                  role="option"
+                  tabindex="0"
+                >
+                  <div
+                    class="emotion-4 emotion-5"
+                    data-testid="option-stack-jupiter"
+                  >
+                    <div
+                      class="emotion-39 emotion-40"
+                    >
+                      <span
+                        class="emotion-41 emotion-42 emotion-10"
+                      >
+                        Jupiter
+                      </span>
+                    </div>
+                    <span
+                      class="emotion-62 emotion-10"
+                    >
+                      Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
+                    </span>
+                  </div>
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="saturn"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-saturn"
+                  id="option-5"
+                  role="option"
+                  tabindex="0"
+                >
+                  <div
+                    class="emotion-4 emotion-5"
+                    data-testid="option-stack-saturn"
+                  >
+                    <div
+                      class="emotion-39 emotion-40"
+                    >
+                      <span
+                        class="emotion-41 emotion-42 emotion-10"
+                      >
+                        Saturn
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="uranus"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-uranus"
+                  id="option-6"
+                  role="option"
+                  tabindex="0"
+                >
+                  <div
+                    class="emotion-4 emotion-5"
+                    data-testid="option-stack-uranus"
+                  >
+                    <div
+                      class="emotion-39 emotion-40"
+                    >
+                      <span
+                        class="emotion-41 emotion-42 emotion-10"
+                      >
+                        Uranus
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-label="neptune"
+                  aria-selected="false"
+                  class="emotion-35 emotion-36"
+                  data-testid="option-neptune"
+                  id="option-7"
+                  role="option"
+                  tabindex="0"
+                >
+                  <div
+                    class="emotion-4 emotion-5"
+                    data-testid="option-stack-neptune"
+                  >
+                    <div
+                      class="emotion-39 emotion-40"
+                    >
+                      <span
+                        class="emotion-41 emotion-42 emotion-10"
+                      >
+                        <div
+                          class="emotion-113 emotion-10"
+                        >
+                          Neptune 
+                          <span
+                            class="emotion-115 emotion-116 emotion-10"
+                          >
+                            Label
+                          </span>
+                        </div>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -10134,7 +10597,7 @@ exports[`SelectInputV2 > renders correctly with emptyState 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with error 1`] = `
+exports[`SelectInput > renders correctly with emptyState 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -10162,6 +10625,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -10171,10 +10638,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -10183,58 +10650,38 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -10246,10 +10693,14 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -10300,11 +10751,11 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10312,6 +10763,9 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -10319,10 +10773,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10331,11 +10785,11 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10344,37 +10798,23 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
 
 .emotion-13 {
   vertical-align: middle;
-  fill: #b3144d;
-  height: 1em;
-  width: 1em;
-  min-width: 1em;
-  min-height: 1em;
+  fill: #3f4250;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
-  stroke: #b3144d;
-  fill: none;
-}
-
-.emotion-15 {
-  vertical-align: middle;
-  fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
-}
-
-.emotion-15 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
 
-.emotion-18 {
+.emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -10390,11 +10830,415 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
+}
+
+.emotion-16[data-animated="true"] {
+  -webkit-animation: 0ms animation-0 forwards;
+  animation: 0ms animation-0 forwards;
+}
+
+.emotion-16[data-has-arrow="true"]::after {
+  content: " ";
+  position: absolute;
+  top: -5px;
+  left: 0px;
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  margin-left: -8px;
+  border-width: 8px;
+  border-style: solid;
+  border-color: #151a2d transparent transparent transparent;
+  pointer-events: none;
+}
+
+.emotion-16[data-visible-in-dom="false"] {
+  display: none;
+}
+
+.emotion-18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+<div
+    data-testid="testing"
+  >
+    <div
+      aria-label="emptystate"
+      class="emotion-0 emotion-1"
+    >
+      <div
+        aria-controls="«rb0»"
+        aria-describedby="«rb0»"
+        class="emotion-2 emotion-3"
+        data-container-full-width="true"
+        tabindex="-1"
+      >
+        <div
+          class="emotion-4 emotion-5"
+        >
+          <div
+            aria-controls="«rb0»"
+            aria-expanded="true"
+            class="emotion-6 emotion-7"
+            data-disabled="false"
+            data-dropdownvisible="true"
+            data-readonly="false"
+            data-size="large"
+            data-state="neutral"
+            data-testid="select-input-emptystate"
+            id="«rav»"
+            role="combobox"
+            tabindex="0"
+          >
+            <p
+              class="emotion-8 emotion-9 emotion-10"
+            >
+              placeholder
+            </p>
+            <div
+              class="emotion-11 emotion-12"
+            >
+              <svg
+                aria-label="show dropdown"
+                class="emotion-13 emotion-14"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="emotion-15 emotion-16 emotion-17"
+          data-animated="false"
+          data-has-arrow="false"
+          id="«rb0»"
+          role="dialog"
+          style="opacity: 1;"
+        >
+          <div
+            class="emotion-18 emotion-5"
+          >
+            <div
+              class="emotion-20 emotion-21"
+            >
+              no option
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SelectInput > renders correctly with error 1`] = `
+<DocumentFragment>
+  @keyframes animation-0 {
+  0% {
+    opacity: 0;
+    -webkit-transform: translate3d(0px, 4px, 0);
+    -moz-transform: translate3d(0px, 4px, 0);
+    -ms-transform: translate3d(0px, 4px, 0);
+    transform: translate3d(0px, 4px, 0);
+  }
+
+  100% {
+    opacity: 1;
+    -webkit-transform: translate3d(0px, 4px, 0);
+    -moz-transform: translate3d(0px, 4px, 0);
+    -ms-transform: translate3d(0px, 4px, 0);
+    transform: translate3d(0px, 4px, 0);
+  }
+}
+
+.emotion-0 {
+  width: 100%;
+}
+
+.emotion-2 {
+  display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
+.emotion-2[data-container-full-width="true"] {
+  width: 100%;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.emotion-6 {
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
+  padding-right: 0;
+  padding-left: 1rem;
+  cursor: pointer;
+  box-shadow: none;
+  background: #ffffff;
+  border-radius: 0.25rem;
+  width: 100%;
+}
+
+.emotion-6[data-size='small'] {
+  height: 2rem;
+  padding-left: 0.5rem;
+}
+
+.emotion-6[data-size='medium'] {
+  height: 2.5rem;
+}
+
+.emotion-6[data-size='large'] {
+  height: 3rem;
+}
+
+.emotion-6[data-state='neutral'] {
+  border: 1px solid #d9dadd;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+  border-color: #792dd4;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
+  border-color: #792dd4;
+  outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
+  border-color: #792dd4;
+}
+
+.emotion-6[data-state='success'] {
+  border: 1px solid #22674e;
+}
+
+.emotion-6[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+  border-color: #1b533f;
+  box-shadow: 0px 0px 0px 3px #45d19f40;
+}
+
+.emotion-6[data-state='success'][data-dropdownvisible='true'] {
+  border-color: #1b533f;
+}
+
+.emotion-6[data-state='danger'] {
+  border: 1px solid #b3144d;
+}
+
+.emotion-6[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+  border-color: #92103f;
+  box-shadow: 0px 0px 0px 3px #f91b6c40;
+}
+
+.emotion-6[data-state='danger'][data-dropdownvisible='true'] {
+  border-color: #92103f;
+}
+
+.emotion-6:not([data-disabled='true']):not([data-readonly]):hover {
+  border-color: #8c40ef;
+}
+
+.emotion-6[data-readonly='true'] {
+  background: #f9f9fa;
+  border-color: #d9dadd;
+  cursor: default;
+}
+
+.emotion-6[data-disabled='true'] {
+  background: #f3f3f4;
+  border-color: #e9eaeb;
+  cursor: not-allowed;
+}
+
+.emotion-9 {
+  color: #727683;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-13 {
+  vertical-align: middle;
+  fill: #b3144d;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
+}
+
+.emotion-13 .fillStroke {
+  stroke: #b3144d;
+  fill: none;
+}
+
+.emotion-15 {
+  vertical-align: middle;
+  fill: #3f4250;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
+}
+
+.emotion-15 .fillStroke {
+  stroke: #3f4250;
+  fill: none;
+}
+
+.emotion-18 {
+  background: #151a2d;
+  color: #ffffff;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+  position: absolute;
+  max-width: 500px;
+  overflow-wrap: break-word;
+  font-size: 0.8rem;
+  inset: 0 auto auto 0;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  -webkit-transform: translate3d(0px, 4px, 0);
+  -moz-transform: translate3d(0px, 4px, 0);
+  -ms-transform: translate3d(0px, 4px, 0);
+  transform: translate3d(0px, 4px, 0);
+  width: 100%;
+  min-width: 320px;
+  background-color: #ffffff;
+  color: #3f4250;
+  box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-18[data-animated="true"] {
@@ -10427,10 +11271,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -10439,10 +11283,9 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-23 {
@@ -10450,10 +11293,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -10462,14 +11305,14 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-25 {
@@ -10480,10 +11323,12 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-25>.emotion-32 {
@@ -10553,10 +11398,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10565,17 +11410,16 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-27[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-31 {
@@ -10586,17 +11430,17 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-31[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-31[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-33 {
@@ -10604,10 +11448,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -10616,19 +11460,19 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-33[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-35 {
@@ -10636,10 +11480,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -10648,21 +11492,22 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-37 {
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-37:hover,
@@ -10670,20 +11515,19 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-37[data-selected='true'] {
+.emotion-37[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-37[disabled] {
+.emotion-37[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-37[disabled]:hover,
-.emotion-37 [disabled]:focus {
+.emotion-37[aria-disabled="true"]:hover,
+.emotion-37 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -10695,10 +11539,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -10706,19 +11550,19 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-44 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10737,11 +11581,11 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
 
 .emotion-64 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -10749,25 +11593,26 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
 }
 
 .emotion-115 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .emotion-118 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -10780,14 +11625,13 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -10796,15 +11640,15 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
 
 .emotion-121 {
   color: #b3144d;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  padding-top: 4px;
+  padding-top: 0.25rem;
 }
 
 <div
@@ -10815,18 +11659,18 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rbk:"
-        aria-describedby=":rbk:"
+        aria-controls="«rd5»"
+        aria-describedby="«rd5»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«rd5»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -10834,7 +11678,7 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
             data-size="large"
             data-state="danger"
             data-testid="select-input-test"
-            id=":rbj:"
+            id="«rd4»"
             role="combobox"
             tabindex="0"
           >
@@ -10848,22 +11692,22 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
             >
               <svg
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0m-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5m0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2"
+                  d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM8 4C8.41421 4 8.75 4.33579 8.75 4.75V7.75C8.75 8.16421 8.41421 8.5 8 8.5C7.58579 8.5 7.25 8.16421 7.25 7.75V4.75C7.25 4.33579 7.58579 4 8 4ZM8 12C8.55228 12 9 11.5523 9 11C9 10.4477 8.55228 10 8 10C7.44772 10 7 10.4477 7 11C7 11.5523 7.44772 12 8 12Z"
                   fill-rule="evenodd"
                 />
               </svg>
               <svg
                 aria-label="show dropdown"
                 class="emotion-15 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -10874,7 +11718,7 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
           class="emotion-17 emotion-18 emotion-19"
           data-animated="false"
           data-has-arrow="false"
-          id=":rbk:"
+          id="«rd5»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -10898,11 +11742,11 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   >
                     <svg
                       class="emotion-15 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -10913,7 +11757,7 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                     class="emotion-31 emotion-32"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":rbo:"
+                    id="«rda»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -10926,16 +11770,16 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
               data-grouped="false"
               id="select-dropdown"
               role="listbox"
-              tabindex="-1"
             >
               <div
                 class="emotion-35 emotion-5"
                 id="items"
               >
                 <div
+                  aria-disabled="false"
                   aria-label="mercury"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-mercury"
                   id="option-0"
                   role="option"
@@ -10957,9 +11801,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="venus"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-venus"
                   id="option-1"
                   role="option"
@@ -10981,9 +11826,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="earth"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-earth"
                   id="option-2"
                   role="option"
@@ -11010,18 +11856,18 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="true"
                   aria-label="mars"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-mars"
-                  disabled=""
                   id="option-3"
                   role="option"
                   tabindex="-1"
                 >
                   <div
-                    aria-controls=":rc1:"
-                    aria-describedby=":rc1:"
+                    aria-controls="«rdj»"
+                    aria-describedby="«rdj»"
                     class="emotion-2 emotion-3"
                     tabindex="0"
                   >
@@ -11042,9 +11888,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="jupiter"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-jupiter"
                   id="option-4"
                   role="option"
@@ -11071,9 +11918,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="saturn"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-saturn"
                   id="option-5"
                   role="option"
@@ -11095,9 +11943,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="uranus"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-uranus"
                   id="option-6"
                   role="option"
@@ -11119,9 +11968,10 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="neptune"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-neptune"
                   id="option-7"
                   role="option"
@@ -11166,7 +12016,7 @@ exports[`SelectInputV2 > renders correctly with error 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with footer 1`] = `
+exports[`SelectInput > renders correctly with footer 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -11194,6 +12044,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -11203,10 +12057,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -11215,58 +12069,38 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -11278,10 +12112,14 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -11332,16 +12170,20 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
 
 .emotion-9 {
   color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -11349,10 +12191,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11361,11 +12203,11 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11375,10 +12217,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -11389,8 +12231,8 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -11406,11 +12248,12 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -11443,10 +12286,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -11455,10 +12298,9 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -11466,10 +12308,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -11478,14 +12320,14 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -11496,10 +12338,12 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -11569,10 +12413,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11581,17 +12425,16 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -11602,17 +12445,17 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -11620,10 +12463,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -11632,19 +12475,18 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -11652,10 +12494,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -11664,16 +12506,16 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-37 {
@@ -11694,12 +12536,16 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-37:focus {
@@ -11708,8 +12554,8 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
 }
 
 .emotion-37[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-37[data-selectgroup='true']:focus {
@@ -11718,11 +12564,11 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
 
 .emotion-39 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -11733,11 +12579,12 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-43:hover,
@@ -11745,20 +12592,19 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-43[data-selected='true'] {
+.emotion-43[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-43[disabled] {
+.emotion-43[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-43[disabled]:hover,
-.emotion-43 [disabled]:focus {
+.emotion-43[aria-disabled="true"]:hover,
+.emotion-43 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -11770,10 +12616,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -11781,19 +12627,19 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-50 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -11810,39 +12656,40 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   max-width: 100%;
 }
 
-.emotion-70 {
+.emotion-52 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: left;
 }
 
-.emotion-140 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-81 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-143 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-84 {
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11855,14 +12702,13 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -11871,7 +12717,7 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
 
 .emotion-145 {
   width: 100%;
-  padding: 12px 16px 12px 16px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
   box-shadow: 0px 4px 24px 6px #d9dadd66;
 }
 
@@ -11883,18 +12729,18 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r3h:"
-        aria-describedby=":r3h:"
+        aria-controls="«r3q»"
+        aria-describedby="«r3q»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r3q»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -11902,7 +12748,7 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r3g:"
+            id="«r3p»"
             role="combobox"
             tabindex="0"
           >
@@ -11917,11 +12763,11 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -11932,7 +12778,7 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r3h:"
+          id="«r3q»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -11956,11 +12802,11 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -11971,7 +12817,7 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r3k:"
+                    id="«r3u»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -12002,164 +12848,6 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      TERRESTRIAL PLANETS
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="emotion-33 emotion-5"
-                  id="items"
-                >
-                  <div
-                    aria-label="mercury"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mercury"
-                    id="option-0"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-mercury"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Mercury
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="venus"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-venus"
-                    id="option-1"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-venus"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Venus
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="earth"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-earth"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-earth"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Earth
-                        </span>
-                      </div>
-                      <span
-                        class="emotion-70 emotion-10"
-                      >
-                        Our home planet
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="mars"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mars"
-                    disabled=""
-                    id="option-3"
-                    role="option"
-                    tabindex="-1"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-mars"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Mars
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="pluto"
-                    class="emotion-43 emotion-44"
-                    data-selected="true"
-                    data-testid="option-pluto"
-                    id="option-4"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-pluto"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Pluto
-                        </span>
-                      </div>
-                      <span
-                        class="emotion-70 emotion-10"
-                      >
-                        Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="emotion-33 emotion-5"
-              >
-                <div
-                  class="emotion-35 emotion-36"
-                >
-                  <button
-                    class="emotion-37 emotion-38"
-                    data-selectgroup="false"
-                    data-testid="group-1"
-                    role="group"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <span
-                      class="emotion-39 emotion-10"
-                    >
                       JOVIAN PLANETS
                     </span>
                   </button>
@@ -12169,9 +12857,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                   id="items"
                 >
                   <div
+                    aria-disabled="false"
                     aria-label="jupiter"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-jupiter"
                     id="option-0"
                     role="option"
@@ -12191,16 +12880,17 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                         </span>
                       </div>
                       <span
-                        class="emotion-70 emotion-10"
+                        class="emotion-52 emotion-10"
                       >
                         Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
                       </span>
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="saturn"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-saturn"
                     id="option-1"
                     role="option"
@@ -12222,9 +12912,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="uranus"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-uranus"
                     id="option-2"
                     role="option"
@@ -12246,9 +12937,10 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="neptune"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-neptune"
                     id="option-3"
                     role="option"
@@ -12265,17 +12957,179 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
                           class="emotion-49 emotion-50 emotion-10"
                         >
                           <div
-                            class="emotion-140 emotion-10"
+                            class="emotion-81 emotion-10"
                           >
                             Neptune 
                             <span
-                              class="emotion-142 emotion-143 emotion-10"
+                              class="emotion-83 emotion-84 emotion-10"
                             >
                               Label
                             </span>
                           </div>
                         </span>
                       </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-33 emotion-5"
+              >
+                <div
+                  class="emotion-35 emotion-36"
+                >
+                  <button
+                    class="emotion-37 emotion-38"
+                    data-selectgroup="false"
+                    data-testid="group-1"
+                    role="group"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-39 emotion-10"
+                    >
+                      TERRESTRIAL PLANETS
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="emotion-33 emotion-5"
+                  id="items"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-label="mercury"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mercury"
+                    id="option-0"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-mercury"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mercury
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="venus"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-venus"
+                    id="option-1"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-venus"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Venus
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="earth"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-earth"
+                    id="option-2"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-earth"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Earth
+                        </span>
+                      </div>
+                      <span
+                        class="emotion-52 emotion-10"
+                      >
+                        Our home planet
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="mars"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mars"
+                    id="option-3"
+                    role="option"
+                    tabindex="-1"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-mars"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mars
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="pluto"
+                    aria-selected="true"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-pluto"
+                    id="option-4"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-pluto"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Pluto
+                        </span>
+                      </div>
+                      <span
+                        class="emotion-52 emotion-10"
+                      >
+                        Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -12294,7 +13148,7 @@ exports[`SelectInputV2 > renders correctly with footer 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with function footer 1`] = `
+exports[`SelectInput > renders correctly with function footer 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -12302,6 +13156,10 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -12313,10 +13171,10 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -12325,58 +13183,38 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -12388,10 +13226,14 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -12442,16 +13284,20 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
 
 .emotion-9 {
   color: #3f4250;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -12459,10 +13305,10 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -12471,11 +13317,11 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12485,10 +13331,10 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -12504,18 +13350,18 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r1st:"
-        aria-describedby=":r1st:"
+        aria-controls="«r24l»"
+        aria-describedby="«r24l»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r24l»"
             aria-expanded="false"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="false"
@@ -12523,7 +13369,7 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r1ss:"
+            id="«r24k»"
             role="combobox"
             tabindex="0"
           >
@@ -12538,11 +13384,11 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -12555,7 +13401,7 @@ exports[`SelectInputV2 > renders correctly with function footer 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with label on the bottom and optional info on the left 1`] = `
+exports[`SelectInput > renders correctly with label on the bottom and optional info on the left 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -12583,6 +13429,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -12592,10 +13442,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -12604,58 +13454,38 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -12667,10 +13497,14 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -12721,11 +13555,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -12733,6 +13567,9 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -12740,10 +13577,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -12752,11 +13589,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12766,10 +13603,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -12780,8 +13617,8 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -12797,11 +13634,12 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -12834,10 +13672,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -12846,10 +13684,9 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -12857,10 +13694,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -12869,14 +13706,14 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -12887,10 +13724,12 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -12960,10 +13799,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -12972,17 +13811,16 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -12993,17 +13831,17 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -13011,10 +13849,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -13023,19 +13861,18 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -13043,10 +13880,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -13055,16 +13892,16 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-37 {
@@ -13085,12 +13922,16 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-37:focus {
@@ -13099,8 +13940,8 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 }
 
 .emotion-37[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-37[data-selectgroup='true']:focus {
@@ -13109,11 +13950,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 
 .emotion-39 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -13124,11 +13965,12 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-43:hover,
@@ -13136,20 +13978,19 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-43[data-selected='true'] {
+.emotion-43[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-43[disabled] {
+.emotion-43[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-43[disabled]:hover,
-.emotion-43 [disabled]:focus {
+.emotion-43[aria-disabled="true"]:hover,
+.emotion-43 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -13161,10 +14002,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -13173,21 +14014,22 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: left;
   -webkit-justify-content: left;
   justify-content: left;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
 }
 
 .emotion-48 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13200,14 +14042,13 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -13219,10 +14060,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -13231,19 +14072,19 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-53 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -13260,15 +14101,28 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   max-width: 100%;
 }
 
-.emotion-69 {
+.emotion-55 {
+  color: #727683;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.25rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: left;
+}
+
+.emotion-59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -13276,31 +14130,18 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
 }
 
-.emotion-76 {
-  color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-150 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-align: left;
-}
-
-.emotion-96 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -13315,18 +14156,18 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r86:"
-        aria-describedby=":r86:"
+        aria-controls="«r8l»"
+        aria-describedby="«r8l»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r8l»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -13334,7 +14175,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r85:"
+            id="«r8k»"
             role="combobox"
             tabindex="0"
           >
@@ -13349,11 +14190,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -13364,7 +14205,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r86:"
+          id="«r8l»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -13388,11 +14229,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -13403,7 +14244,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r89:"
+                    id="«r8p»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -13434,177 +14275,6 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      TERRESTRIAL PLANETS
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="emotion-33 emotion-5"
-                  id="items"
-                >
-                  <div
-                    aria-label="mercury"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mercury"
-                    id="option-0"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                    >
-                      <span
-                        class="emotion-47 emotion-48 emotion-10"
-                      >
-                        Optional info
-                      </span>
-                      <div
-                        class="emotion-50 emotion-51"
-                        data-testid="option-stack-mercury"
-                      >
-                        <span
-                          class="emotion-52 emotion-53 emotion-10"
-                        >
-                          Mercury
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="venus"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-venus"
-                    id="option-1"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                    >
-                      <span
-                        class="emotion-47 emotion-48 emotion-10"
-                      >
-                        Optional info
-                      </span>
-                      <div
-                        class="emotion-50 emotion-51"
-                        data-testid="option-stack-venus"
-                      >
-                        <span
-                          class="emotion-52 emotion-53 emotion-10"
-                        >
-                          Venus
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="earth"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-earth"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-69 emotion-5"
-                    >
-                      <div
-                        class="emotion-50 emotion-51"
-                        data-testid="option-stack-earth"
-                      >
-                        <span
-                          class="emotion-52 emotion-53 emotion-10"
-                        >
-                          Earth
-                        </span>
-                        <span
-                          class="emotion-76 emotion-10"
-                        >
-                          Our home planet
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="mars"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mars"
-                    id="option-3"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-69 emotion-5"
-                    >
-                      <div
-                        class="emotion-50 emotion-51"
-                        data-testid="option-stack-mars"
-                      >
-                        <span
-                          class="emotion-52 emotion-53 emotion-10"
-                        >
-                          Mars
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="pluto"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-pluto"
-                    id="option-4"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-69 emotion-5"
-                    >
-                      <div
-                        class="emotion-50 emotion-51"
-                        data-testid="option-stack-pluto"
-                      >
-                        <span
-                          class="emotion-52 emotion-53 emotion-10"
-                        >
-                          <div
-                            class="emotion-96 emotion-10"
-                          >
-                            Pluto
-                          </div>
-                        </span>
-                        <span
-                          class="emotion-76 emotion-10"
-                        >
-                          Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="emotion-33 emotion-5"
-              >
-                <div
-                  class="emotion-35 emotion-36"
-                >
-                  <button
-                    class="emotion-37 emotion-38"
-                    data-selectgroup="false"
-                    data-testid="group-1"
-                    role="group"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <span
-                      class="emotion-39 emotion-10"
-                    >
                       JOVIAN PLANETS
                     </span>
                   </button>
@@ -13614,9 +14284,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                   id="items"
                 >
                   <div
+                    aria-disabled="false"
                     aria-label="jupiter"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-jupiter"
                     id="option-0"
                     role="option"
@@ -13640,7 +14311,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                           Jupiter
                         </span>
                         <span
-                          class="emotion-76 emotion-10"
+                          class="emotion-55 emotion-10"
                         >
                           Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
                         </span>
@@ -13648,16 +14319,17 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="saturn"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-saturn"
                     id="option-1"
                     role="option"
                     tabindex="0"
                   >
                     <div
-                      class="emotion-69 emotion-5"
+                      class="emotion-59 emotion-5"
                     >
                       <div
                         class="emotion-50 emotion-51"
@@ -13672,9 +14344,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="uranus"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-uranus"
                     id="option-2"
                     role="option"
@@ -13701,16 +14374,17 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="neptune"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-neptune"
                     id="option-3"
                     role="option"
                     tabindex="0"
                   >
                     <div
-                      class="emotion-69 emotion-5"
+                      class="emotion-59 emotion-5"
                     >
                       <div
                         class="emotion-50 emotion-51"
@@ -13726,6 +14400,182 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                   </div>
                 </div>
               </div>
+              <div
+                class="emotion-33 emotion-5"
+              >
+                <div
+                  class="emotion-35 emotion-36"
+                >
+                  <button
+                    class="emotion-37 emotion-38"
+                    data-selectgroup="false"
+                    data-testid="group-1"
+                    role="group"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-39 emotion-10"
+                    >
+                      TERRESTRIAL PLANETS
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="emotion-33 emotion-5"
+                  id="items"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-label="mercury"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mercury"
+                    id="option-0"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                    >
+                      <span
+                        class="emotion-47 emotion-48 emotion-10"
+                      >
+                        Optional info
+                      </span>
+                      <div
+                        class="emotion-50 emotion-51"
+                        data-testid="option-stack-mercury"
+                      >
+                        <span
+                          class="emotion-52 emotion-53 emotion-10"
+                        >
+                          Mercury
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="venus"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-venus"
+                    id="option-1"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                    >
+                      <span
+                        class="emotion-47 emotion-48 emotion-10"
+                      >
+                        Optional info
+                      </span>
+                      <div
+                        class="emotion-50 emotion-51"
+                        data-testid="option-stack-venus"
+                      >
+                        <span
+                          class="emotion-52 emotion-53 emotion-10"
+                        >
+                          Venus
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="earth"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-earth"
+                    id="option-2"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-59 emotion-5"
+                    >
+                      <div
+                        class="emotion-50 emotion-51"
+                        data-testid="option-stack-earth"
+                      >
+                        <span
+                          class="emotion-52 emotion-53 emotion-10"
+                        >
+                          Earth
+                        </span>
+                        <span
+                          class="emotion-55 emotion-10"
+                        >
+                          Our home planet
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="mars"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mars"
+                    id="option-3"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-59 emotion-5"
+                    >
+                      <div
+                        class="emotion-50 emotion-51"
+                        data-testid="option-stack-mars"
+                      >
+                        <span
+                          class="emotion-52 emotion-53 emotion-10"
+                        >
+                          Mars
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="pluto"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-pluto"
+                    id="option-4"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-59 emotion-5"
+                    >
+                      <div
+                        class="emotion-50 emotion-51"
+                        data-testid="option-stack-pluto"
+                      >
+                        <span
+                          class="emotion-52 emotion-53 emotion-10"
+                        >
+                          <div
+                            class="emotion-150 emotion-10"
+                          >
+                            Pluto
+                          </div>
+                        </span>
+                        <span
+                          class="emotion-55 emotion-10"
+                        >
+                          Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -13735,7 +14585,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with label on the bottom and optional info on the right 1`] = `
+exports[`SelectInput > renders correctly with label on the bottom and optional info on the right 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -13763,6 +14613,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -13772,10 +14626,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -13784,58 +14638,38 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -13847,10 +14681,14 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -13901,11 +14739,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -13913,6 +14751,9 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -13920,10 +14761,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13932,11 +14773,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13946,10 +14787,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -13960,8 +14801,8 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -13977,11 +14818,12 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -14014,10 +14856,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -14026,10 +14868,9 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -14037,10 +14878,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -14049,14 +14890,14 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -14067,10 +14908,12 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -14140,10 +14983,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14152,17 +14995,16 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -14173,17 +15015,17 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -14191,10 +15033,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -14203,19 +15045,18 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -14223,10 +15064,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -14235,16 +15076,16 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-37 {
@@ -14265,12 +15106,16 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-37:focus {
@@ -14279,8 +15124,8 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 }
 
 .emotion-37[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-37[data-selectgroup='true']:focus {
@@ -14289,11 +15134,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 
 .emotion-39 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -14304,11 +15149,12 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-43:hover,
@@ -14316,20 +15162,19 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-43[data-selected='true'] {
+.emotion-43[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-43[disabled] {
+.emotion-43[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-43[disabled]:hover,
-.emotion-43 [disabled]:focus {
+.emotion-43[aria-disabled="true"]:hover,
+.emotion-43 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -14341,10 +15186,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -14352,19 +15197,19 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-50 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -14388,14 +15233,15 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 }
 
 .emotion-55 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14408,39 +15254,38 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.emotion-80 {
+.emotion-57 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: left;
 }
 
-.emotion-100 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-158 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -14455,18 +15300,18 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r98:"
-        aria-describedby=":r98:"
+        aria-controls="«r9o»"
+        aria-describedby="«r9o»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r9o»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -14474,7 +15319,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r97:"
+            id="«r9n»"
             role="combobox"
             tabindex="0"
           >
@@ -14489,11 +15334,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -14504,7 +15349,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r98:"
+          id="«r9o»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -14528,11 +15373,11 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -14543,7 +15388,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r9b:"
+                    id="«r9s»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -14574,6 +15419,156 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     <span
                       class="emotion-39 emotion-10"
                     >
+                      JOVIAN PLANETS
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="emotion-33 emotion-5"
+                  id="items"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-label="jupiter"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-jupiter"
+                    id="option-0"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-jupiter"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Jupiter
+                        </span>
+                        <div
+                          class="emotion-52 emotion-53"
+                        >
+                          <span
+                            class="emotion-54 emotion-55 emotion-10"
+                          >
+                            Optional info
+                          </span>
+                        </div>
+                      </div>
+                      <span
+                        class="emotion-57 emotion-10"
+                      >
+                        Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="saturn"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-saturn"
+                    id="option-1"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-saturn"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Saturn
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="uranus"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-uranus"
+                    id="option-2"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-uranus"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Uranus
+                        </span>
+                        <div
+                          class="emotion-52 emotion-53"
+                        >
+                          <span
+                            class="emotion-54 emotion-55 emotion-10"
+                          >
+                            Optional info
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="neptune"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-neptune"
+                    id="option-3"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-4 emotion-5"
+                      data-testid="option-stack-neptune"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Neptune
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-33 emotion-5"
+              >
+                <div
+                  class="emotion-35 emotion-36"
+                >
+                  <button
+                    class="emotion-37 emotion-38"
+                    data-selectgroup="false"
+                    data-testid="group-1"
+                    role="group"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-39 emotion-10"
+                    >
                       TERRESTRIAL PLANETS
                     </span>
                   </button>
@@ -14583,9 +15578,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                   id="items"
                 >
                   <div
+                    aria-disabled="false"
                     aria-label="mercury"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-mercury"
                     id="option-0"
                     role="option"
@@ -14616,9 +15612,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="venus"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-venus"
                     id="option-1"
                     role="option"
@@ -14649,9 +15646,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="earth"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-earth"
                     id="option-2"
                     role="option"
@@ -14671,16 +15669,17 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                         </span>
                       </div>
                       <span
-                        class="emotion-80 emotion-10"
+                        class="emotion-57 emotion-10"
                       >
                         Our home planet
                       </span>
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="mars"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-mars"
                     id="option-3"
                     role="option"
@@ -14702,9 +15701,10 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                     </div>
                   </div>
                   <div
+                    aria-disabled="false"
                     aria-label="pluto"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
                     data-testid="option-pluto"
                     id="option-4"
                     role="option"
@@ -14721,14 +15721,14 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                           class="emotion-49 emotion-50 emotion-10"
                         >
                           <div
-                            class="emotion-100 emotion-10"
+                            class="emotion-158 emotion-10"
                           >
                             Pluto
                           </div>
                         </span>
                       </div>
                       <span
-                        class="emotion-80 emotion-10"
+                        class="emotion-57 emotion-10"
                       >
                         Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
                       </span>
@@ -14736,152 +15736,6 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
                   </div>
                 </div>
               </div>
-              <div
-                class="emotion-33 emotion-5"
-              >
-                <div
-                  class="emotion-35 emotion-36"
-                >
-                  <button
-                    class="emotion-37 emotion-38"
-                    data-selectgroup="false"
-                    data-testid="group-1"
-                    role="group"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <span
-                      class="emotion-39 emotion-10"
-                    >
-                      JOVIAN PLANETS
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="emotion-33 emotion-5"
-                  id="items"
-                >
-                  <div
-                    aria-label="jupiter"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-jupiter"
-                    id="option-0"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-jupiter"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Jupiter
-                        </span>
-                        <div
-                          class="emotion-52 emotion-53"
-                        >
-                          <span
-                            class="emotion-54 emotion-55 emotion-10"
-                          >
-                            Optional info
-                          </span>
-                        </div>
-                      </div>
-                      <span
-                        class="emotion-80 emotion-10"
-                      >
-                        Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="saturn"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-saturn"
-                    id="option-1"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-saturn"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Saturn
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="uranus"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-uranus"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-uranus"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Uranus
-                        </span>
-                        <div
-                          class="emotion-52 emotion-53"
-                        >
-                          <span
-                            class="emotion-54 emotion-55 emotion-10"
-                          >
-                            Optional info
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="neptune"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-neptune"
-                    id="option-3"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-4 emotion-5"
-                      data-testid="option-stack-neptune"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Neptune
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -14891,7 +15745,7 @@ exports[`SelectInputV2 > renders correctly with label on the bottom and optional
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with label on the right and optional info on the left 1`] = `
+exports[`SelectInput > renders correctly with label on the right and optional info on the left 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -14919,6 +15773,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -14928,10 +15786,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -14940,58 +15798,38 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -15003,10 +15841,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -15057,11 +15899,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -15069,6 +15911,9 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -15076,10 +15921,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15088,11 +15933,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15102,10 +15947,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -15116,8 +15961,8 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -15133,11 +15978,12 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -15170,10 +16016,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -15182,10 +16028,9 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -15193,10 +16038,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -15205,14 +16050,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -15223,10 +16068,12 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -15296,10 +16143,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15308,17 +16155,16 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -15329,17 +16175,17 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -15347,10 +16193,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -15359,19 +16205,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -15379,10 +16224,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -15391,16 +16236,16 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-37 {
@@ -15421,12 +16266,16 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-37:focus {
@@ -15435,8 +16284,8 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 }
 
 .emotion-37[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-37[data-selectgroup='true']:focus {
@@ -15445,11 +16294,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 
 .emotion-39 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -15460,11 +16309,12 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-43:hover,
@@ -15472,20 +16322,19 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-43[data-selected='true'] {
+.emotion-43[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-43[disabled] {
+.emotion-43[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-43[disabled]:hover,
-.emotion-43 [disabled]:focus {
+.emotion-43[aria-disabled="true"]:hover,
+.emotion-43 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -15497,10 +16346,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -15508,10 +16357,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
 }
 
 .emotion-47 {
@@ -15519,10 +16368,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -15531,19 +16380,19 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-50 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -15561,20 +16410,34 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 }
 
 .emotion-52 {
+  color: #727683;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.25rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: left;
+}
+
+.emotion-54 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
 }
 
-.emotion-55 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-57 {
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15587,39 +16450,25 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.emotion-80 {
-  color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-158 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-align: left;
-}
-
-.emotion-100 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -15634,18 +16483,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r62:"
-        aria-describedby=":r62:"
+        aria-controls="«r6f»"
+        aria-describedby="«r6f»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r6f»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -15653,7 +16502,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r61:"
+            id="«r6e»"
             role="combobox"
             tabindex="0"
           >
@@ -15668,11 +16517,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -15683,7 +16532,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r62:"
+          id="«r6f»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -15707,11 +16556,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -15722,7 +16571,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r65:"
+                    id="«r6j»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -15753,7 +16602,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      TERRESTRIAL PLANETS
+                      JOVIAN PLANETS
                     </span>
                   </button>
                 </div>
@@ -15762,17 +16611,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                   id="items"
                 >
                   <div
-                    aria-label="mercury"
+                    aria-disabled="false"
+                    aria-label="jupiter"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mercury"
+                    data-testid="option-jupiter"
                     id="option-0"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-mercury"
+                      data-testid="option-stack-jupiter"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -15780,14 +16630,19 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Mercury
+                          Jupiter
+                        </span>
+                        <span
+                          class="emotion-52 emotion-10"
+                        >
+                          Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -15795,17 +16650,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="venus"
+                    aria-disabled="false"
+                    aria-label="saturn"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-venus"
+                    data-testid="option-saturn"
                     id="option-1"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-venus"
+                      data-testid="option-stack-saturn"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -15813,14 +16669,39 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Venus
+                          Saturn
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="uranus"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-uranus"
+                    id="option-2"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                      data-testid="option-stack-uranus"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Uranus
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -15828,46 +16709,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="earth"
+                    aria-disabled="false"
+                    aria-label="neptune"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-earth"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                      data-testid="option-stack-earth"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Earth
-                        </span>
-                        <span
-                          class="emotion-80 emotion-10"
-                        >
-                          Our home planet
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="mars"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mars"
+                    data-testid="option-neptune"
                     id="option-3"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-mars"
+                      data-testid="option-stack-neptune"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -15875,40 +16728,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Mars
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="pluto"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-pluto"
-                    id="option-4"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                      data-testid="option-stack-pluto"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          <div
-                            class="emotion-100 emotion-10"
-                          >
-                            Pluto
-                          </div>
-                        </span>
-                        <span
-                          class="emotion-80 emotion-10"
-                        >
-                          Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
+                          Neptune
                         </span>
                       </div>
                     </div>
@@ -15932,7 +16752,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      JOVIAN PLANETS
+                      TERRESTRIAL PLANETS
                     </span>
                   </button>
                 </div>
@@ -15941,17 +16761,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                   id="items"
                 >
                   <div
-                    aria-label="jupiter"
+                    aria-disabled="false"
+                    aria-label="mercury"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-jupiter"
+                    data-testid="option-mercury"
                     id="option-0"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-jupiter"
+                      data-testid="option-stack-mercury"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -15959,19 +16780,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Jupiter
-                        </span>
-                        <span
-                          class="emotion-80 emotion-10"
-                        >
-                          Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
+                          Mercury
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -15979,17 +16795,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="saturn"
+                    aria-disabled="false"
+                    aria-label="venus"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-saturn"
+                    data-testid="option-venus"
                     id="option-1"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-saturn"
+                      data-testid="option-stack-venus"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -15997,38 +16814,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Saturn
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="uranus"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-uranus"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                      data-testid="option-stack-uranus"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Uranus
+                          Venus
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -16036,17 +16829,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="neptune"
+                    aria-disabled="false"
+                    aria-label="earth"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-neptune"
-                    id="option-3"
+                    data-testid="option-earth"
+                    id="option-2"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-neptune"
+                      data-testid="option-stack-earth"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -16054,7 +16848,71 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Neptune
+                          Earth
+                        </span>
+                        <span
+                          class="emotion-52 emotion-10"
+                        >
+                          Our home planet
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="mars"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mars"
+                    id="option-3"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                      data-testid="option-stack-mars"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mars
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="pluto"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-pluto"
+                    id="option-4"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                      data-testid="option-stack-pluto"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          <div
+                            class="emotion-158 emotion-10"
+                          >
+                            Pluto
+                          </div>
+                        </span>
+                        <span
+                          class="emotion-52 emotion-10"
+                        >
+                          Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
                         </span>
                       </div>
                     </div>
@@ -16070,7 +16928,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with label on the right and optional info on the right 1`] = `
+exports[`SelectInput > renders correctly with label on the right and optional info on the right 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -16098,6 +16956,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -16107,10 +16969,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -16119,58 +16981,38 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -16182,10 +17024,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -16236,11 +17082,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -16248,6 +17094,9 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -16255,10 +17104,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -16267,11 +17116,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16281,10 +17130,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -16295,8 +17144,8 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -16312,11 +17161,12 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -16349,10 +17199,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -16361,10 +17211,9 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-21 {
@@ -16372,10 +17221,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -16384,14 +17233,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-23 {
@@ -16402,10 +17251,12 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-23>.emotion-30 {
@@ -16475,10 +17326,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -16487,17 +17338,16 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-25[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-29 {
@@ -16508,17 +17358,17 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-29[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-29[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-31 {
@@ -16526,10 +17376,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -16538,19 +17388,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-31[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-33 {
@@ -16558,10 +17407,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -16570,16 +17419,16 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-35 {
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 0;
 }
 
 .emotion-37 {
@@ -16600,12 +17449,16 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   background-color: #f9f9fa;
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
-  padding-right: 16px;
-  padding-left: 16px;
-  height: 32px;
+  top: 0;
+  padding-right: 1rem;
+  padding-left: 1rem;
+  height: 2rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 0.125rem;
 }
 
 .emotion-37:focus {
@@ -16614,8 +17467,8 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 }
 
 .emotion-37[data-selectgroup='true'] {
-  padding-left: 16px;
-  border-left: 4px solid #f9f9fa;
+  padding-left: 1rem;
+  border-left: 0.25rem solid #f9f9fa;
 }
 
 .emotion-37[data-selectgroup='true']:focus {
@@ -16624,11 +17477,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 
 .emotion-39 {
   color: #3f4250;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -16639,11 +17492,12 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-43:hover,
@@ -16651,20 +17505,19 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-43[data-selected='true'] {
+.emotion-43[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-43[disabled] {
+.emotion-43[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-43[disabled]:hover,
-.emotion-43 [disabled]:focus {
+.emotion-43[aria-disabled="true"]:hover,
+.emotion-43 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -16676,10 +17529,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -16687,10 +17540,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
 }
 
 .emotion-47 {
@@ -16698,10 +17551,10 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -16710,19 +17563,19 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-50 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -16740,20 +17593,34 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 }
 
 .emotion-52 {
+  color: #727683;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.25rem;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: left;
+}
+
+.emotion-54 {
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
   align-content: center;
 }
 
-.emotion-55 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-57 {
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16766,39 +17633,25 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
   border: 1px solid #d9dadd;
 }
 
-.emotion-80 {
-  color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-158 {
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
-  text-transform: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-align: left;
-}
-
-.emotion-100 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -16813,18 +17666,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":r74:"
-        aria-describedby=":r74:"
+        aria-controls="«r7i»"
+        aria-describedby="«r7i»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«r7i»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -16832,7 +17685,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":r73:"
+            id="«r7h»"
             role="combobox"
             tabindex="0"
           >
@@ -16847,11 +17700,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -16862,7 +17715,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":r74:"
+          id="«r7i»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -16886,11 +17739,11 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                   >
                     <svg
                       class="emotion-13 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -16901,7 +17754,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     class="emotion-29 emotion-30"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":r77:"
+                    id="«r7m»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -16932,7 +17785,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      TERRESTRIAL PLANETS
+                      JOVIAN PLANETS
                     </span>
                   </button>
                 </div>
@@ -16941,17 +17794,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                   id="items"
                 >
                   <div
-                    aria-label="mercury"
+                    aria-disabled="false"
+                    aria-label="jupiter"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mercury"
+                    data-testid="option-jupiter"
                     id="option-0"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-mercury"
+                      data-testid="option-stack-jupiter"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -16959,14 +17813,19 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Mercury
+                          Jupiter
+                        </span>
+                        <span
+                          class="emotion-52 emotion-10"
+                        >
+                          Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -16974,17 +17833,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="venus"
+                    aria-disabled="false"
+                    aria-label="saturn"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-venus"
+                    data-testid="option-saturn"
                     id="option-1"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-venus"
+                      data-testid="option-stack-saturn"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -16992,14 +17852,39 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Venus
+                          Saturn
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="uranus"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-uranus"
+                    id="option-2"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                      data-testid="option-stack-uranus"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Uranus
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -17007,46 +17892,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="earth"
+                    aria-disabled="false"
+                    aria-label="neptune"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-earth"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                      data-testid="option-stack-earth"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Earth
-                        </span>
-                        <span
-                          class="emotion-80 emotion-10"
-                        >
-                          Our home planet
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="mars"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-mars"
+                    data-testid="option-neptune"
                     id="option-3"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-mars"
+                      data-testid="option-stack-neptune"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -17054,40 +17911,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Mars
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="pluto"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-pluto"
-                    id="option-4"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                      data-testid="option-stack-pluto"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          <div
-                            class="emotion-100 emotion-10"
-                          >
-                            Pluto
-                          </div>
-                        </span>
-                        <span
-                          class="emotion-80 emotion-10"
-                        >
-                          Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
+                          Neptune
                         </span>
                       </div>
                     </div>
@@ -17111,7 +17935,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     <span
                       class="emotion-39 emotion-10"
                     >
-                      JOVIAN PLANETS
+                      TERRESTRIAL PLANETS
                     </span>
                   </button>
                 </div>
@@ -17120,17 +17944,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                   id="items"
                 >
                   <div
-                    aria-label="jupiter"
+                    aria-disabled="false"
+                    aria-label="mercury"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-jupiter"
+                    data-testid="option-mercury"
                     id="option-0"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-jupiter"
+                      data-testid="option-stack-mercury"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -17138,19 +17963,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Jupiter
-                        </span>
-                        <span
-                          class="emotion-80 emotion-10"
-                        >
-                          Jupiter is the fifth planet from the Sun and the largest in the Solar System. It is a gas giant with a mass more than two and a half times that of all the other planets in the Solar System combined, and slightly less than one one-thousandth the mass of the Sun.
+                          Mercury
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -17158,17 +17978,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="saturn"
+                    aria-disabled="false"
+                    aria-label="venus"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-saturn"
+                    data-testid="option-venus"
                     id="option-1"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-saturn"
+                      data-testid="option-stack-venus"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -17176,38 +17997,14 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Saturn
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="uranus"
-                    class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-uranus"
-                    id="option-2"
-                    role="option"
-                    tabindex="0"
-                  >
-                    <div
-                      class="emotion-45 emotion-5"
-                      data-testid="option-stack-uranus"
-                    >
-                      <div
-                        class="emotion-47 emotion-48"
-                      >
-                        <span
-                          class="emotion-49 emotion-50 emotion-10"
-                        >
-                          Uranus
+                          Venus
                         </span>
                       </div>
                       <div
-                        class="emotion-52 emotion-53"
+                        class="emotion-54 emotion-55"
                       >
                         <span
-                          class="emotion-54 emotion-55 emotion-10"
+                          class="emotion-56 emotion-57 emotion-10"
                         >
                           Optional info
                         </span>
@@ -17215,17 +18012,18 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                     </div>
                   </div>
                   <div
-                    aria-label="neptune"
+                    aria-disabled="false"
+                    aria-label="earth"
+                    aria-selected="false"
                     class="emotion-43 emotion-44"
-                    data-selected="false"
-                    data-testid="option-neptune"
-                    id="option-3"
+                    data-testid="option-earth"
+                    id="option-2"
                     role="option"
                     tabindex="0"
                   >
                     <div
                       class="emotion-45 emotion-5"
-                      data-testid="option-stack-neptune"
+                      data-testid="option-stack-earth"
                     >
                       <div
                         class="emotion-47 emotion-48"
@@ -17233,7 +18031,71 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
                         <span
                           class="emotion-49 emotion-50 emotion-10"
                         >
-                          Neptune
+                          Earth
+                        </span>
+                        <span
+                          class="emotion-52 emotion-10"
+                        >
+                          Our home planet
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="mars"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-mars"
+                    id="option-3"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                      data-testid="option-stack-mars"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          Mars
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="pluto"
+                    aria-selected="false"
+                    class="emotion-43 emotion-44"
+                    data-testid="option-pluto"
+                    id="option-4"
+                    role="option"
+                    tabindex="0"
+                  >
+                    <div
+                      class="emotion-45 emotion-5"
+                      data-testid="option-stack-pluto"
+                    >
+                      <div
+                        class="emotion-47 emotion-48"
+                      >
+                        <span
+                          class="emotion-49 emotion-50 emotion-10"
+                        >
+                          <div
+                            class="emotion-158 emotion-10"
+                          >
+                            Pluto
+                          </div>
+                        </span>
+                        <span
+                          class="emotion-52 emotion-10"
+                        >
+                          Pluto does not fit the usual classification of either terrestrial or Jovian planets, but is rocky
                         </span>
                       </div>
                     </div>
@@ -17249,7 +18111,7 @@ exports[`SelectInputV2 > renders correctly with label on the right and optional 
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
+exports[`SelectInput > renders correctly with not searchable 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -17277,6 +18139,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -17286,10 +18152,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -17298,58 +18164,38 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -17361,10 +18207,14 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -17415,11 +18265,11 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -17427,6 +18277,9 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -17434,10 +18287,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -17446,11 +18299,11 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -17460,10 +18313,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -17474,8 +18327,8 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
 .emotion-16 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -17491,11 +18344,12 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-16[data-animated="true"] {
@@ -17528,10 +18382,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -17540,10 +18394,9 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-20 {
@@ -17551,10 +18404,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -17563,19 +18416,19 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-20[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-22 {
@@ -17583,10 +18436,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -17595,21 +18448,22 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-24 {
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-24:hover,
@@ -17617,20 +18471,19 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-24[data-selected='true'] {
+.emotion-24[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-24[disabled] {
+.emotion-24[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-24[disabled]:hover,
-.emotion-24 [disabled]:focus {
+.emotion-24[aria-disabled="true"]:hover,
+.emotion-24 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -17642,10 +18495,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -17653,19 +18506,19 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-31 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -17684,11 +18537,11 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
 
 .emotion-51 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -17696,25 +18549,26 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
 }
 
 .emotion-102 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .emotion-105 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -17727,14 +18581,13 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -17749,18 +18602,18 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rda:"
-        aria-describedby=":rda:"
+        aria-controls="«ret»"
+        aria-describedby="«ret»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«ret»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -17768,7 +18621,7 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
             data-size="large"
             data-state="neutral"
             data-testid="select-input-test"
-            id=":rd9:"
+            id="«res»"
             role="combobox"
             tabindex="0"
           >
@@ -17783,11 +18636,11 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
               <svg
                 aria-label="show dropdown"
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -17798,7 +18651,7 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
           class="emotion-15 emotion-16 emotion-17"
           data-animated="false"
           data-has-arrow="false"
-          id=":rda:"
+          id="«ret»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -17810,16 +18663,16 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
               data-grouped="false"
               id="select-dropdown"
               role="listbox"
-              tabindex="-1"
             >
               <div
                 class="emotion-22 emotion-5"
                 id="items"
               >
                 <div
+                  aria-disabled="false"
                   aria-label="mercury"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-mercury"
                   id="option-0"
                   role="option"
@@ -17841,9 +18694,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="venus"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-venus"
                   id="option-1"
                   role="option"
@@ -17865,9 +18719,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="earth"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-earth"
                   id="option-2"
                   role="option"
@@ -17894,18 +18749,18 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="true"
                   aria-label="mars"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-mars"
-                  disabled=""
                   id="option-3"
                   role="option"
                   tabindex="-1"
                 >
                   <div
-                    aria-controls=":rdk:"
-                    aria-describedby=":rdk:"
+                    aria-controls="«rf8»"
+                    aria-describedby="«rf8»"
                     class="emotion-2 emotion-3"
                     tabindex="0"
                   >
@@ -17926,9 +18781,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="jupiter"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-jupiter"
                   id="option-4"
                   role="option"
@@ -17955,9 +18811,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="saturn"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-saturn"
                   id="option-5"
                   role="option"
@@ -17979,9 +18836,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="uranus"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-uranus"
                   id="option-6"
                   role="option"
@@ -18003,9 +18861,10 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="neptune"
+                  aria-selected="false"
                   class="emotion-24 emotion-25"
-                  data-selected="false"
                   data-testid="option-neptune"
                   id="option-7"
                   role="option"
@@ -18045,7 +18904,7 @@ exports[`SelectInputV2 > renders correctly with not searchable 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with success 1`] = `
+exports[`SelectInput > renders correctly with success 1`] = `
 <DocumentFragment>
   @keyframes animation-0 {
   0% {
@@ -18073,6 +18932,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: inherit;
 }
 
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
+}
+
 .emotion-2[data-container-full-width="true"] {
   width: 100%;
 }
@@ -18082,10 +18945,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -18094,58 +18957,38 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
 .emotion-6[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
 .emotion-6[data-size='medium'] {
-  height: 40px;
+  height: 2.5rem;
 }
 
 .emotion-6[data-size='large'] {
-  height: 48px;
+  height: 3rem;
 }
 
 .emotion-6[data-state='neutral'] {
@@ -18157,10 +19000,14 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-6[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-6[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-6[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
+}
+
+.emotion-6[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
 }
 
 .emotion-6[data-state='neutral'][data-dropdownvisible='true'] {
@@ -18211,11 +19058,11 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 
 .emotion-9 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -18223,6 +19070,9 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
 .emotion-11 {
@@ -18230,10 +19080,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18242,11 +19092,11 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -18256,10 +19106,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 .emotion-13 {
   vertical-align: middle;
   fill: #22674e;
-  height: 1em;
-  width: 1em;
-  min-width: 1em;
-  min-height: 1em;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-13 .fillStroke {
@@ -18270,10 +19120,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 .emotion-15 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
 .emotion-15 .fillStroke {
@@ -18284,8 +19134,8 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 .emotion-18 {
   background: #151a2d;
   color: #ffffff;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
   text-align: center;
   position: absolute;
   max-width: 500px;
@@ -18301,11 +19151,12 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-transform: translate3d(0px, 4px, 0);
   transform: translate3d(0px, 4px, 0);
   width: 100%;
+  min-width: 320px;
   background-color: #ffffff;
   color: #3f4250;
   box-shadow: 0px 4px 8px 0px #22263829,0px 8px 24px 0px #2226383d;
-  padding: 0;
-  margin-bottom: 80px;
+  padding: 0rem;
+  margin-bottom: 5rem;
 }
 
 .emotion-18[data-animated="true"] {
@@ -18338,10 +19189,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -18350,10 +19201,9 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .emotion-23 {
@@ -18361,10 +19211,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -18373,14 +19223,14 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .emotion-25 {
@@ -18391,10 +19241,12 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  height: 40px;
+  height: 2.5rem;
   background: #ffffff;
   border: 1px solid #d9dadd;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  box-shadow: 0px 0px 0px 3px #8c40ef40;
+  border: 1px solid #8c40ef;
 }
 
 .emotion-25>.emotion-32 {
@@ -18464,10 +19316,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18476,17 +19328,16 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 1rem;
   border-right: 1px solid;
   border-color: inherit;
 }
 
 .emotion-27[data-size="small"] {
-  padding: 8px;
+  padding: 0.5rem;
 }
 
 .emotion-31 {
@@ -18497,17 +19348,17 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   outline: none;
   height: 100%;
   width: 100%;
-  padding-left: 16px;
+  padding-left: 1rem;
   background: transparent;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .emotion-31[data-size='large'] {
-  font-size: 16px;
+  font-size: 1rem;
 }
 
 .emotion-31[data-size='small'] {
-  padding-left: 8px;
+  padding-left: 0.5rem;
 }
 
 .emotion-33 {
@@ -18515,10 +19366,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -18527,19 +19378,19 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
   max-height: 256px;
-  overflow-y: scroll;
-  padding: 0;
-  padding-bottom: 4px;
-  padding-top: 4px;
+  overflow-y: auto;
+  padding: 0rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
 }
 
 .emotion-33[data-grouped="true"] {
-  padding-top: 0;
+  padding-top: 0rem;
 }
 
 .emotion-35 {
@@ -18547,10 +19398,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 2px;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -18559,21 +19410,22 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 0.125rem;
 }
 
 .emotion-37 {
   text-align: left;
   border: none;
   background-color: #ffffff;
-  padding: 12px 16px 12px 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+  padding: 0.75rem 1rem 0.75rem 1rem;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   color: #3f4250;
-  border-radius: 4px;
+  border-radius: 0.25rem;
+  border: 1px transparent solid;
 }
 
 .emotion-37:hover,
@@ -18581,20 +19433,19 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   background-color: #f1eefc;
   color: #641cb3;
   cursor: pointer;
-  outline: none;
 }
 
-.emotion-37[data-selected='true'] {
+.emotion-37[aria-selected='true'] {
   background-color: #f1eefc;
 }
 
-.emotion-37[disabled] {
+.emotion-37[aria-disabled="true"] {
   background-color: #f3f3f4;
   color: #b5b7bd;
 }
 
-.emotion-37[disabled]:hover,
-.emotion-37 [disabled]:focus {
+.emotion-37[aria-disabled="true"]:hover,
+.emotion-37 [aria-disabled="true"]:focus {
   background-color: #f3f3f4;
   color: #b5b7bd;
   cursor: not-allowed;
@@ -18606,10 +19457,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -18617,19 +19468,19 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.25rem;
   overflow: hidden;
 }
 
 .emotion-44 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -18648,11 +19499,11 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 
 .emotion-64 {
   color: #727683;
-  font-size: 14px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.875rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 20px;
+  line-height: 1.25rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -18660,25 +19511,26 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 }
 
 .emotion-115 {
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .emotion-118 {
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  white-space: nowrap;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -18691,14 +19543,13 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  white-space: nowrap;
-  border-radius: 16px;
-  padding: 0 16px;
-  gap: 8px;
+  border-radius: 1rem;
+  padding: 0 0.75rem;
+  gap: 0.5rem;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
-  height: 24px;
+  height: 1.5rem;
   text-transform: uppercase;
   color: #3f4250;
   background: #f9f9fa;
@@ -18707,15 +19558,15 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 
 .emotion-121 {
   color: #22674e;
-  font-size: 12px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 0.75rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 16px;
+  line-height: 1rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
-  padding-top: 4px;
+  padding-top: 0.25rem;
 }
 
 <div
@@ -18726,18 +19577,18 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rcf:"
-        aria-describedby=":rcf:"
+        aria-controls="«re1»"
+        aria-describedby="«re1»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
           <div
+            aria-controls="«re1»"
             aria-expanded="true"
-            aria-haspopup="listbox"
             class="emotion-6 emotion-7"
             data-disabled="false"
             data-dropdownvisible="true"
@@ -18745,7 +19596,7 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
             data-size="large"
             data-state="success"
             data-testid="select-input-test"
-            id=":rce:"
+            id="«re0»"
             role="combobox"
             tabindex="0"
           >
@@ -18759,22 +19610,22 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
             >
               <svg
                 class="emotion-13 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16m3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089z"
+                  d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM11.8435 6.20859C12.0967 5.88082 12.0363 5.40981 11.7086 5.15654C11.3808 4.90327 10.9098 4.96365 10.6565 5.29141L6.95615 10.0801L5.30747 8.24828C5.03038 7.94039 4.55616 7.91543 4.24828 8.19253C3.94039 8.46962 3.91544 8.94384 4.19253 9.25172L6.44253 11.7517C6.59132 11.917 6.80582 12.0078 7.02809 11.9995C7.25036 11.9911 7.45746 11.8846 7.59346 11.7086L11.8435 6.20859Z"
                   fill-rule="evenodd"
                 />
               </svg>
               <svg
                 aria-label="show dropdown"
                 class="emotion-15 emotion-14"
-                viewBox="0 0 20 20"
+                viewBox="0 0 16 16"
               >
                 <path
                   clip-rule="evenodd"
-                  d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                  d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                   fill-rule="evenodd"
                 />
               </svg>
@@ -18785,7 +19636,7 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
           class="emotion-17 emotion-18 emotion-19"
           data-animated="false"
           data-has-arrow="false"
-          id=":rcf:"
+          id="«re1»"
           role="dialog"
           style="opacity: 1;"
         >
@@ -18809,11 +19660,11 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   >
                     <svg
                       class="emotion-15 emotion-14"
-                      viewBox="0 0 20 20"
+                      viewBox="0 0 16 16"
                     >
                       <path
                         clip-rule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
+                        d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
                         fill-rule="evenodd"
                       />
                     </svg>
@@ -18824,7 +19675,7 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                     class="emotion-31 emotion-32"
                     data-size="medium"
                     data-testid="search-bar"
-                    id=":rcj:"
+                    id="«re6»"
                     placeholder="placeholdersearch"
                     type="text"
                     value=""
@@ -18837,16 +19688,16 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
               data-grouped="false"
               id="select-dropdown"
               role="listbox"
-              tabindex="-1"
             >
               <div
                 class="emotion-35 emotion-5"
                 id="items"
               >
                 <div
+                  aria-disabled="false"
                   aria-label="mercury"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-mercury"
                   id="option-0"
                   role="option"
@@ -18868,9 +19719,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="venus"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-venus"
                   id="option-1"
                   role="option"
@@ -18892,9 +19744,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="earth"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-earth"
                   id="option-2"
                   role="option"
@@ -18921,18 +19774,18 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="true"
                   aria-label="mars"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-mars"
-                  disabled=""
                   id="option-3"
                   role="option"
                   tabindex="-1"
                 >
                   <div
-                    aria-controls=":rcs:"
-                    aria-describedby=":rcs:"
+                    aria-controls="«ref»"
+                    aria-describedby="«ref»"
                     class="emotion-2 emotion-3"
                     tabindex="0"
                   >
@@ -18953,9 +19806,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="jupiter"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-jupiter"
                   id="option-4"
                   role="option"
@@ -18982,9 +19836,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="saturn"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-saturn"
                   id="option-5"
                   role="option"
@@ -19006,9 +19861,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="uranus"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-uranus"
                   id="option-6"
                   role="option"
@@ -19030,9 +19886,10 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-disabled="false"
                   aria-label="neptune"
+                  aria-selected="false"
                   class="emotion-37 emotion-38"
-                  data-selected="false"
                   data-testid="option-neptune"
                   id="option-7"
                   role="option"
@@ -19077,7 +19934,7 @@ exports[`SelectInputV2 > renders correctly with success 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SelectInputV2 > renders correctly with tooltip 1`] = `
+exports[`SelectInput > renders correctly with tooltip 1`] = `
 <DocumentFragment>
   .emotion-0 {
   width: 100%;
@@ -19085,6 +19942,10 @@ exports[`SelectInputV2 > renders correctly with tooltip 1`] = `
 
 .emotion-2 {
   display: inherit;
+}
+
+.emotion-2[data-container-full-height="true"] {
+  height: 100%;
 }
 
 .emotion-2[data-container-full-width="true"] {
@@ -19096,175 +19957,137 @@ exports[`SelectInputV2 > renders correctly with tooltip 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 4px;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
+  gap: 0.25rem;
 }
 
-.emotion-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 4px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.emotion-8 {
-  color: #222638;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+.emotion-7 {
+  color: #3f4250;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 500;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
+  cursor: pointer;
 }
 
-.emotion-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
+.emotion-11 {
+  display: grid;
+  width: 100%;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto;
+  padding: 0.5rem;
   padding-right: 0;
-  padding-left: 16px;
+  padding-left: 1rem;
   cursor: pointer;
   box-shadow: none;
   background: #ffffff;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   width: 100%;
-  overflow: hidden;
 }
 
-.emotion-12[data-size='small'] {
-  height: 32px;
-  padding-left: 8px;
+.emotion-11[data-size='small'] {
+  height: 2rem;
+  padding-left: 0.5rem;
 }
 
-.emotion-12[data-size='medium'] {
-  height: 40px;
+.emotion-11[data-size='medium'] {
+  height: 2.5rem;
 }
 
-.emotion-12[data-size='large'] {
-  height: 48px;
+.emotion-11[data-size='large'] {
+  height: 3rem;
 }
 
-.emotion-12[data-state='neutral'] {
+.emotion-11[data-state='neutral'] {
   border: 1px solid #d9dadd;
 }
 
-.emotion-12[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-11[data-state='neutral']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #792dd4;
   box-shadow: 0px 0px 0px 3px #8c40ef40;
 }
 
-.emotion-12[data-state='neutral']:not([data-disabled='true']):hover,
-.emotion-12[data-state='neutral']:not([data-disabled='true']):focus {
+.emotion-11[data-state='neutral']:not([data-disabled='true']):hover {
   border-color: #792dd4;
   outline: none;
 }
 
-.emotion-12[data-state='neutral'][data-dropdownvisible='true'] {
+.emotion-11[data-state='neutral']:not([data-disabled='true']):focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.emotion-11[data-state='neutral'][data-dropdownvisible='true'] {
   border-color: #792dd4;
 }
 
-.emotion-12[data-state='success'] {
+.emotion-11[data-state='success'] {
   border: 1px solid #22674e;
 }
 
-.emotion-12[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-11[data-state='success']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #1b533f;
   box-shadow: 0px 0px 0px 3px #45d19f40;
 }
 
-.emotion-12[data-state='success'][data-dropdownvisible='true'] {
+.emotion-11[data-state='success'][data-dropdownvisible='true'] {
   border-color: #1b533f;
 }
 
-.emotion-12[data-state='danger'] {
+.emotion-11[data-state='danger'] {
   border: 1px solid #b3144d;
 }
 
-.emotion-12[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
+.emotion-11[data-state='danger']:not([data-disabled="true"]):not([data-readonly="true"]):active {
   border-color: #92103f;
   box-shadow: 0px 0px 0px 3px #f91b6c40;
 }
 
-.emotion-12[data-state='danger'][data-dropdownvisible='true'] {
+.emotion-11[data-state='danger'][data-dropdownvisible='true'] {
   border-color: #92103f;
 }
 
-.emotion-12:not([data-disabled='true']):not([data-readonly]):hover {
+.emotion-11:not([data-disabled='true']):not([data-readonly]):hover {
   border-color: #8c40ef;
 }
 
-.emotion-12[data-readonly='true'] {
+.emotion-11[data-readonly='true'] {
   background: #f9f9fa;
   border-color: #d9dadd;
   cursor: default;
 }
 
-.emotion-12[data-disabled='true'] {
+.emotion-11[data-disabled='true'] {
   background: #f3f3f4;
   border-color: #e9eaeb;
   cursor: not-allowed;
 }
 
-.emotion-15 {
+.emotion-14 {
   color: #727683;
-  font-size: 16px;
-  font-family: Inter,Asap,sans-serif;
+  font-size: 1rem;
+  font-family: Inter,sans-serif;
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 24px;
+  line-height: 1.5rem;
   text-transform: none;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -19272,17 +20095,20 @@ exports[`SelectInputV2 > renders correctly with tooltip 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
 }
 
-.emotion-17 {
+.emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -19291,27 +20117,27 @@ exports[`SelectInputV2 > renders correctly with tooltip 1`] = `
   -ms-flex-pack: normal;
   -webkit-justify-content: normal;
   justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  padding-right: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 0.5rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-19 {
+.emotion-18 {
   vertical-align: middle;
   fill: #3f4250;
-  height: 16px;
-  width: 16px;
-  min-width: 16px;
-  min-height: 16px;
+  height: 1rem;
+  width: 1rem;
+  min-width: 1rem;
+  min-height: 1rem;
 }
 
-.emotion-19 .fillStroke {
+.emotion-18 .fillStroke {
   stroke: #3f4250;
   fill: none;
 }
@@ -19324,61 +20150,58 @@ exports[`SelectInputV2 > renders correctly with tooltip 1`] = `
       class="emotion-0 emotion-1"
     >
       <div
-        aria-controls=":rb:"
-        aria-describedby=":rb:"
+        aria-controls="«rd»"
+        aria-describedby="«rd»"
         class="emotion-2 emotion-3"
         data-container-full-width="true"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="emotion-4 emotion-5"
         >
-          <div
-            class="emotion-6 emotion-5"
+          <label
+            class="emotion-6 emotion-7 emotion-8"
+            for="«rc»"
           >
-            <label
-              class="emotion-8 emotion-9"
-            >
-              label
-            </label>
-          </div>
+            label
+          </label>
           <div
-            aria-controls=":rd:"
-            aria-describedby=":rd:"
+            aria-controls="«rg»"
+            aria-describedby="«rg»"
             class="emotion-2 emotion-3"
             tabindex="0"
           >
             <div
+              aria-controls="«rd»"
               aria-expanded="false"
-              aria-haspopup="listbox"
               aria-label="label"
-              class="emotion-12 emotion-13"
+              class="emotion-11 emotion-12"
               data-disabled="false"
               data-dropdownvisible="false"
               data-readonly="false"
               data-size="large"
               data-state="neutral"
               data-testid="select-input-test"
-              id=":ra:"
+              id="«rc»"
               role="combobox"
               tabindex="0"
             >
               <p
-                class="emotion-14 emotion-15 emotion-9"
+                class="emotion-13 emotion-14 emotion-8"
               >
                 Select item
               </p>
               <div
-                class="emotion-17 emotion-18"
+                class="emotion-16 emotion-17"
               >
                 <svg
                   aria-label="show dropdown"
-                  class="emotion-19 emotion-20"
-                  viewBox="0 0 20 20"
+                  class="emotion-18 emotion-19"
+                  viewBox="0 0 16 16"
                 >
                   <path
                     clip-rule="evenodd"
-                    d="M5.47 7.47a.75.75 0 0 1 1.06 0l3.72 3.72 3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.47 8.53a.75.75 0 0 1 0-1.06"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
                     fill-rule="evenodd"
                   />
                 </svg>

--- a/packages/ui/src/components/SelectInput/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectInput/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
 import type { ReactNode } from 'react'
@@ -26,14 +26,14 @@ describe('SelectInput', () => {
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {})
   })
 
-  test.skip('renders correctly', () => {
+  test('renders correctly', () => {
     const { asFragment } = renderWithTheme(
       <SelectInput label="label" name="test" options={dataUnGrouped} />,
     )
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly small', () => {
+  test('renders correctly small', () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         label="label"
@@ -45,7 +45,7 @@ describe('SelectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with tooltip', () => {
+  test('renders correctly with tooltip', () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         label="label"
@@ -57,7 +57,7 @@ describe('SelectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly required', () => {
+  test('renders correctly required', () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         label="label"
@@ -69,7 +69,7 @@ describe('SelectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly not clearable', () => {
+  test('renders correctly not clearable', () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         clearable={false}
@@ -84,7 +84,7 @@ describe('SelectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly ungrouped', async () => {
+  test('renders correctly ungrouped', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         name="test"
@@ -95,10 +95,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly grouped', async () => {
+  test('renders correctly grouped', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         name="test"
@@ -109,10 +114,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with default value', async () => {
+  test('renders correctly with default value', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         name="test"
@@ -124,10 +134,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('Pluto')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with footer', async () => {
+  test('renders correctly with footer', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         footer="this is a footer"
@@ -140,10 +155,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('Pluto')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly multiselect', async () => {
+  test('renders correctly multiselect', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         multiselect
@@ -156,10 +176,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('Pluto')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with label on the right and optional info on the left', async () => {
+  test('renders correctly with label on the right and optional info on the left', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -172,10 +197,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with label on the right and optional info on the right', async () => {
+  test('renders correctly with label on the right and optional info on the right', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -188,10 +218,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with label on the bottom and optional info on the left', async () => {
+  test('renders correctly with label on the bottom and optional info on the left', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         descriptionDirection="column"
@@ -204,10 +239,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with label on the bottom and optional info on the right', async () => {
+  test('renders correctly with label on the bottom and optional info on the right', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         descriptionDirection="column"
@@ -220,10 +260,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly loadMore', () => {
+  test('renders correctly loadMore', () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         clearable={false}
@@ -238,7 +283,7 @@ describe('SelectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with emptyState', async () => {
+  test('renders correctly with emptyState', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         emptyState="no option"
@@ -250,10 +295,14 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly disabled', async () => {
+  test('renders correctly disabled', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         disabled
@@ -264,11 +313,11 @@ describe('SelectInput', () => {
       />,
     )
     const input = screen.getByText('placeholder')
-    await userEvent.click(input)
+    await userEvent.click(input) // it shouldn't open the dropdown
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly required', async () => {
+  test('renders correctly required', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         name="test"
@@ -281,10 +330,15 @@ describe('SelectInput', () => {
 
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with dropdownAlign', async () => {
+  test('renders correctly with dropdownAlign', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         dropdownAlign="center"
@@ -298,10 +352,15 @@ describe('SelectInput', () => {
 
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly readOnly', async () => {
+  test('renders correctly readOnly', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         name="test"
@@ -311,12 +370,13 @@ describe('SelectInput', () => {
         readOnly
       />,
     )
+
     const input = screen.getByText('placeholder')
-    await userEvent.click(input)
+    await userEvent.click(input) // it shouldn't open the dropdown
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with error', async () => {
+  test('renders correctly with error', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         error="error"
@@ -328,10 +388,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with success', async () => {
+  test('renders correctly with success', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         name="test"
@@ -343,10 +408,15 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+    await userEvent.click(screen.getByTestId('search-bar'))
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with not searchable', async () => {
+  test('renders correctly with not searchable', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         name="test"
@@ -358,10 +428,14 @@ describe('SelectInput', () => {
     )
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('handles correctly dropdown with clicks - grouped', async () => {
+  test('handles correctly dropdown with clicks - grouped', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -376,14 +450,16 @@ describe('SelectInput', () => {
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
 
     await userEvent.click(input)
     await userEvent.click(input)
     expect(dropdown).not.toBeInTheDocument()
   })
 
-  test.skip('handles correctly dropdown with clicks - ungrouped', async () => {
+  test('handles correctly dropdown with clicks - ungrouped', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -399,14 +475,16 @@ describe('SelectInput', () => {
     const input = screen.getByText('placeholder')
     await userEvent.click(input)
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
 
     await userEvent.click(input)
     await userEvent.click(input)
     expect(dropdown).not.toBeInTheDocument()
   })
 
-  test.skip('handles correctly closable tags', async () => {
+  test('handles correctly closable tags', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -424,7 +502,7 @@ describe('SelectInput', () => {
     await userEvent.click(venusCloseButton)
     expect(venus).not.toBeVisible()
   })
-  test.skip('renders correctly unclosable tags when readonly', () => {
+  test('renders correctly unclosable tags when readonly', () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         multiselect
@@ -438,10 +516,11 @@ describe('SelectInput', () => {
         value={[dataUnGrouped[1].value]}
       />,
     )
+
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('handles correctly dropdown with arrow down/up key press with ungrouped data', async () => {
+  test('handles correctly dropdown with arrow down/up key press with ungrouped data', async () => {
     renderWithTheme(
       <SelectInput
         name="test"
@@ -454,11 +533,12 @@ describe('SelectInput', () => {
 
     const input = screen.getByTestId('select-input-test')
     await userEvent.tab()
-    await userEvent.tab()
     expect(input).toHaveFocus()
     await userEvent.keyboard('[arrowDown]')
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     await userEvent.keyboard('[arrowDown]')
     await userEvent.keyboard('[arrowUp]')
     const mercury = screen.getByRole('option', {
@@ -466,7 +546,7 @@ describe('SelectInput', () => {
     })
     expect(mercury).toHaveFocus()
   })
-  test.skip('handles correctly dropdown with arrow pressing enter or space', async () => {
+  test('handles correctly dropdown with arrow pressing enter or space', async () => {
     renderWithTheme(
       <SelectInput
         name="test"
@@ -479,13 +559,15 @@ describe('SelectInput', () => {
 
     const input = screen.getByTestId('select-input-test')
     await userEvent.tab()
-    await userEvent.tab()
     expect(input).toHaveFocus()
     await userEvent.keyboard(' ')
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
   })
-  test.skip('handles correctly dropdown with arrow down/up key press with grouped data', async () => {
+
+  test('handles correctly dropdown with arrow down/up key press with grouped data', async () => {
     renderWithTheme(
       <SelectInput
         name="test"
@@ -498,21 +580,22 @@ describe('SelectInput', () => {
 
     const input = screen.getByTestId('select-input-test')
     await userEvent.tab()
-    await userEvent.tab()
     expect(input).toHaveFocus()
     await userEvent.keyboard('[arrowDown]')
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     await userEvent.tab()
     await userEvent.keyboard('[arrowDown]')
     await userEvent.keyboard('[arrowUp]')
-    const mercury = screen.getByRole('option', {
-      name: /mercury/i,
+    const jupiter = screen.getByRole('option', {
+      name: /jupiter/i,
     })
-    expect(mercury).toHaveFocus()
+    expect(jupiter).toHaveFocus()
   })
 
-  test.skip('handles correctly clear all', async () => {
+  test('handles correctly clear all', async () => {
     renderWithTheme(
       <SelectInput
         clearable
@@ -529,7 +612,7 @@ describe('SelectInput', () => {
     expect(clearAll).not.toBeInTheDocument()
   })
 
-  test.skip('handles click autoclose when outside click', async () => {
+  test('handles click autoclose when outside click', async () => {
     renderWithTheme(
       <>
         Test outside element
@@ -547,13 +630,15 @@ describe('SelectInput', () => {
     const dropdown = screen.getByRole('dialog')
     const outsideClick = screen.getByText('Test outside element')
 
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     await userEvent.click(outsideClick)
     await userEvent.click(outsideClick)
 
     expect(dropdown).not.toBeVisible()
   })
-  test.skip('handles click on item', async () => {
+  test('handles click on item', async () => {
     const onChange = vi.fn()
 
     renderWithTheme(
@@ -571,13 +656,15 @@ describe('SelectInput', () => {
     const dropdown = screen.getByRole('dialog')
     const venus = screen.getByText('Venus')
 
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     await userEvent.click(venus)
 
     expect(onChange).toHaveBeenCalledTimes(1)
   })
 
-  test.skip('handles keydown when not searchable on ungrouped data', async () => {
+  test('handles keydown when not searchable on ungrouped data', async () => {
     renderWithTheme(
       <SelectInput
         name="test"
@@ -598,7 +685,7 @@ describe('SelectInput', () => {
     await userEvent.type(dropdown, 'a')
   })
 
-  test.skip('handles keydown when not searchable on grouped data', async () => {
+  test('handles keydown when not searchable on grouped data', async () => {
     renderWithTheme(
       <SelectInput
         name="test"
@@ -612,15 +699,11 @@ describe('SelectInput', () => {
     const input = screen.getByTestId('select-input-test')
     await userEvent.click(input)
     const dropdown = screen.getByRole('dialog')
-    const venus = screen.getByRole('option', {
-      name: /venus/i,
-    })
     await userEvent.type(dropdown, 'v')
-    expect(venus).toHaveFocus()
     await userEvent.type(dropdown, 'a')
   })
 
-  test.skip('renders with onChange', async () => {
+  test('renders with onChange', async () => {
     renderWithTheme(
       <SelectInput
         name="test"
@@ -637,7 +720,7 @@ describe('SelectInput', () => {
     await userEvent.click(earth)
     await userEvent.click(earth)
   })
-  test.skip('renders with onChange - multiselect', async () => {
+  test('renders with onChange - multiselect', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -655,7 +738,7 @@ describe('SelectInput', () => {
     await userEvent.click(earth)
     await userEvent.click(earth)
   })
-  test.skip('handles correctly searchable and closest value - grouped data', async () => {
+  test('handles correctly searchable and closest value - grouped data', async () => {
     renderWithTheme(
       <SelectInput
         name="test"
@@ -668,7 +751,9 @@ describe('SelectInput', () => {
     const input = screen.getByTestId('select-input-test')
     await userEvent.click(input)
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     const venus = screen.getByTestId('option-venus')
     const earth = screen.getByTestId('option-earth')
 
@@ -724,7 +809,9 @@ describe('SelectInput', () => {
     const input = screen.getByTestId('select-input-test')
     await userEvent.click(input)
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
     const venus = screen.getByText('Venus')
     const earth = screen.getByText('Earth')
     const earthCheckbox = screen.getByRole('checkbox', {
@@ -732,13 +819,21 @@ describe('SelectInput', () => {
     })
     await userEvent.keyboard('[Enter]') // empty search doesn't do anything
     await userEvent.keyboard('e')
-    expect(earth).toBeVisible()
-    expect(venus).toBeVisible()
+    await waitFor(() => {
+      expect(earth).toBeVisible()
+    })
+    await waitFor(() => {
+      expect(venus).toBeVisible()
+    })
 
     await userEvent.keyboard('a')
     await userEvent.keyboard('[Enter]')
-    expect(venus).not.toBeVisible()
-    expect(earthCheckbox).toBeChecked()
+    await waitFor(() => {
+      expect(venus).not.toBeVisible()
+    })
+    await waitFor(() => {
+      expect(earthCheckbox).toBeChecked()
+    })
 
     await userEvent.keyboard(
       '[Backspace][Backspace][Backspace][Backspace][Backspace]',
@@ -774,21 +869,19 @@ describe('SelectInput', () => {
     const input = screen.getByTestId('select-input-test')
     await userEvent.click(input)
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
-    const venus = screen.getByText('Venus')
-    const earth = screen.getByText('Earth')
-    const earthCheckbox = screen.getByRole('checkbox', {
-      name: /earth/i,
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
     })
-    await userEvent.keyboard('[Enter]') // empty search doesn't do anything
+    const jupiter = screen.getByText('Jupiter')
+    const earth = screen.getByText('Earth')
     await userEvent.keyboard('e')
-    expect(earth).toBeVisible()
-    expect(venus).toBeVisible()
+    await waitFor(() => expect(jupiter).toBeVisible())
 
-    await userEvent.keyboard('a')
-    await userEvent.keyboard('[Enter]')
-    expect(venus).not.toBeVisible()
-    expect(earthCheckbox).toBeChecked()
+    await userEvent.keyboard('ea')
+    await waitFor(() => expect(earth).toBeVisible())
+    await waitFor(() => {
+      expect(screen.queryByText('jupiter')).not.toBeVisible()
+    })
 
     await userEvent.keyboard(
       '[Backspace][Backspace][Backspace][Backspace][Backspace]',
@@ -812,7 +905,7 @@ describe('SelectInput', () => {
     await userEvent.keyboard('[Enter]')
   }, 10000)
 
-  test.skip('renders correctly selected tags when multiselect', async () => {
+  test('renders correctly selected tags when multiselect', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="column"
@@ -836,17 +929,17 @@ describe('SelectInput', () => {
     await userEvent.click(input)
     const options = screen.getAllByRole('option')
 
-    fireEvent.click(options[1])
-    fireEvent.click(options[2])
-    fireEvent.click(options[4])
-    fireEvent.click(options[5])
-    fireEvent.click(options[6])
+    await userEvent.click(options[1])
+    await userEvent.click(options[2])
+    await userEvent.click(options[4])
+    await userEvent.click(options[5])
+    await userEvent.click(options[6])
 
     const plustag = screen.getByTestId('plus-tag')
     expect(plustag).toBeInTheDocument()
   })
 
-  test.skip('handles correcty selectAll grouped data', async () => {
+  test('handles correcty selectAll grouped data', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -903,7 +996,7 @@ describe('SelectInput', () => {
     expect(selectAllCheckBox).toBeChecked()
   }, 15000)
 
-  test.skip('handles correcty selectAll ungrouped data', async () => {
+  test('handles correcty selectAll ungrouped data', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -960,7 +1053,7 @@ describe('SelectInput', () => {
     expect(selectAllCheckBox).toBeChecked()
   }, 10000)
 
-  test.skip('handles correcty selectAllGroup', async () => {
+  test('handles correcty selectAllGroup', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -977,7 +1070,7 @@ describe('SelectInput', () => {
     const selectAllGroupCheckBox = screen.getByRole('checkbox', {
       name: 'TERRESTRIAL PLANETS',
     })
-    const selectAllGroup = screen.getByTestId('group-0')
+    const selectAllGroup = screen.getByTestId('group-1')
     await userEvent.click(selectAllGroup)
     const mercury = screen.getByRole('checkbox', {
       name: /mercury/i,
@@ -1004,7 +1097,7 @@ describe('SelectInput', () => {
     expect(selectAllGroupCheckBox).toBeChecked()
   }, 10000)
 
-  test.skip('handles correcty selectAllGroup - keyboard events', async () => {
+  test('handles correcty selectAllGroup - keyboard events', async () => {
     renderWithTheme(
       <SelectInput
         multiselect
@@ -1021,7 +1114,7 @@ describe('SelectInput', () => {
     const selectAllGroupCheckBox = screen.getByRole('checkbox', {
       name: 'TERRESTRIAL PLANETS',
     })
-    const selectAllGroup = screen.getByTestId('group-0')
+    const selectAllGroup = screen.getByTestId('group-1')
     await userEvent.click(selectAllGroup)
     const earth = screen.getByTestId('option-earth')
 
@@ -1037,7 +1130,7 @@ describe('SelectInput', () => {
     expect(selectAllGroupCheckBox).not.toBeChecked()
   }, 10000)
 
-  test.skip('handles correcty selectAllGroup with selectAll - grouped data', async () => {
+  test('handles correcty selectAllGroup with selectAll - grouped data', async () => {
     renderWithTheme(
       <SelectInput
         clearable={false}
@@ -1059,7 +1152,7 @@ describe('SelectInput', () => {
     const selectAllGroupCheckBox = screen.getByRole('checkbox', {
       name: 'TERRESTRIAL PLANETS',
     })
-    const selectAllGroup = screen.getByTestId('group-0')
+    const selectAllGroup = screen.getByTestId('group-1')
     await userEvent.click(selectAllGroup)
     const venus = screen.getByRole('checkbox', {
       name: /venus/i,
@@ -1096,7 +1189,7 @@ describe('SelectInput', () => {
     expect(selectAllCheckBox).toBeChecked()
   }, 10000)
 
-  test.skip('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="row" & multiselect', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="row" & multiselect', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -1112,7 +1205,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="row" & multiselect', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="row" & multiselect', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -1128,7 +1221,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="column" & multiselect', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="column" & multiselect', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="column"
@@ -1144,7 +1237,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="column" & multiselect', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="column" & multiselect', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="column"
@@ -1160,7 +1253,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="row"', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="row"', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -1175,7 +1268,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="row"', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="row"', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -1190,7 +1283,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="column"', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="left" & descriptionDirection="column"', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="column"
@@ -1205,7 +1298,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="column"', async () => {
+  test('handles correctly click on item - optionalInfoPlacement="right" & descriptionDirection="column"', async () => {
     renderWithTheme(
       <SelectInput
         descriptionDirection="column"
@@ -1220,7 +1313,7 @@ describe('SelectInput', () => {
     const earth = screen.getByTestId('option-earth')
     await userEvent.click(earth)
   })
-  test.skip('renders correctly loading - grouped data', async () => {
+  test('renders correctly loading - grouped data', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -1236,7 +1329,7 @@ describe('SelectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly loading - ungrouped data', async () => {
+  test('renders correctly loading - ungrouped data', async () => {
     const { asFragment } = renderWithTheme(
       <SelectInput
         descriptionDirection="row"
@@ -1252,7 +1345,7 @@ describe('SelectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test.skip('renders correctly with function footer', async () => {
+  test('renders correctly with function footer', async () => {
     const f = vi.fn(() => {})
 
     const { asFragment } = renderWithTheme(
@@ -1281,7 +1374,9 @@ describe('SelectInput', () => {
 
     const footer = screen.getByTestId('buttonclose')
     const dropdown = screen.getByRole('dialog')
-    expect(dropdown).toBeVisible()
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
 
     await userEvent.click(footer)
 


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

SelectInput is polluting the dom with hidden tag element in order to calculate the size. Instead I remove it once the size is calculated and to avoid blinks I used `useLayoutEffect`.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1082" height="110" alt="Screenshot 2025-07-31 at 14 57 59" src="https://github.com/user-attachments/assets/e95e3056-7715-4944-bebf-792c34d5f125" /> |  <img width="1098" height="120" alt="Screenshot 2025-07-31 at 14 58 10" src="https://github.com/user-attachments/assets/41b69777-65f1-4f7f-b60c-a1c674b1706c" /> |
