### PR TITLE
feat(CodeEditor): add lineNumbers prop

### DIFF
--- a/.changeset/many-items-wear.md
+++ b/.changeset/many-items-wear.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": minor
+---
+
+add lineNumbers prop

--- a/.changeset/many-items-wear.md
+++ b/.changeset/many-items-wear.md
@@ -2,4 +2,4 @@
 "@ultraviolet/plus": minor
 ---
 
-add lineNumbers prop
+Add lineNumber prop on `<CodeEditor />` component

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -145,7 +145,7 @@ export const CodeEditor = ({
   'aria-label': ariaLabel,
   'data-testid': dataTestId,
   className,
-  lineNumbers = false,
+  lineNumbers = true,
 }: CodeEditorProps) => (
   <StyledStack data-disabled={disabled} gap={0.5}>
     {label ? <Label labelDescription={labelDescription}>{label}</Label> : null}

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -125,6 +125,7 @@ type CodeEditorProps = {
   'aria-label'?: string
   'data-testid'?: string
   className?: string
+  lineNumbers?: boolean
 }
 
 export const CodeEditor = ({
@@ -144,6 +145,7 @@ export const CodeEditor = ({
   'aria-label': ariaLabel,
   'data-testid': dataTestId,
   className,
+  lineNumbers = false,
 }: CodeEditorProps) => (
   <StyledStack data-disabled={disabled} gap={0.5}>
     {label ? <Label labelDescription={labelDescription}>{label}</Label> : null}
@@ -155,6 +157,7 @@ export const CodeEditor = ({
           autocompletion: autoCompletion,
           highlightActiveLine: false,
           highlightActiveLineGutter: false,
+          lineNumbers,
         }}
         className={className}
         data-testid={dataTestId}


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

#### What is expected?

add a prop to show/hide line numbers

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1174" height="403" alt="Screenshot 2025-08-14 at 13 43 49" src="https://github.com/user-attachments/assets/5e733a01-fe49-49d1-a6a4-eb0990090621" /> | <img width="1174" height="403" alt="Screenshot 2025-08-14 at 13 43 34" src="https://github.com/user-attachments/assets/734c5daa-a758-4f87-9aa7-deccee03d2a8" /> |
| url  | screenshot | screenshot |
