### PR TITLE
fix: sideEffects config

### DIFF
--- a/.changeset/short-chefs-smell.md
+++ b/.changeset/short-chefs-smell.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix sideEffects configuration to avoid a tree shaking error in some components (Navigation, EstimateCost, Filters)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,8 @@
   "type": "module",
   "sideEffects": [
     "**/*.css",
-    "**/*.css.ts"
+    "**/*.css.ts",
+    "**/compositions/*/index.js"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

(Description of the new behavior)

#### The following changes were made:

- add compositions components to sideEffects because they can have an import from a `_virtual_` folder that must be kept during bundling

