### PR TITLE
fix(SelectInput): select bar default values

### DIFF
--- a/.changeset/little-dogs-type.md
+++ b/.changeset/little-dogs-type.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`SelectInput`: should display values correctly on first render


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?
`SelectInput`: should display values correctly on first render

Before: 

https://github.com/user-attachments/assets/28805e31-ba87-4b25-8708-c1ec5ab3b491


After : 

https://github.com/user-attachments/assets/3e4b16a0-4677-4360-80b6-66ce3f360ac9

