### PR TITLE
docs: fix Ultraviolet logo on Storybook and improve readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-![](.storybook/assets/logo-dark.png#gh-dark-mode-only)
-![](.storybook/assets/logo-light.png#gh-light-mode-only)
-
-![Codecov](https://img.shields.io/codecov/c/github/scaleway/ultraviolet)
-![GitHub last commit](https://img.shields.io/github/last-commit/scaleway/ultraviolet)
-![GitHub closed issues](https://img.shields.io/github/issues-closed/scaleway/ultraviolet)
-![GitHub contributors](https://img.shields.io/github/contributors/scaleway/ultraviolet)
-![GitHub commit activity](https://img.shields.io/github/commit-activity/m/scaleway/ultraviolet)
-![GitHub](https://img.shields.io/github/license/scaleway/ultraviolet)
+<p align="center">
+  <img src=".storybook/assets/logo-dark.png#gh-dark-mode-only" width="400" alt="Ultraviolet logo" />
+  <img src=".storybook/assets/logo-light.png#gh-light-mode-only" width="400" alt="Ultraviolet logo" />
+  <br />
+  <img src="https://img.shields.io/codecov/c/github/scaleway/ultraviolet" alt="Codecov" style="margin: 2px"/>
+  <img src="https://img.shields.io/github/last-commit/scaleway/ultraviolet" alt="GitHub last commit" style="margin: 2px"/>
+  <img src="https://img.shields.io/github/issues-closed/scaleway/ultraviolet" alt="GitHub closed issues" style="margin: 2px"/>
+  <img src="https://img.shields.io/github/contributors/scaleway/ultraviolet" alt="GitHub contributors" style="margin: 2px"/>
+  <img src="https://img.shields.io/github/commit-activity/m/scaleway/ultraviolet" alt="GitHub commit activity" style="margin: 2px"/>
+  <img src="https://img.shields.io/github/license/scaleway/ultraviolet" alt="GitHub" style="margin: 2px"/>
+</p>
 
 # Ultraviolet Core
 

--- a/utils/stories/src/GetStarted.mdx
+++ b/utils/stories/src/GetStarted.mdx
@@ -1,6 +1,9 @@
 import { Markdown, Meta } from '@storybook/addon-docs/blocks'
 import Readme from '../../../README.md?raw'
+import logoLight from '../../../.storybook/assets/logo-light.png'
 
 <Meta title="Get started" />
 
-<Markdown>{Readme}</Markdown>
+<Markdown>
+  {Readme.replace('.storybook/assets/logo-light.png', logoLight).replace(/<img[^>]+logo-dark[^>]+\/>/, '')}
+</Markdown>


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarize concisely:

We displayed the readme in Storybook using a link that only works on GitHub. I fixed it and resized the logo to be a bit less huge

#### What is expected?

readme header looks good on github and Storybook


## Relevant logs and/or screenshots

- [Storybook](https://ultravioletjxvhzygy-readmelogostorybook.functions.fnc.fr-par.scw.cloud/?path=/docs/get-started--docs)
- [GitHub](https://github.com/scaleway/ultraviolet/tree/readme-logo)

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| storybook  | <img width="1477" height="494" alt="image" src="https://github.com/user-attachments/assets/09925db2-88c4-4d0a-88f3-76e36416dfbb" /> | <img width="1477" height="414" alt="image" src="https://github.com/user-attachments/assets/a33695a7-00ff-4296-8792-670937ed1306" /> |
| github  | <img width="1872" height="867" alt="image" src="https://github.com/user-attachments/assets/f1606496-0e2d-4a0b-9ca9-71f4722142c8" /> | <img width="927" height="319" alt="image" src="https://github.com/user-attachments/assets/94dd852d-ca8a-4b74-8c54-ca41bbea3c75" /> |
