### PR TITLE
fix: theme provider to inject theme in head

### DIFF
--- a/.changeset/neat-regions-repair.md
+++ b/.changeset/neat-regions-repair.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<ThemeProvider />` to inject theme variable in the `<head>` of the page


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There is an issue with the current theme provider, it will add the styles only at the level of the children it is being called at. The main issue is that modals and other portal elements are at the same level and cannot get the correct styles.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="559" height="331" alt="Screenshot 2025-08-06 at 16 08 33" src="https://github.com/user-attachments/assets/1e6375a2-bdc4-4474-80e7-59ee9e4c4a81" /> | <img width="504" height="324" alt="Screenshot 2025-08-06 at 16 08 46" src="https://github.com/user-attachments/assets/4416f59a-57a5-46bc-abf9-030285aa8e03" /> |
