### PR TITLE
fix: style on individual stories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,6 +13,7 @@ import { globalStyles } from './components/globalStyle'
 import { dark, light } from './storybookThemes'
 import '@ultraviolet/fonts/fonts.css'
 import { scan } from "react-scan"
+import { ThemeProvider as ThemeProviderUI } from '@ultraviolet/ui'
 
 const BREAKPOINT_ORDER = [
   'xlarge',
@@ -142,16 +143,16 @@ const withThemeProvider = (Story: StoryFn, context: { globals: { theme: string }
 }
 
 const decorators = [
-  (Story: StoryFn) => {
-    return (
+  (Story: StoryFn) => (
       <>
-        {
-          // eslint-disable-next-line react/jsx-curly-brace-presence
-          <Story />
-        }
+        <ThemeProviderUI>
+          {
+            // eslint-disable-next-line react/jsx-curly-brace-presence
+            <Story />
+          }
+        </ThemeProviderUI>
       </>
-    ) // Storybook is broken without this please refer to this issue: https://github.com/storybookjs/storybook/issues/24625
-  },
+    ), // Storybook is broken without this please refer to this issue: https://github.com/storybookjs/storybook/issues/24625
   withThemeFromJSXProvider({
     themes: {
       light: lightTheme,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?
Style with Vanilla-Extract did not work on individual stories

Before: 
<img width="1500" height="644" alt="Capture d’écran 2025-08-20 à 10 47 28" src="https://github.com/user-attachments/assets/e8a9af7a-62d6-4c62-a618-5e9c16795ff9" />
After: 
<img width="1500" height="644" alt="Capture d’écran 2025-08-20 à 10 47 21" src="https://github.com/user-attachments/assets/a2afb4f4-36bf-42cf-b69d-5ca6a160ea5c" />

