### PR TITLE
fix(Navigation): add as prop on stack polymorphic component

### DIFF
--- a/.changeset/good-hoops-invite.md
+++ b/.changeset/good-hoops-invite.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/plus": patch
+"@ultraviolet/ui": patch
+---
+
+Fix `<Stack />` to provide `as` prop for polymorphic composition used in `<Navigation />` for example

--- a/packages/plus/src/components/Navigation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/Navigation/__tests__/__snapshots__/index.test.tsx.snap
@@ -331,9 +331,9 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -342,7 +342,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -351,66 +351,66 @@ exports[`Navigation > click on expand / collapse button 1`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -418,8 +418,8 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -427,9 +427,9 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -439,14 +439,14 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
@@ -457,9 +457,9 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -468,7 +468,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -477,66 +477,66 @@ exports[`Navigation > click on expand / collapse button 1`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -544,8 +544,8 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -553,9 +553,9 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -565,26 +565,26 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -592,7 +592,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -600,41 +600,41 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   padding: 0.5rem 0;
 }
 
-.emotion-20[data-expanded='true'] {
+.emotion-19[data-expanded='true'] {
   padding-left: 2rem;
   margin-left: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   padding: 0.5rem 0;
 }
 
-.emotion-20[data-expanded='true'] {
+.emotion-19[data-expanded='true'] {
   padding-left: 2rem;
   margin-left: 0.25rem;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: relative;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: relative;
 }
 
-.emotion-24 {
+.emotion-23 {
   position: absolute;
   right: 0;
   left: 0;
@@ -645,7 +645,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-24::before {
+.emotion-23::before {
   content: '';
   position: absolute;
   left: 0;
@@ -657,7 +657,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   border-radius: 100%;
 }
 
-.emotion-24 {
+.emotion-23 {
   position: absolute;
   right: 0;
   left: 0;
@@ -668,7 +668,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-24::before {
+.emotion-23::before {
   content: '';
   position: absolute;
   left: 0;
@@ -680,43 +680,43 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   border-radius: 100%;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin: 1rem -1rem;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin: 1rem -1rem;
 }
 
-.emotion-28[data-animation='expand'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='expand'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-28[data-animation='collapse'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='collapse'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-28[data-animation='expand'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='expand'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-28[data-animation='collapse'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='collapse'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-30 {
+.emotion-29 {
   padding-top: 0.5rem;
 }
 
-.emotion-30 {
+.emotion-29 {
   padding-top: 0.5rem;
 }
 
-.emotion-32 {
+.emotion-31 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -724,7 +724,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-32 {
+.emotion-31 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -732,15 +732,15 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-46 {
+.emotion-43 {
   position: relative;
 }
 
-.emotion-46 {
+.emotion-43 {
   position: relative;
 }
 
-.emotion-48 {
+.emotion-45 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -750,13 +750,13 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   margin: auto;
 }
 
-.emotion-48:hover,
-.emotion-48:focus,
-.emotion-48:active {
+.emotion-45:hover,
+.emotion-45:focus,
+.emotion-45:active {
   opacity: 1;
 }
 
-.emotion-48 {
+.emotion-45 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -766,13 +766,13 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   margin: auto;
 }
 
-.emotion-48:hover,
-.emotion-48:focus,
-.emotion-48:active {
+.emotion-45:hover,
+.emotion-45:focus,
+.emotion-45:active {
   opacity: 1;
 }
 
-.emotion-50 {
+.emotion-47 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -781,11 +781,11 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-50:hover {
+.emotion-47:hover {
   background: #e9eaeb;
 }
 
-.emotion-50 {
+.emotion-47 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -794,11 +794,11 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-50:hover {
+.emotion-47:hover {
   background: #e9eaeb;
 }
 
-.emotion-52 {
+.emotion-49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -818,12 +818,12 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-52[data-has-overflow-style="false"] {
+.emotion-49[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-52 {
+.emotion-49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -843,12 +843,12 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-52[data-has-overflow-style="false"] {
+.emotion-49[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-54 {
+.emotion-51 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -863,11 +863,11 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   display: flex;
 }
 
-.emotion-54:hover {
+.emotion-51:hover {
   border-color: #8c40ef;
 }
 
-.emotion-54 {
+.emotion-51 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -882,7 +882,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
   display: flex;
 }
 
-.emotion-54:hover {
+.emotion-51:hover {
   border-color: #8c40ef;
 }
 
@@ -918,7 +918,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
           >
             <div>
               <button
-                class="emotion-12 emotion-13"
+                class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                 data-animation="false"
                 data-has-active-children="false"
                 data-has-children="true"
@@ -927,7 +927,6 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                 data-is-pinnable="false"
                 data-pinned-feature="true"
                 data-testid="pinned-group"
-                direction="row"
                 draggable="false"
                 id="pinned-group"
               >
@@ -935,7 +934,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                   class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                 >
                   <div
-                    class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                    class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                   >
                     <svg
                       class="style_neutral__1m2xqlz3"
@@ -965,7 +964,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                     class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                   >
                     <span
-                      class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                      class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                       style="--uv_qabug41: pre-wrap;"
                     >
                       Pinned items
@@ -976,7 +975,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                   class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-18 emotion-19 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
+                    class="emotion-17 emotion-18 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
                   >
                     <svg
                       class="styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
@@ -996,7 +995,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                   class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                     data-expanded="true"
                   >
                     <p
@@ -1006,10 +1005,10 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                     </p>
                   </div>
                   <div
-                    class="emotion-22 emotion-23"
+                    class="emotion-21 emotion-22"
                   >
                     <div
-                      class="emotion-24 emotion-25"
+                      class="emotion-23 emotion-24"
                     />
                   </div>
                 </div>
@@ -1017,24 +1016,24 @@ exports[`Navigation > click on expand / collapse button 1`] = `
             </div>
             <hr
               aria-orientation="horizontal"
-              class="emotion-26 emotion-27 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
+              class="emotion-25 emotion-26 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
               role="separator"
               style="--uv_bu43fb0: 1px;"
             />
             <div
-              class="emotion-28 emotion-29"
+              class="emotion-27 emotion-28"
               data-animation="false"
             >
               <div
-                class="emotion-30 emotion-31 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
+                class="emotion-29 emotion-30 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
               >
                 <span
-                  class="emotion-32 emotion-33 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
+                  class="emotion-31 emotion-32 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
                 >
                   Products
                 </span>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -1043,7 +1042,6 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                   data-is-active="true"
                   data-is-pinnable="false"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -1051,7 +1049,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_neutral__1m2xqlz3"
@@ -1087,7 +1085,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -1099,7 +1097,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                   />
                 </button>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -1107,7 +1105,6 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                   data-has-sub-label="false"
                   data-is-pinnable="true"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -1115,7 +1112,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_primary__1m2xqlz1"
@@ -1151,7 +1148,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -1168,15 +1165,15 @@ exports[`Navigation > click on expand / collapse button 1`] = `
                       tabindex="0"
                     >
                       <div
-                        class="emotion-46 emotion-195"
+                        class="emotion-43 emotion-184"
                       >
                         <div
                           aria-label="pin"
-                          class="emotion-48 emotion-197"
+                          class="emotion-45 emotion-186"
                           role="button"
                         >
                           <svg
-                            class="emotion-50 emotion-193 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                            class="emotion-47 emotion-182 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                             viewBox="0 0 20 20"
                           >
                             <path
@@ -1193,7 +1190,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
             </div>
           </div>
           <div
-            class="emotion-52 emotion-53"
+            class="emotion-49 emotion-50"
             data-has-overflow-style="false"
           >
             <div
@@ -1223,7 +1220,7 @@ exports[`Navigation > click on expand / collapse button 1`] = `
         </div>
       </div>
       <div
-        class="emotion-54 emotion-55"
+        class="emotion-51 emotion-52"
         data-testid="slider"
       />
     </nav>
@@ -2171,9 +2168,9 @@ exports[`Navigation > pin and unpin an item 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -2182,7 +2179,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -2191,66 +2188,66 @@ exports[`Navigation > pin and unpin an item 1`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -2258,8 +2255,8 @@ exports[`Navigation > pin and unpin an item 1`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -2267,9 +2264,9 @@ exports[`Navigation > pin and unpin an item 1`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -2279,14 +2276,14 @@ exports[`Navigation > pin and unpin an item 1`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
@@ -2297,9 +2294,9 @@ exports[`Navigation > pin and unpin an item 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -2308,7 +2305,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -2317,66 +2314,66 @@ exports[`Navigation > pin and unpin an item 1`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -2384,8 +2381,8 @@ exports[`Navigation > pin and unpin an item 1`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -2393,9 +2390,9 @@ exports[`Navigation > pin and unpin an item 1`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -2405,26 +2402,26 @@ exports[`Navigation > pin and unpin an item 1`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -2432,7 +2429,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -2440,23 +2437,23 @@ exports[`Navigation > pin and unpin an item 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   position: relative;
 }
 
-.emotion-20 {
+.emotion-19 {
   position: relative;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: absolute;
   right: 0;
   left: 0;
@@ -2467,7 +2464,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-22::before {
+.emotion-21::before {
   content: '';
   position: absolute;
   left: 0;
@@ -2479,7 +2476,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
   border-radius: 100%;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: absolute;
   right: 0;
   left: 0;
@@ -2490,7 +2487,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-22::before {
+.emotion-21::before {
   content: '';
   position: absolute;
   left: 0;
@@ -2502,22 +2499,22 @@ exports[`Navigation > pin and unpin an item 1`] = `
   border-radius: 100%;
 }
 
-.emotion-26 {
+.emotion-24 {
   opacity: 0;
   margin: 0 0.125rem;
   cursor: -webkit-grab;
   cursor: grab;
 }
 
-.emotion-30 {
+.emotion-28 {
+  position: relative;
+}
+
+.emotion-28 {
   position: relative;
 }
 
 .emotion-30 {
-  position: relative;
-}
-
-.emotion-32 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -2527,13 +2524,13 @@ exports[`Navigation > pin and unpin an item 1`] = `
   margin: auto;
 }
 
-.emotion-32:hover,
-.emotion-32:focus,
-.emotion-32:active {
+.emotion-30:hover,
+.emotion-30:focus,
+.emotion-30:active {
   opacity: 1;
 }
 
-.emotion-32 {
+.emotion-30 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -2543,13 +2540,13 @@ exports[`Navigation > pin and unpin an item 1`] = `
   margin: auto;
 }
 
-.emotion-32:hover,
-.emotion-32:focus,
-.emotion-32:active {
+.emotion-30:hover,
+.emotion-30:focus,
+.emotion-30:active {
   opacity: 1;
 }
 
-.emotion-34 {
+.emotion-32 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -2558,47 +2555,47 @@ exports[`Navigation > pin and unpin an item 1`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-34:hover {
+.emotion-32:hover {
   background: #e9eaeb;
 }
 
-.emotion-40 {
+.emotion-38 {
   margin: 1rem -1rem;
 }
 
-.emotion-40 {
+.emotion-38 {
   margin: 1rem -1rem;
 }
 
-.emotion-42[data-animation='expand'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='expand'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-42[data-animation='collapse'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='collapse'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-42[data-animation='expand'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='expand'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-42[data-animation='collapse'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='collapse'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-44 {
+.emotion-42 {
+  padding-top: 0.5rem;
+}
+
+.emotion-42 {
   padding-top: 0.5rem;
 }
 
 .emotion-44 {
-  padding-top: 0.5rem;
-}
-
-.emotion-46 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -2606,7 +2603,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-46 {
+.emotion-44 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -2614,7 +2611,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-66 {
+.emotion-62 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2634,12 +2631,12 @@ exports[`Navigation > pin and unpin an item 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-66[data-has-overflow-style="false"] {
+.emotion-62[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-66 {
+.emotion-62 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2659,12 +2656,12 @@ exports[`Navigation > pin and unpin an item 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-66[data-has-overflow-style="false"] {
+.emotion-62[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-68 {
+.emotion-64 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -2679,11 +2676,11 @@ exports[`Navigation > pin and unpin an item 1`] = `
   display: flex;
 }
 
-.emotion-68:hover {
+.emotion-64:hover {
   border-color: #8c40ef;
 }
 
-.emotion-68 {
+.emotion-64 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -2698,7 +2695,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
   display: flex;
 }
 
-.emotion-68:hover {
+.emotion-64:hover {
   border-color: #8c40ef;
 }
 
@@ -2734,7 +2731,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
           >
             <div>
               <button
-                class="emotion-12 emotion-13"
+                class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                 data-animation="false"
                 data-has-active-children="false"
                 data-has-children="true"
@@ -2743,7 +2740,6 @@ exports[`Navigation > pin and unpin an item 1`] = `
                 data-is-pinnable="false"
                 data-pinned-feature="true"
                 data-testid="pinned-group"
-                direction="row"
                 draggable="false"
                 id="pinned-group"
               >
@@ -2751,7 +2747,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                   class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                 >
                   <div
-                    class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                    class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                   >
                     <svg
                       class="style_neutral__1m2xqlz3"
@@ -2781,7 +2777,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                     class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                   >
                     <span
-                      class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                      class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                       style="--uv_qabug41: pre-wrap;"
                     >
                       Pinned items
@@ -2792,7 +2788,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                   class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-18 emotion-19 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
+                    class="emotion-17 emotion-18 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
                   >
                     <svg
                       class="styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
@@ -2812,13 +2808,13 @@ exports[`Navigation > pin and unpin an item 1`] = `
                   class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                   >
                     <div
-                      class="emotion-22 emotion-23"
+                      class="emotion-21 emotion-22"
                     />
                     <button
-                      class="emotion-12 emotion-13"
+                      class="emotion-12 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                       data-animation="false"
                       data-has-active-children="false"
                       data-has-children="false"
@@ -2827,7 +2823,6 @@ exports[`Navigation > pin and unpin an item 1`] = `
                       data-is-active="false"
                       data-is-pinnable="true"
                       data-pinned-feature="true"
-                      direction="row"
                       draggable="true"
                       id="item1"
                     >
@@ -2835,7 +2830,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                         class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                       >
                         <svg
-                          class="emotion-26 emotion-191 styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
+                          class="emotion-24 emotion-180 styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
                           viewBox="0 0 16 16"
                         >
                           <path
@@ -2846,7 +2841,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                           class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                         >
                           <span
-                            class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow20 uv_m4c9ow3c"
+                            class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow20 uv_m4c9ow3c"
                             style="--uv_qabug41: pre-wrap;"
                           >
                             item1
@@ -2863,15 +2858,15 @@ exports[`Navigation > pin and unpin an item 1`] = `
                           tabindex="0"
                         >
                           <div
-                            class="emotion-30 emotion-195"
+                            class="emotion-28 emotion-184"
                           >
                             <div
                               aria-label="unpin"
-                              class="emotion-32 emotion-197"
+                              class="emotion-30 emotion-186"
                               role="button"
                             >
                               <svg
-                                class="emotion-34 emotion-196 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                                class="emotion-32 emotion-185 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                                 viewBox="0 0 20 20"
                               >
                                 <path
@@ -2885,10 +2880,10 @@ exports[`Navigation > pin and unpin an item 1`] = `
                     </button>
                   </div>
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                   >
                     <div
-                      class="emotion-22 emotion-23"
+                      class="emotion-21 emotion-22"
                     />
                   </div>
                 </div>
@@ -2896,24 +2891,24 @@ exports[`Navigation > pin and unpin an item 1`] = `
             </div>
             <hr
               aria-orientation="horizontal"
-              class="emotion-40 emotion-41 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
+              class="emotion-38 emotion-39 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
               role="separator"
               style="--uv_bu43fb0: 1px;"
             />
             <div
-              class="emotion-42 emotion-43"
+              class="emotion-40 emotion-41"
               data-animation="false"
             >
               <div
-                class="emotion-44 emotion-45 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
+                class="emotion-42 emotion-43 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
               >
                 <span
-                  class="emotion-46 emotion-47 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
+                  class="emotion-44 emotion-45 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
                 >
                   Products
                 </span>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -2922,7 +2917,6 @@ exports[`Navigation > pin and unpin an item 1`] = `
                   data-is-active="true"
                   data-is-pinnable="false"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -2930,7 +2924,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_neutral__1m2xqlz3"
@@ -2966,7 +2960,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -2978,7 +2972,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                   />
                 </button>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -2986,7 +2980,6 @@ exports[`Navigation > pin and unpin an item 1`] = `
                   data-has-sub-label="false"
                   data-is-pinnable="true"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -2994,7 +2987,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_primary__1m2xqlz1"
@@ -3030,7 +3023,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -3047,15 +3040,15 @@ exports[`Navigation > pin and unpin an item 1`] = `
                       tabindex="0"
                     >
                       <div
-                        class="emotion-30 emotion-195"
+                        class="emotion-28 emotion-184"
                       >
                         <div
                           aria-label="unpin"
-                          class="emotion-32 emotion-197"
+                          class="emotion-30 emotion-186"
                           role="button"
                         >
                           <svg
-                            class="emotion-34 emotion-196 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                            class="emotion-32 emotion-185 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                             viewBox="0 0 20 20"
                           >
                             <path
@@ -3071,7 +3064,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
             </div>
           </div>
           <div
-            class="emotion-66 emotion-67"
+            class="emotion-62 emotion-63"
             data-has-overflow-style="false"
           >
             <div
@@ -3101,7 +3094,7 @@ exports[`Navigation > pin and unpin an item 1`] = `
         </div>
       </div>
       <div
-        class="emotion-68 emotion-69"
+        class="emotion-64 emotion-65"
         data-testid="slider"
       />
     </nav>
@@ -3440,9 +3433,9 @@ exports[`Navigation > pin and unpin an item 2`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -3451,7 +3444,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -3460,66 +3453,66 @@ exports[`Navigation > pin and unpin an item 2`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -3527,8 +3520,8 @@ exports[`Navigation > pin and unpin an item 2`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -3536,9 +3529,9 @@ exports[`Navigation > pin and unpin an item 2`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -3548,14 +3541,14 @@ exports[`Navigation > pin and unpin an item 2`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
@@ -3566,9 +3559,9 @@ exports[`Navigation > pin and unpin an item 2`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -3577,7 +3570,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -3586,66 +3579,66 @@ exports[`Navigation > pin and unpin an item 2`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -3653,8 +3646,8 @@ exports[`Navigation > pin and unpin an item 2`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -3662,9 +3655,9 @@ exports[`Navigation > pin and unpin an item 2`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -3674,26 +3667,26 @@ exports[`Navigation > pin and unpin an item 2`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -3701,7 +3694,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -3709,23 +3702,23 @@ exports[`Navigation > pin and unpin an item 2`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   position: relative;
 }
 
-.emotion-20 {
+.emotion-19 {
   position: relative;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: absolute;
   right: 0;
   left: 0;
@@ -3736,7 +3729,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-22::before {
+.emotion-21::before {
   content: '';
   position: absolute;
   left: 0;
@@ -3748,7 +3741,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
   border-radius: 100%;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: absolute;
   right: 0;
   left: 0;
@@ -3759,7 +3752,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-22::before {
+.emotion-21::before {
   content: '';
   position: absolute;
   left: 0;
@@ -3771,22 +3764,22 @@ exports[`Navigation > pin and unpin an item 2`] = `
   border-radius: 100%;
 }
 
-.emotion-26 {
+.emotion-24 {
   opacity: 0;
   margin: 0 0.125rem;
   cursor: -webkit-grab;
   cursor: grab;
 }
 
-.emotion-30 {
+.emotion-28 {
+  position: relative;
+}
+
+.emotion-28 {
   position: relative;
 }
 
 .emotion-30 {
-  position: relative;
-}
-
-.emotion-32 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -3796,13 +3789,13 @@ exports[`Navigation > pin and unpin an item 2`] = `
   margin: auto;
 }
 
-.emotion-32:hover,
-.emotion-32:focus,
-.emotion-32:active {
+.emotion-30:hover,
+.emotion-30:focus,
+.emotion-30:active {
   opacity: 1;
 }
 
-.emotion-32 {
+.emotion-30 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -3812,13 +3805,13 @@ exports[`Navigation > pin and unpin an item 2`] = `
   margin: auto;
 }
 
-.emotion-32:hover,
-.emotion-32:focus,
-.emotion-32:active {
+.emotion-30:hover,
+.emotion-30:focus,
+.emotion-30:active {
   opacity: 1;
 }
 
-.emotion-34 {
+.emotion-32 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -3827,47 +3820,47 @@ exports[`Navigation > pin and unpin an item 2`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-34:hover {
+.emotion-32:hover {
   background: #e9eaeb;
 }
 
-.emotion-40 {
+.emotion-38 {
   margin: 1rem -1rem;
 }
 
-.emotion-40 {
+.emotion-38 {
   margin: 1rem -1rem;
 }
 
-.emotion-42[data-animation='expand'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='expand'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-42[data-animation='collapse'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='collapse'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-42[data-animation='expand'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='expand'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-42[data-animation='collapse'][data-animation-type="complex"] .emotion-47 {
+.emotion-40[data-animation='collapse'][data-animation-type="complex"] .emotion-45 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-44 {
+.emotion-42 {
+  padding-top: 0.5rem;
+}
+
+.emotion-42 {
   padding-top: 0.5rem;
 }
 
 .emotion-44 {
-  padding-top: 0.5rem;
-}
-
-.emotion-46 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -3875,7 +3868,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-46 {
+.emotion-44 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -3883,7 +3876,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-66 {
+.emotion-62 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3903,12 +3896,12 @@ exports[`Navigation > pin and unpin an item 2`] = `
   justify-content: flex-end;
 }
 
-.emotion-66[data-has-overflow-style="false"] {
+.emotion-62[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-66 {
+.emotion-62 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3928,12 +3921,12 @@ exports[`Navigation > pin and unpin an item 2`] = `
   justify-content: flex-end;
 }
 
-.emotion-66[data-has-overflow-style="false"] {
+.emotion-62[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-68 {
+.emotion-64 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -3948,11 +3941,11 @@ exports[`Navigation > pin and unpin an item 2`] = `
   display: flex;
 }
 
-.emotion-68:hover {
+.emotion-64:hover {
   border-color: #8c40ef;
 }
 
-.emotion-68 {
+.emotion-64 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -3967,7 +3960,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
   display: flex;
 }
 
-.emotion-68:hover {
+.emotion-64:hover {
   border-color: #8c40ef;
 }
 
@@ -4003,7 +3996,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
           >
             <div>
               <button
-                class="emotion-12 emotion-13"
+                class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                 data-animation="false"
                 data-has-active-children="false"
                 data-has-children="true"
@@ -4012,7 +4005,6 @@ exports[`Navigation > pin and unpin an item 2`] = `
                 data-is-pinnable="false"
                 data-pinned-feature="true"
                 data-testid="pinned-group"
-                direction="row"
                 draggable="false"
                 id="pinned-group"
               >
@@ -4020,7 +4012,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                   class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                 >
                   <div
-                    class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                    class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                   >
                     <svg
                       class="style_neutral__1m2xqlz3"
@@ -4050,7 +4042,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                     class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                   >
                     <span
-                      class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                      class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                       style="--uv_qabug41: pre-wrap;"
                     >
                       Pinned items
@@ -4061,7 +4053,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                   class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-18 emotion-19 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
+                    class="emotion-17 emotion-18 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
                   >
                     <svg
                       class="styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
@@ -4083,13 +4075,13 @@ exports[`Navigation > pin and unpin an item 2`] = `
                   class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                   >
                     <div
-                      class="emotion-22 emotion-23"
+                      class="emotion-21 emotion-22"
                     />
                     <button
-                      class="emotion-12 emotion-13"
+                      class="emotion-12 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                       data-animation="false"
                       data-has-active-children="false"
                       data-has-children="false"
@@ -4098,7 +4090,6 @@ exports[`Navigation > pin and unpin an item 2`] = `
                       data-is-active="false"
                       data-is-pinnable="true"
                       data-pinned-feature="true"
-                      direction="row"
                       draggable="true"
                       id="item1"
                     >
@@ -4106,7 +4097,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                         class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                       >
                         <svg
-                          class="emotion-26 emotion-191 styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
+                          class="emotion-24 emotion-180 styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
                           viewBox="0 0 16 16"
                         >
                           <path
@@ -4117,7 +4108,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                           class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                         >
                           <span
-                            class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow20 uv_m4c9ow3c"
+                            class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow20 uv_m4c9ow3c"
                             style="--uv_qabug41: pre-wrap;"
                           >
                             item1
@@ -4134,15 +4125,15 @@ exports[`Navigation > pin and unpin an item 2`] = `
                           tabindex="0"
                         >
                           <div
-                            class="emotion-30 emotion-195"
+                            class="emotion-28 emotion-184"
                           >
                             <div
                               aria-label="unpin"
-                              class="emotion-32 emotion-197"
+                              class="emotion-30 emotion-186"
                               role="button"
                             >
                               <svg
-                                class="emotion-34 emotion-196 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                                class="emotion-32 emotion-185 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                                 viewBox="0 0 20 20"
                               >
                                 <path
@@ -4156,10 +4147,10 @@ exports[`Navigation > pin and unpin an item 2`] = `
                     </button>
                   </div>
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                   >
                     <div
-                      class="emotion-22 emotion-23"
+                      class="emotion-21 emotion-22"
                     />
                   </div>
                 </div>
@@ -4167,24 +4158,24 @@ exports[`Navigation > pin and unpin an item 2`] = `
             </div>
             <hr
               aria-orientation="horizontal"
-              class="emotion-40 emotion-41 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
+              class="emotion-38 emotion-39 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
               role="separator"
               style="--uv_bu43fb0: 1px;"
             />
             <div
-              class="emotion-42 emotion-43"
+              class="emotion-40 emotion-41"
               data-animation="false"
             >
               <div
-                class="emotion-44 emotion-45 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
+                class="emotion-42 emotion-43 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
               >
                 <span
-                  class="emotion-46 emotion-47 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
+                  class="emotion-44 emotion-45 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
                 >
                   Products
                 </span>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -4193,7 +4184,6 @@ exports[`Navigation > pin and unpin an item 2`] = `
                   data-is-active="true"
                   data-is-pinnable="false"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -4201,7 +4191,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_neutral__1m2xqlz3"
@@ -4237,7 +4227,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -4249,7 +4239,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                   />
                 </button>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -4257,7 +4247,6 @@ exports[`Navigation > pin and unpin an item 2`] = `
                   data-has-sub-label="false"
                   data-is-pinnable="true"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -4265,7 +4254,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_primary__1m2xqlz1"
@@ -4301,7 +4290,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -4318,15 +4307,15 @@ exports[`Navigation > pin and unpin an item 2`] = `
                       tabindex="0"
                     >
                       <div
-                        class="emotion-30 emotion-195"
+                        class="emotion-28 emotion-184"
                       >
                         <div
                           aria-label="unpin"
-                          class="emotion-32 emotion-197"
+                          class="emotion-30 emotion-186"
                           role="button"
                         >
                           <svg
-                            class="emotion-34 emotion-196 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                            class="emotion-32 emotion-185 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                             viewBox="0 0 20 20"
                           >
                             <path
@@ -4342,7 +4331,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
             </div>
           </div>
           <div
-            class="emotion-66 emotion-67"
+            class="emotion-62 emotion-63"
             data-has-overflow-style="false"
           >
             <div
@@ -4372,7 +4361,7 @@ exports[`Navigation > pin and unpin an item 2`] = `
         </div>
       </div>
       <div
-        class="emotion-68 emotion-69"
+        class="emotion-64 emotion-65"
         data-testid="slider"
       />
     </nav>
@@ -4711,9 +4700,9 @@ exports[`Navigation > pin and unpin an item 3`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -4722,7 +4711,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -4731,66 +4720,66 @@ exports[`Navigation > pin and unpin an item 3`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -4798,8 +4787,8 @@ exports[`Navigation > pin and unpin an item 3`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -4807,9 +4796,9 @@ exports[`Navigation > pin and unpin an item 3`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -4819,14 +4808,14 @@ exports[`Navigation > pin and unpin an item 3`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
@@ -4837,9 +4826,9 @@ exports[`Navigation > pin and unpin an item 3`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -4848,7 +4837,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -4857,66 +4846,66 @@ exports[`Navigation > pin and unpin an item 3`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -4924,8 +4913,8 @@ exports[`Navigation > pin and unpin an item 3`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -4933,9 +4922,9 @@ exports[`Navigation > pin and unpin an item 3`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -4945,26 +4934,26 @@ exports[`Navigation > pin and unpin an item 3`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -4972,7 +4961,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -4980,41 +4969,41 @@ exports[`Navigation > pin and unpin an item 3`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   padding: 0.5rem 0;
 }
 
-.emotion-20[data-expanded='true'] {
+.emotion-19[data-expanded='true'] {
   padding-left: 2rem;
   margin-left: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   padding: 0.5rem 0;
 }
 
-.emotion-20[data-expanded='true'] {
+.emotion-19[data-expanded='true'] {
   padding-left: 2rem;
   margin-left: 0.25rem;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: relative;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: relative;
 }
 
-.emotion-24 {
+.emotion-23 {
   position: absolute;
   right: 0;
   left: 0;
@@ -5025,7 +5014,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-24::before {
+.emotion-23::before {
   content: '';
   position: absolute;
   left: 0;
@@ -5037,7 +5026,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
   border-radius: 100%;
 }
 
-.emotion-24 {
+.emotion-23 {
   position: absolute;
   right: 0;
   left: 0;
@@ -5048,7 +5037,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-24::before {
+.emotion-23::before {
   content: '';
   position: absolute;
   left: 0;
@@ -5060,43 +5049,43 @@ exports[`Navigation > pin and unpin an item 3`] = `
   border-radius: 100%;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin: 1rem -1rem;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin: 1rem -1rem;
 }
 
-.emotion-28[data-animation='expand'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='expand'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-28[data-animation='collapse'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='collapse'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-28[data-animation='expand'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='expand'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-28[data-animation='collapse'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='collapse'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-30 {
+.emotion-29 {
   padding-top: 0.5rem;
 }
 
-.emotion-30 {
+.emotion-29 {
   padding-top: 0.5rem;
 }
 
-.emotion-32 {
+.emotion-31 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -5104,7 +5093,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-32 {
+.emotion-31 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -5112,15 +5101,15 @@ exports[`Navigation > pin and unpin an item 3`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-46 {
+.emotion-43 {
   position: relative;
 }
 
-.emotion-46 {
+.emotion-43 {
   position: relative;
 }
 
-.emotion-48 {
+.emotion-45 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -5130,13 +5119,13 @@ exports[`Navigation > pin and unpin an item 3`] = `
   margin: auto;
 }
 
-.emotion-48:hover,
-.emotion-48:focus,
-.emotion-48:active {
+.emotion-45:hover,
+.emotion-45:focus,
+.emotion-45:active {
   opacity: 1;
 }
 
-.emotion-48 {
+.emotion-45 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -5146,13 +5135,13 @@ exports[`Navigation > pin and unpin an item 3`] = `
   margin: auto;
 }
 
-.emotion-48:hover,
-.emotion-48:focus,
-.emotion-48:active {
+.emotion-45:hover,
+.emotion-45:focus,
+.emotion-45:active {
   opacity: 1;
 }
 
-.emotion-50 {
+.emotion-47 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -5161,11 +5150,11 @@ exports[`Navigation > pin and unpin an item 3`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-50:hover {
+.emotion-47:hover {
   background: #e9eaeb;
 }
 
-.emotion-50 {
+.emotion-47 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -5174,11 +5163,11 @@ exports[`Navigation > pin and unpin an item 3`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-50:hover {
+.emotion-47:hover {
   background: #e9eaeb;
 }
 
-.emotion-52 {
+.emotion-49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5198,12 +5187,12 @@ exports[`Navigation > pin and unpin an item 3`] = `
   justify-content: flex-end;
 }
 
-.emotion-52[data-has-overflow-style="false"] {
+.emotion-49[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-52 {
+.emotion-49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5223,12 +5212,12 @@ exports[`Navigation > pin and unpin an item 3`] = `
   justify-content: flex-end;
 }
 
-.emotion-52[data-has-overflow-style="false"] {
+.emotion-49[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-54 {
+.emotion-51 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -5243,11 +5232,11 @@ exports[`Navigation > pin and unpin an item 3`] = `
   display: flex;
 }
 
-.emotion-54:hover {
+.emotion-51:hover {
   border-color: #8c40ef;
 }
 
-.emotion-54 {
+.emotion-51 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -5262,7 +5251,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
   display: flex;
 }
 
-.emotion-54:hover {
+.emotion-51:hover {
   border-color: #8c40ef;
 }
 
@@ -5298,7 +5287,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
           >
             <div>
               <button
-                class="emotion-12 emotion-13"
+                class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                 data-animation="false"
                 data-has-active-children="false"
                 data-has-children="true"
@@ -5307,7 +5296,6 @@ exports[`Navigation > pin and unpin an item 3`] = `
                 data-is-pinnable="false"
                 data-pinned-feature="true"
                 data-testid="pinned-group"
-                direction="row"
                 draggable="false"
                 id="pinned-group"
               >
@@ -5315,7 +5303,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                   class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                 >
                   <div
-                    class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                    class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                   >
                     <svg
                       class="style_neutral__1m2xqlz3"
@@ -5345,7 +5333,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                     class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                   >
                     <span
-                      class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                      class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                       style="--uv_qabug41: pre-wrap;"
                     >
                       Pinned items
@@ -5356,7 +5344,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                   class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-18 emotion-19 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
+                    class="emotion-17 emotion-18 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
                   >
                     <svg
                       class="styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
@@ -5378,7 +5366,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                   class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                     data-expanded="true"
                   >
                     <p
@@ -5388,10 +5376,10 @@ exports[`Navigation > pin and unpin an item 3`] = `
                     </p>
                   </div>
                   <div
-                    class="emotion-22 emotion-23"
+                    class="emotion-21 emotion-22"
                   >
                     <div
-                      class="emotion-24 emotion-25"
+                      class="emotion-23 emotion-24"
                     />
                   </div>
                 </div>
@@ -5399,24 +5387,24 @@ exports[`Navigation > pin and unpin an item 3`] = `
             </div>
             <hr
               aria-orientation="horizontal"
-              class="emotion-26 emotion-27 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
+              class="emotion-25 emotion-26 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
               role="separator"
               style="--uv_bu43fb0: 1px;"
             />
             <div
-              class="emotion-28 emotion-29"
+              class="emotion-27 emotion-28"
               data-animation="false"
             >
               <div
-                class="emotion-30 emotion-31 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
+                class="emotion-29 emotion-30 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
               >
                 <span
-                  class="emotion-32 emotion-33 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
+                  class="emotion-31 emotion-32 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
                 >
                   Products
                 </span>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -5425,7 +5413,6 @@ exports[`Navigation > pin and unpin an item 3`] = `
                   data-is-active="true"
                   data-is-pinnable="false"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -5433,7 +5420,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_neutral__1m2xqlz3"
@@ -5469,7 +5456,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -5481,7 +5468,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                   />
                 </button>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -5489,7 +5476,6 @@ exports[`Navigation > pin and unpin an item 3`] = `
                   data-has-sub-label="false"
                   data-is-pinnable="true"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -5497,7 +5483,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_primary__1m2xqlz1"
@@ -5533,7 +5519,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -5550,15 +5536,15 @@ exports[`Navigation > pin and unpin an item 3`] = `
                       tabindex="0"
                     >
                       <div
-                        class="emotion-46 emotion-195"
+                        class="emotion-43 emotion-184"
                       >
                         <div
                           aria-label="pin"
-                          class="emotion-48 emotion-197"
+                          class="emotion-45 emotion-186"
                           role="button"
                         >
                           <svg
-                            class="emotion-50 emotion-193 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                            class="emotion-47 emotion-182 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                             viewBox="0 0 20 20"
                           >
                             <path
@@ -5575,7 +5561,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
             </div>
           </div>
           <div
-            class="emotion-52 emotion-53"
+            class="emotion-49 emotion-50"
             data-has-overflow-style="false"
           >
             <div
@@ -5605,7 +5591,7 @@ exports[`Navigation > pin and unpin an item 3`] = `
         </div>
       </div>
       <div
-        class="emotion-54 emotion-55"
+        class="emotion-51 emotion-52"
         data-testid="slider"
       />
     </nav>
@@ -5783,9 +5769,9 @@ exports[`Navigation > render with basic content 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -5794,7 +5780,7 @@ exports[`Navigation > render with basic content 1`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -5803,66 +5789,66 @@ exports[`Navigation > render with basic content 1`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -5870,8 +5856,8 @@ exports[`Navigation > render with basic content 1`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -5879,9 +5865,9 @@ exports[`Navigation > render with basic content 1`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -5891,22 +5877,22 @@ exports[`Navigation > render with basic content 1`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -5914,24 +5900,24 @@ exports[`Navigation > render with basic content 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   padding: 0.5rem 0;
 }
 
-.emotion-20[data-expanded='true'] {
+.emotion-19[data-expanded='true'] {
   padding-left: 2rem;
   margin-left: 0.25rem;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: relative;
 }
 
-.emotion-24 {
+.emotion-23 {
   position: absolute;
   right: 0;
   left: 0;
@@ -5942,7 +5928,7 @@ exports[`Navigation > render with basic content 1`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-24::before {
+.emotion-23::before {
   content: '';
   position: absolute;
   left: 0;
@@ -5954,25 +5940,25 @@ exports[`Navigation > render with basic content 1`] = `
   border-radius: 100%;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin: 1rem -1rem;
 }
 
-.emotion-28[data-animation='expand'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='expand'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-28[data-animation='collapse'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='collapse'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-30 {
+.emotion-29 {
   padding-top: 0.5rem;
 }
 
-.emotion-32 {
+.emotion-31 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -5980,11 +5966,11 @@ exports[`Navigation > render with basic content 1`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-46 {
+.emotion-43 {
   position: relative;
 }
 
-.emotion-48 {
+.emotion-45 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -5994,13 +5980,13 @@ exports[`Navigation > render with basic content 1`] = `
   margin: auto;
 }
 
-.emotion-48:hover,
-.emotion-48:focus,
-.emotion-48:active {
+.emotion-45:hover,
+.emotion-45:focus,
+.emotion-45:active {
   opacity: 1;
 }
 
-.emotion-50 {
+.emotion-47 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -6009,11 +5995,11 @@ exports[`Navigation > render with basic content 1`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-50:hover {
+.emotion-47:hover {
   background: #e9eaeb;
 }
 
-.emotion-52 {
+.emotion-49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6033,12 +6019,12 @@ exports[`Navigation > render with basic content 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-52[data-has-overflow-style="false"] {
+.emotion-49[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-54 {
+.emotion-51 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -6053,7 +6039,7 @@ exports[`Navigation > render with basic content 1`] = `
   display: flex;
 }
 
-.emotion-54:hover {
+.emotion-51:hover {
   border-color: #8c40ef;
 }
 
@@ -6089,7 +6075,7 @@ exports[`Navigation > render with basic content 1`] = `
           >
             <div>
               <button
-                class="emotion-12 emotion-13"
+                class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                 data-animation="false"
                 data-has-active-children="false"
                 data-has-children="true"
@@ -6098,7 +6084,6 @@ exports[`Navigation > render with basic content 1`] = `
                 data-is-pinnable="false"
                 data-pinned-feature="true"
                 data-testid="pinned-group"
-                direction="row"
                 draggable="false"
                 id="pinned-group"
               >
@@ -6106,7 +6091,7 @@ exports[`Navigation > render with basic content 1`] = `
                   class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                 >
                   <div
-                    class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                    class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                   >
                     <svg
                       class="style_neutral__1m2xqlz3"
@@ -6136,7 +6121,7 @@ exports[`Navigation > render with basic content 1`] = `
                     class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                   >
                     <span
-                      class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                      class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                       style="--uv_qabug41: pre-wrap;"
                     >
                       Pinned items
@@ -6147,7 +6132,7 @@ exports[`Navigation > render with basic content 1`] = `
                   class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-18 emotion-19 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
+                    class="emotion-17 emotion-18 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
                   >
                     <svg
                       class="styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
@@ -6167,7 +6152,7 @@ exports[`Navigation > render with basic content 1`] = `
                   class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                     data-expanded="true"
                   >
                     <p
@@ -6177,10 +6162,10 @@ exports[`Navigation > render with basic content 1`] = `
                     </p>
                   </div>
                   <div
-                    class="emotion-22 emotion-23"
+                    class="emotion-21 emotion-22"
                   >
                     <div
-                      class="emotion-24 emotion-25"
+                      class="emotion-23 emotion-24"
                     />
                   </div>
                 </div>
@@ -6188,24 +6173,24 @@ exports[`Navigation > render with basic content 1`] = `
             </div>
             <hr
               aria-orientation="horizontal"
-              class="emotion-26 emotion-27 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
+              class="emotion-25 emotion-26 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
               role="separator"
               style="--uv_bu43fb0: 1px;"
             />
             <div
-              class="emotion-28 emotion-29"
+              class="emotion-27 emotion-28"
               data-animation="false"
             >
               <div
-                class="emotion-30 emotion-31 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
+                class="emotion-29 emotion-30 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
               >
                 <span
-                  class="emotion-32 emotion-33 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
+                  class="emotion-31 emotion-32 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
                 >
                   Products
                 </span>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -6214,7 +6199,6 @@ exports[`Navigation > render with basic content 1`] = `
                   data-is-active="true"
                   data-is-pinnable="false"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -6222,7 +6206,7 @@ exports[`Navigation > render with basic content 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_neutral__1m2xqlz3"
@@ -6258,7 +6242,7 @@ exports[`Navigation > render with basic content 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -6270,7 +6254,7 @@ exports[`Navigation > render with basic content 1`] = `
                   />
                 </button>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -6278,7 +6262,6 @@ exports[`Navigation > render with basic content 1`] = `
                   data-has-sub-label="false"
                   data-is-pinnable="true"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -6286,7 +6269,7 @@ exports[`Navigation > render with basic content 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_primary__1m2xqlz1"
@@ -6322,7 +6305,7 @@ exports[`Navigation > render with basic content 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -6339,15 +6322,15 @@ exports[`Navigation > render with basic content 1`] = `
                       tabindex="0"
                     >
                       <div
-                        class="emotion-46 emotion-195"
+                        class="emotion-43 emotion-184"
                       >
                         <div
                           aria-label="pin"
-                          class="emotion-48 emotion-197"
+                          class="emotion-45 emotion-186"
                           role="button"
                         >
                           <svg
-                            class="emotion-50 emotion-193 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                            class="emotion-47 emotion-182 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                             viewBox="0 0 20 20"
                           >
                             <path
@@ -6364,7 +6347,7 @@ exports[`Navigation > render with basic content 1`] = `
             </div>
           </div>
           <div
-            class="emotion-52 emotion-53"
+            class="emotion-49 emotion-50"
             data-has-overflow-style="false"
           >
             <div
@@ -6394,7 +6377,7 @@ exports[`Navigation > render with basic content 1`] = `
         </div>
       </div>
       <div
-        class="emotion-54 emotion-55"
+        class="emotion-51 emotion-52"
         data-testid="slider"
       />
     </nav>
@@ -6598,9 +6581,9 @@ exports[`Navigation > render without pinnedFeature 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -6609,7 +6592,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
 }
 
 .emotion-20[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-20:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -6618,66 +6601,66 @@ exports[`Navigation > render without pinnedFeature 1`] = `
 .emotion-20:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-20[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-20[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-25 {
-  color: #3f4250;
+    ) .emotion-24 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-20[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .e134hokc17 {
+    ) .e134hokc16 {
   opacity: 1;
 }
 
 .emotion-20[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc10 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc17,
-.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc17,
-.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc17,
-.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc11,
-.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc11,
-.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc11 {
-  opacity: 1;
-}
-
+.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc16,
+.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc16,
+.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc16,
 .emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc10,
 .emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc10,
 .emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc10 {
+  opacity: 1;
+}
+
+.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-20[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-20:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-25 {
-  color: #3f4250;
+.emotion-20:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-24 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-20:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-20[data-is-active="true"],
 .emotion-20:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-20[data-is-active="true"]:hover,
 .emotion-20:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-20[disabled] {
@@ -6685,8 +6668,8 @@ exports[`Navigation > render without pinnedFeature 1`] = `
   background-color: unset;
 }
 
-.emotion-20[disabled] .emotion-25 {
-  color: #b5b7bd;
+.emotion-20[disabled] .emotion-24 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-20[data-animation="collapse"][data-animation-type="complex"] {
@@ -6694,9 +6677,9 @@ exports[`Navigation > render without pinnedFeature 1`] = `
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-20[data-animation="collapse"][data-animation-type="complex"] .emotion-25,
-.emotion-20[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-20[data-animation="collapse"][data-animation-type="complex"] .e134hokc10 {
+.emotion-20[data-animation="collapse"][data-animation-type="complex"] .emotion-24,
+.emotion-20[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-20[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
@@ -6706,22 +6689,22 @@ exports[`Navigation > render without pinnedFeature 1`] = `
   animation: animation-1 250ms ease-in-out reverse;
 }
 
-.emotion-20[data-animation="expand"][data-animation-type="complex"] .emotion-25,
-.emotion-20[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-20[data-animation="expand"][data-animation-type="complex"] .e134hokc10 {
+.emotion-20[data-animation="expand"][data-animation-type="complex"] .emotion-24,
+.emotion-20[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-20[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-20[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-20[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
-.emotion-22 {
+.emotion-21 {
   min-width: 20px;
 }
 
-.emotion-24 {
+.emotion-23 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -6729,7 +6712,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-32 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6749,12 +6732,12 @@ exports[`Navigation > render without pinnedFeature 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-32[data-has-overflow-style="false"] {
+.emotion-30[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-34 {
+.emotion-32 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -6769,7 +6752,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
   display: flex;
 }
 
-.emotion-34:hover {
+.emotion-32:hover {
   border-color: #8c40ef;
 }
 
@@ -6822,7 +6805,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                   Products
                 </span>
                 <button
-                  class="emotion-20 emotion-21"
+                  class="emotion-20 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -6831,7 +6814,6 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                   data-is-active="true"
                   data-is-pinnable="false"
                   data-pinned-feature="false"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -6839,7 +6821,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-22 emotion-23 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-21 emotion-22 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_neutral__1m2xqlz3"
@@ -6875,7 +6857,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-24 emotion-25 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
+                        class="emotion-23 emotion-24 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -6887,7 +6869,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                   />
                 </button>
                 <button
-                  class="emotion-20 emotion-21"
+                  class="emotion-20 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -6895,7 +6877,6 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                   data-has-sub-label="false"
                   data-is-pinnable="false"
                   data-pinned-feature="false"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -6903,7 +6884,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-22 emotion-23 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-21 emotion-22 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_primary__1m2xqlz1"
@@ -6939,7 +6920,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-24 emotion-25 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                        class="emotion-23 emotion-24 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -6954,7 +6935,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
             </div>
           </div>
           <div
-            class="emotion-32 emotion-33"
+            class="emotion-30 emotion-31"
             data-has-overflow-style="false"
           >
             <div
@@ -6984,7 +6965,7 @@ exports[`Navigation > render without pinnedFeature 1`] = `
         </div>
       </div>
       <div
-        class="emotion-34 emotion-35"
+        class="emotion-32 emotion-33"
         data-testid="slider"
       />
     </nav>
@@ -7323,9 +7304,9 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -7334,7 +7315,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -7343,66 +7324,66 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -7410,8 +7391,8 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -7419,9 +7400,9 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -7431,14 +7412,14 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
@@ -7449,9 +7430,9 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   background-color: inherit;
   border: none;
   text-align: left;
-  border-radius: 0.25rem;
-  margin-top: 0.125rem;
-  padding: calc(0.125rem + 0.25rem) 0.5rem;
+  border-radius: var(--rwwhsl85);
+  margin-top: var(--rwwhsla5);
+  padding: calc(var(--rwwhsla5) + var(--rwwhsla4)) var(--rwwhsl9u);
   width: 100%;
 }
 
@@ -7460,7 +7441,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
 }
 
 .emotion-12[data-has-sub-label="true"] {
-  padding: 0.25rem 0.5rem;
+  padding: var(--rwwhsla4) var(--rwwhsl9u);
 }
 
 .emotion-12:hover[data-has-no-expand="false"]:not([disabled]):not(
@@ -7469,66 +7450,66 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
 .emotion-12:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #f9f9fa;
+  background-color: var(--rwwhsl1r);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-17 {
-  color: #3f4250;
+    ) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    ) .emotion-197 {
+    ) .emotion-186 {
   opacity: 1;
 }
 
 .emotion-12[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
-    )[data-is-pinnable="true"][data-pinned-feature="true"] .emotion-190 {
+    )[data-is-pinnable="true"][data-pinned-feature="true"] .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-197,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-191,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-191 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-186,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-180,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-180 {
   opacity: 1;
 }
 
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .emotion-190,
-.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .emotion-190 {
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):hover .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):focus .e134hokc9,
+.emotion-12[data-has-no-expand="false"][data-pinned-feature="true"][data-is-pinnable="true"]:not([disabled]):active .e134hokc9 {
   opacity: 0;
 }
 
-.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-17 {
-  color: #3f4250;
+.emotion-12:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) .emotion-16 {
+  color: var(--rwwhsl2u);
 }
 
 .emotion-12:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-  background-color: #e9eaeb;
+  background-color: var(--rwwhsl1k);
 }
 
 .emotion-12[data-is-active="true"],
 .emotion-12:hover[data-has-active="true"] {
-  background-color: #f1eefc;
+  background-color: var(--rwwhsl5g);
 }
 
 .emotion-12[data-is-active="true"]:hover,
 .emotion-12:hover[data-has-active="true"]:hover {
-  background-color: #e5dbfd;
+  background-color: var(--rwwhsl5i);
 }
 
 .emotion-12[disabled] {
@@ -7536,8 +7517,8 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   background-color: unset;
 }
 
-.emotion-12[disabled] .emotion-17 {
-  color: #b5b7bd;
+.emotion-12[disabled] .emotion-16 {
+  color: var(--rwwhsl2t);
 }
 
 .emotion-12[data-animation="collapse"][data-animation-type="complex"] {
@@ -7545,9 +7526,9 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   animation: animation-0 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="collapse"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out reverse;
   animation: animation-1 250ms ease-in-out reverse;
 }
@@ -7557,26 +7538,26 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   animation: animation-0 250ms ease-in-out reverse;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-17,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc6,
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-190 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .emotion-16,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc5,
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc9 {
   -webkit-animation: animation-1 250ms ease-in-out;
   animation: animation-1 250ms ease-in-out;
 }
 
-.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc4 {
+.emotion-12[data-animation="expand"][data-animation-type="complex"] .e134hokc3 {
   display: none;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-14 {
+.emotion-13 {
   min-width: 20px;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -7584,7 +7565,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-16 {
+.emotion-15 {
   overflow-wrap: anywhere;
   overflow: hidden;
   display: -webkit-box;
@@ -7592,41 +7573,41 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   -webkit-line-clamp: 2;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-18 {
+.emotion-17 {
   padding-top: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   padding: 0.5rem 0;
 }
 
-.emotion-20[data-expanded='true'] {
+.emotion-19[data-expanded='true'] {
   padding-left: 2rem;
   margin-left: 0.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   padding: 0.5rem 0;
 }
 
-.emotion-20[data-expanded='true'] {
+.emotion-19[data-expanded='true'] {
   padding-left: 2rem;
   margin-left: 0.25rem;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: relative;
 }
 
-.emotion-22 {
+.emotion-21 {
   position: relative;
 }
 
-.emotion-24 {
+.emotion-23 {
   position: absolute;
   right: 0;
   left: 0;
@@ -7637,7 +7618,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-24::before {
+.emotion-23::before {
   content: '';
   position: absolute;
   left: 0;
@@ -7649,7 +7630,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   border-radius: 100%;
 }
 
-.emotion-24 {
+.emotion-23 {
   position: absolute;
   right: 0;
   left: 0;
@@ -7660,7 +7641,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   padding: 0.25rem 0;
 }
 
-.emotion-24::before {
+.emotion-23::before {
   content: '';
   position: absolute;
   left: 0;
@@ -7672,43 +7653,43 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   border-radius: 100%;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin: 1rem -1rem;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin: 1rem -1rem;
 }
 
-.emotion-28[data-animation='expand'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='expand'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-28[data-animation='collapse'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='collapse'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-28[data-animation='expand'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='expand'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out;
   animation: animation-2 250ms ease-in-out;
 }
 
-.emotion-28[data-animation='collapse'][data-animation-type="complex"] .emotion-33 {
+.emotion-27[data-animation='collapse'][data-animation-type="complex"] .emotion-32 {
   -webkit-animation: animation-2 250ms ease-in-out reverse;
   animation: animation-2 250ms ease-in-out reverse;
 }
 
-.emotion-30 {
+.emotion-29 {
   padding-top: 0.5rem;
 }
 
-.emotion-30 {
+.emotion-29 {
   padding-top: 0.5rem;
 }
 
-.emotion-32 {
+.emotion-31 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -7716,7 +7697,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-32 {
+.emotion-31 {
   padding-bottom: 0.5rem;
   padding-left: 0.5rem;
   -webkit-transition: opacity 250ms ease-in-out,height 250ms ease-in-out;
@@ -7724,15 +7705,15 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   height: calc(1.25rem + 0.5rem);
 }
 
-.emotion-46 {
+.emotion-43 {
   position: relative;
 }
 
-.emotion-46 {
+.emotion-43 {
   position: relative;
 }
 
-.emotion-48 {
+.emotion-45 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -7742,13 +7723,13 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   margin: auto;
 }
 
-.emotion-48:hover,
-.emotion-48:focus,
-.emotion-48:active {
+.emotion-45:hover,
+.emotion-45:focus,
+.emotion-45:active {
   opacity: 1;
 }
 
-.emotion-48 {
+.emotion-45 {
   opacity: 0;
   right: 0;
   position: absolute;
@@ -7758,13 +7739,13 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   margin: auto;
 }
 
-.emotion-48:hover,
-.emotion-48:focus,
-.emotion-48:active {
+.emotion-45:hover,
+.emotion-45:focus,
+.emotion-45:active {
   opacity: 1;
 }
 
-.emotion-50 {
+.emotion-47 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -7773,11 +7754,11 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-50:hover {
+.emotion-47:hover {
   background: #e9eaeb;
 }
 
-.emotion-50 {
+.emotion-47 {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -7786,11 +7767,11 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   border-radius: 0.25rem;
 }
 
-.emotion-50:hover {
+.emotion-47:hover {
   background: #e9eaeb;
 }
 
-.emotion-52 {
+.emotion-49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7810,12 +7791,12 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-52[data-has-overflow-style="false"] {
+.emotion-49[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-52 {
+.emotion-49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7835,12 +7816,12 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   justify-content: flex-end;
 }
 
-.emotion-52[data-has-overflow-style="false"] {
+.emotion-49[data-has-overflow-style="false"] {
   box-shadow: none;
   border: none;
 }
 
-.emotion-54 {
+.emotion-51 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -7855,11 +7836,11 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   display: flex;
 }
 
-.emotion-54:hover {
+.emotion-51:hover {
   border-color: #8c40ef;
 }
 
-.emotion-54 {
+.emotion-51 {
   background: transparent;
   position: absolute;
   top: 0;
@@ -7874,7 +7855,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
   display: flex;
 }
 
-.emotion-54:hover {
+.emotion-51:hover {
   border-color: #8c40ef;
 }
 
@@ -7910,7 +7891,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
           >
             <div>
               <button
-                class="emotion-12 emotion-13"
+                class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                 data-animation="false"
                 data-has-active-children="false"
                 data-has-children="true"
@@ -7919,7 +7900,6 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                 data-is-pinnable="false"
                 data-pinned-feature="true"
                 data-testid="pinned-group"
-                direction="row"
                 draggable="false"
                 id="pinned-group"
               >
@@ -7927,7 +7907,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                   class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                 >
                   <div
-                    class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                    class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                   >
                     <svg
                       class="style_neutral__1m2xqlz3"
@@ -7957,7 +7937,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                     class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                   >
                     <span
-                      class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                      class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                       style="--uv_qabug41: pre-wrap;"
                     >
                       Pinned items
@@ -7968,7 +7948,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                   class="uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-18 emotion-19 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
+                    class="emotion-17 emotion-18 uv_toi52u0 uv_toi52u3d uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5d"
                   >
                     <svg
                       class="styles__1sbwqkz0 styles_prominence_weak__1sbwqkzj styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_small__1sbwqkza styles_undefined_compound_23__1sbwqkz17"
@@ -7988,7 +7968,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                   class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                 >
                   <div
-                    class="emotion-20 emotion-21"
+                    class="emotion-19 emotion-20"
                     data-expanded="true"
                   >
                     <p
@@ -7998,10 +7978,10 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                     </p>
                   </div>
                   <div
-                    class="emotion-22 emotion-23"
+                    class="emotion-21 emotion-22"
                   >
                     <div
-                      class="emotion-24 emotion-25"
+                      class="emotion-23 emotion-24"
                     />
                   </div>
                 </div>
@@ -8009,24 +7989,24 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
             </div>
             <hr
               aria-orientation="horizontal"
-              class="emotion-26 emotion-27 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
+              class="emotion-25 emotion-26 uv_bu43fbb uv_bu43fbc uv_bu43fbi"
               role="separator"
               style="--uv_bu43fb0: 1px;"
             />
             <div
-              class="emotion-28 emotion-29"
+              class="emotion-27 emotion-28"
               data-animation="false"
             >
               <div
-                class="emotion-30 emotion-31 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
+                class="emotion-29 emotion-30 uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
               >
                 <span
-                  class="emotion-32 emotion-33 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
+                  class="emotion-31 emotion-32 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owl uv_m4c9owo uv_m4c9ow1b uv_m4c9ow23 uv_m4c9ow3f"
                 >
                   Products
                 </span>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -8035,7 +8015,6 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                   data-is-active="true"
                   data-is-pinnable="false"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -8043,7 +8022,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_neutral__1m2xqlz3"
@@ -8079,7 +8058,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9ow9 uv_m4c9owi uv_m4c9owo uv_m4c9ow1b uv_m4c9ow1c uv_m4c9ow3c"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -8091,7 +8070,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                   />
                 </button>
                 <button
-                  class="emotion-12 emotion-13"
+                  class="emotion-12 uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u6p"
                   data-animation="false"
                   data-has-active-children="false"
                   data-has-children="false"
@@ -8099,7 +8078,6 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                   data-has-sub-label="false"
                   data-is-pinnable="true"
                   data-pinned-feature="true"
-                  direction="row"
                   draggable="false"
                   id="item1"
                 >
@@ -8107,7 +8085,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                     class="uv_toi52u0 uv_toi52u3v uv_toi52u2j uv_toi52u7d uv_toi52u7 uv_toi52u5j"
                   >
                     <div
-                      class="emotion-14 emotion-15 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
+                      class="emotion-13 emotion-14 uv_toi52u0 uv_toi52u3d uv_toi52u2d uv_toi52u7d uv_toi52u5j"
                     >
                       <svg
                         class="style_primary__1m2xqlz1"
@@ -8143,7 +8121,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                       class="uv_toi52u0 uv_toi52u31 uv_toi52u2d uv_toi52u7d uv_toi52u5d"
                     >
                       <span
-                        class="emotion-16 emotion-17 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
+                        class="emotion-15 emotion-16 uv_m4c9ow0 uv_m4c9ow2 uv_m4c9ow4 uv_m4c9ow6 uv_m4c9ow8 uv_m4c9owb uv_m4c9owj uv_m4c9owo uv_m4c9ow1b uv_m4c9ow21 uv_m4c9ow3d"
                         style="--uv_qabug41: pre-wrap;"
                       >
                         item1
@@ -8160,15 +8138,15 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
                       tabindex="0"
                     >
                       <div
-                        class="emotion-46 emotion-195"
+                        class="emotion-43 emotion-184"
                       >
                         <div
                           aria-label="pin"
-                          class="emotion-48 emotion-197"
+                          class="emotion-45 emotion-186"
                           role="button"
                         >
                           <svg
-                            class="emotion-50 emotion-193 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
+                            class="emotion-47 emotion-182 styles__1sbwqkz0 styles_prominence_default__1sbwqkzg styles_disabled_false__1sbwqkzf styles_sentiment_neutral__1sbwqkz3 styles_size_medium__1sbwqkz9 styles_undefined_compound_2__1sbwqkzm"
                             viewBox="0 0 20 20"
                           >
                             <path
@@ -8185,7 +8163,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
             </div>
           </div>
           <div
-            class="emotion-52 emotion-53"
+            class="emotion-49 emotion-50"
             data-has-overflow-style="false"
           >
             <div
@@ -8215,7 +8193,7 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
         </div>
       </div>
       <div
-        class="emotion-54 emotion-55"
+        class="emotion-51 emotion-52"
         data-testid="slider"
       />
     </nav>

--- a/packages/plus/src/components/Navigation/components/Item.tsx
+++ b/packages/plus/src/components/Navigation/components/Item.tsx
@@ -11,6 +11,7 @@ import {
   UnpinIcon,
 } from '@ultraviolet/icons'
 import { OrganizationDashboardCategoryIcon } from '@ultraviolet/icons/category'
+import { theme as vanillaTheme } from '@ultraviolet/themes'
 import {
   Badge,
   Button,
@@ -24,7 +25,7 @@ import {
 import type {
   ComponentProps,
   DragEvent,
-  JSX,
+  ElementType,
   MouseEvent,
   ReactNode,
 } from 'react'
@@ -148,19 +149,18 @@ const StyledStack = styled(Stack)`
   padding-left: 28px; // This value needs to be hardcoded because of the category icon size
 `
 
-const StyledContainer = styled(Stack)`
+const StyledContainer = css`
   ${NeutralButtonLink};
-  border-radius: ${({ theme }) => theme.radii.default};
+  border-radius: ${vanillaTheme.radii.default};
 
   &[data-has-no-expand="false"] {
     cursor: pointer;
   }
-  margin-top: ${({ theme }) => theme.space['0.25']};
-  padding: ${({ theme }) =>
-    `calc(${theme.space['0.25']} + ${theme.space['0.5']}) ${theme.space['1']}`};
+  margin-top: ${vanillaTheme.space['0.25']};
+  padding: ${`calc(${vanillaTheme.space['0.25']} + ${vanillaTheme.space['0.5']}) ${vanillaTheme.space['1']}`};
 
   &[data-has-sub-label="true"] {
-    padding: ${({ theme }) => `${theme.space['0.5']} ${theme.space['1']}`};
+    padding: ${`${vanillaTheme.space['0.5']} ${vanillaTheme.space['1']}`};
   }
 
   width: 100%;
@@ -171,14 +171,14 @@ const StyledContainer = styled(Stack)`
   &:focus[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-    background-color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
+    background-color: ${vanillaTheme.colors.neutral.backgroundWeak};
   }
   &[data-has-active-children="true"][data-has-no-expand="false"]:not(
       [disabled][data-is-active="true"]
     ) {
-    background-color: ${({ theme }) => theme.colors.neutral.backgroundWeakHover};
+    background-color: ${vanillaTheme.colors.neutral.backgroundWeakHover};
     ${WrapText} {
-      color: ${({ theme }) => theme.colors.neutral.textWeakHover};
+      color: ${vanillaTheme.colors.neutral.textWeakHover};
     }
 
     ${PinnedButton} {
@@ -208,22 +208,22 @@ const StyledContainer = styled(Stack)`
 
   &:hover[data-has-children="false"][data-is-active="false"][data-is-pinnable="true"]:not([disabled]) {
     ${WrapText} {
-      color: ${({ theme }) => theme.colors.neutral.textWeakHover};
+      color: ${vanillaTheme.colors.neutral.textWeakHover};
     }
   }
 
   &:active[data-has-no-expand="false"]:not([disabled]):not(
       [data-is-active="true"]
     ) {
-    background-color: ${({ theme }) => theme.colors.neutral.backgroundHover};
+    background-color: ${vanillaTheme.colors.neutral.backgroundHover};
   }
 
   &[data-is-active="true"],
   &:hover[data-has-active="true"] {
-    background-color: ${({ theme }) => theme.colors.primary.background};
+    background-color: ${vanillaTheme.colors.primary.background};
 
     &:hover {
-      background-color: ${({ theme }) => theme.colors.primary.backgroundHover};
+      background-color: ${vanillaTheme.colors.primary.backgroundHover};
     }
   }
 
@@ -232,7 +232,7 @@ const StyledContainer = styled(Stack)`
     background-color: unset;
 
     ${WrapText} {
-      color: ${({ theme }) => theme.colors.neutral.textWeakDisabled};
+      color: ${vanillaTheme.colors.neutral.textWeakDisabled};
     }
   }
 
@@ -342,7 +342,7 @@ type ItemProps = {
    * a non focusable element. This option allows you to choose the tag of the
    * item.
    */
-  as?: keyof JSX.IntrinsicElements
+  as?: ElementType
   /**
    * Use this prop if you want to remove the expand behavior when the item
    * has sub items.
@@ -483,11 +483,6 @@ export const Item = memo(
       return 'button'
     }, [as, hasHrefAndNoChildren, noExpand])
 
-    const Container = useMemo(
-      () => StyledContainer.withComponent(containerTag),
-      [containerTag],
-    )
-
     const ArrowIcon = useMemo(
       () => (internalExpanded ? ArrowDownIcon : ArrowRightIcon),
       [internalExpanded],
@@ -549,9 +544,11 @@ export const Item = memo(
     if (expanded || (!expanded && animation === 'expand')) {
       return (
         <>
-          <Container
+          <Stack
             alignItems={categoryIcon ? 'flex-start' : 'center'}
             aria-expanded={ariaExpanded}
+            as={containerTag}
+            css={StyledContainer}
             data-animation={shouldAnimate ? animation : undefined}
             data-animation-type={animationType}
             data-has-active-children={hasActiveChildren}
@@ -563,7 +560,7 @@ export const Item = memo(
             data-pinned-feature={pinnedFeature}
             data-testid={dataTestId}
             direction="row"
-            disabled={disabled}
+            disabled={containerTag === 'button' ? disabled : undefined}
             draggable={type === 'pinned' && expanded}
             gap={1}
             href={href}
@@ -713,7 +710,7 @@ export const Item = memo(
                 </StackIcon>
               ) : null}
             </Stack>
-          </Container>
+          </Stack>
           {children ? (
             <>
               {!noExpand ? (
@@ -901,8 +898,10 @@ export const Item = memo(
       return (
         <Tooltip placement="right" text={label}>
           <MenuStack alignItems="start" gap={1} justifyContent="start">
-            <Container
+            <Stack
               alignItems="center"
+              as={containerTag}
+              css={StyledContainer}
               gap={1}
               href={href}
               justifyContent="center"
@@ -910,7 +909,7 @@ export const Item = memo(
               target={target}
             >
               <AnimatedIcon prominence="weak" sentiment="neutral" />
-            </Container>
+            </Stack>
           </MenuStack>
         </Tooltip>
       )

--- a/packages/ui/src/components/ExpandableCard/index.tsx
+++ b/packages/ui/src/components/ExpandableCard/index.tsx
@@ -30,7 +30,7 @@ const DropableArea = styled.div`
   &[data-first="true"] {
     top: -${({ theme }) => theme.space['3']};
   }
-  
+
   &::after {
     content: '';
     left: 0;
@@ -263,7 +263,7 @@ const BaseExpandableCard = forwardRef(
             data-testid={`draggable-icon-${value}`}
             data-visible={isHovered}
             justifyContent="center"
-            onKeyDown={event => {
+            onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
               if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault()
                 if (clicking && containerRef.current) {

--- a/packages/ui/src/components/Stack/types.ts
+++ b/packages/ui/src/components/Stack/types.ts
@@ -1,0 +1,16 @@
+import type {
+  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
+  ElementType,
+} from 'react'
+
+type MainProps<E extends ElementType> = {
+  as?: E
+  ref?: ComponentPropsWithRef<E>['ref']
+}
+
+type PropsToOmit<E extends ElementType, P> = keyof (MainProps<E> & P)
+
+export type PolymorphicComponentProps<E extends ElementType, P> = P &
+  MainProps<E> &
+  Omit<ComponentPropsWithoutRef<E>, PropsToOmit<E, P>>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Navigation needs to use polymorphic component such as Stack in order to provide a more accurate tag in it's content.
With the migration of vanilla extract it is now hard to achieve that, so I added a prop `as` only for this component.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="950" height="811" alt="Screenshot 2025-09-16 at 16 17 00" src="https://github.com/user-attachments/assets/45e2b504-c55c-4ebe-aa53-1588a1f86815" /> | <img width="955" height="812" alt="Screenshot 2025-09-16 at 16 17 05" src="https://github.com/user-attachments/assets/9d721c58-d8e3-4a89-9d9a-ab4a1234478d" /> |
