### PR TITLE
chore: correctly group all @testing-library packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,8 +16,6 @@
     "**/__fixtures__/**"
   ],
   "prConcurrentLimit": 5,
-  "reviewers": ["team:console"],
-  "reviewersSampleSize": 2,
   "labels": ["dependencies"],
   "packageRules": [
     {
@@ -41,10 +39,11 @@
     {
       "extends": ["packages:jsUnitTest"],
       "matchPackageNames": ["happy-dom", "jsdom"],
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": ["devDependencies", "dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "non-major tests devDependencies",
-      "groupSlug": "non-major-tests-dev-deps"
+      "groupName": "non-major tests dependencies",
+      "groupSlug": "non-major-tests-deps",
+      "semanticCommitScope": "devdeps"
     },
     {
       "matchPackageNames": ["/storybook/"],
@@ -73,10 +72,6 @@
       "matchPackageNames": ["/^@uiw//"],
       "groupName": "CodeMirror",
       "groupSlug": "codemirror"
-    },
-    {
-      "matchPackageNames": ["/^@testing-library/"],
-      "semanticCommitScope": "devDeps"
     },
     {
       "matchPackageNames": ["/prosemirror/"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,16 @@
       "groupSlug": "non-major-dev-deps"
     },
     {
+      "matchDepTypes": ["dependencies"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchDepTypes": ["packageManager", "devDependencies"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "devDeps"
+    },
+    {
       "extends": ["packages:linters"],
       "matchPackageNames": ["/oxfmt/", "/oxlint/", "publint", "lint-staged"],
       "matchDepTypes": ["devDependencies"],
@@ -50,17 +60,7 @@
       "groupName": "storybook"
     },
     {
-      "matchDepTypes": ["dependencies"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps"
-    },
-    {
       "matchManagers": ["dockerfile", "github-actions"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "devDeps"
-    },
-    {
-      "matchDepTypes": ["packageManager", "devDependencies"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "devDeps"
     },


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

We had two rules for @testing-library packages:
- one that extends `packages:jsUnitTest` and match all `devDependencies` of test libs
- on that enforced a `devDeps` scope on the testing-library packages, which are used as `dependencies` in the package `utils/test`

Since the testing-library packages are declared as `dependencies` in the package `utils/test`, they didn't match the first rule in the config, which triggers 2 distinct PRs for testing-library (see [one here](https://github.com/scaleway/ultraviolet/pull/6796)). These PRs always fail the CI because there is a mismatch in libs versions in the monorepo.

#### What is expected?

All testing-library updates are grouped in the same PR

#### The following changes were made:

- extend the first rule to include the `dependencies` and force a `devDeps` scope to include the testing-library from utils/test
- remove the second rule

This change assumes that no other test lib is a `dependency`, or that we accept that all test libs are marked as `devDeps`