### PR TITLE
fix: remove vanilla-extract types exports

### DIFF
--- a/.changeset/pink-snakes-wave.md
+++ b/.changeset/pink-snakes-wave.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Badge`, `Banner`, `Button` & `Separator`: define props directly instead of inferring from vanilla-extract recipes
+
+`Text`, `Alert`: remove unused vanilla-extract type export

--- a/packages/ui/src/components/Alert/styles.css.ts
+++ b/packages/ui/src/components/Alert/styles.css.ts
@@ -1,7 +1,6 @@
 import { theme } from '@ultraviolet/themes'
 import { style, styleVariants } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
 import type { AlertSentiment } from './type'
 
 function createStyleAlert(sentiment: AlertSentiment) {
@@ -65,8 +64,6 @@ const button = styleVariants({
 const buttonClose = style({
   alignSelf: 'flex-start',
 })
-
-export type AlertVariants = NonNullable<RecipeVariants<typeof alert>>
 
 const icon = style({
   marginTop: theme.space['0.25'],

--- a/packages/ui/src/components/Badge/index.tsx
+++ b/packages/ui/src/components/Badge/index.tsx
@@ -6,14 +6,17 @@ import type { CSSProperties, ReactNode } from 'react'
 import { Text } from '../Text'
 import { TEXT_VARIANT } from './constant'
 import { badgeStyle } from './styles.css'
-import type { BadgeVariants } from './styles.css'
 
 type BadgeProps = {
+  disabled?: boolean
+  prominence?: 'default' | 'strong'
+  sentiment?: 'danger' | 'info' | 'success' | 'warning' | 'neutral' | 'black' | 'white' | 'primary' | 'secondary'
+  size?: 'medium' | 'small' | 'large' | 'xsmall'
   className?: string
   children: ReactNode
   'data-testid'?: string
   style?: CSSProperties
-} & BadgeVariants
+}
 
 /**
  * Badge component is used to display a status or a label in a small container.

--- a/packages/ui/src/components/Badge/styles.css.ts
+++ b/packages/ui/src/components/Badge/styles.css.ts
@@ -1,6 +1,5 @@
 import { theme } from '@ultraviolet/themes'
 import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
 import { SIZES } from './constant'
 
 const sentiments = ['primary', 'secondary', 'danger', 'info', 'success', 'warning', 'neutral'] as const
@@ -120,5 +119,4 @@ const badge = recipe({
   },
 })
 
-export type BadgeVariants = NonNullable<RecipeVariants<typeof badge>>
 export const badgeStyle = { badge }

--- a/packages/ui/src/components/Banner/index.tsx
+++ b/packages/ui/src/components/Banner/index.tsx
@@ -12,7 +12,6 @@ import { Text } from '../Text'
 import defaultIllustrationSmall from './assets/default-image-small.svg'
 import defaultIllustration from './assets/default-image.svg'
 import { bannerStyle } from './styles.css'
-import type { BannerVariants } from './styles.css'
 
 type BannerProps = {
   title: string
@@ -32,7 +31,9 @@ type BannerProps = {
   className?: string
   'data-testid'?: string
   style?: CSSProperties
-} & BannerVariants
+  size?: 'small' | 'medium'
+  variant?: 'intro' | 'promotional'
+}
 
 /**
  * Banner component is used to display an informative message to the user with style.

--- a/packages/ui/src/components/Banner/styles.css.ts
+++ b/packages/ui/src/components/Banner/styles.css.ts
@@ -1,7 +1,6 @@
 import { theme } from '@ultraviolet/themes'
 import { style, styleVariants } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
 
 const banner = recipe({
   base: {
@@ -84,7 +83,6 @@ const closeButton = style({
   },
 })
 
-export type BannerVariants = NonNullable<RecipeVariants<typeof banner>>
 export const bannerStyle = {
   banner,
   imageStack,

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -8,7 +8,6 @@ import type { AriaRole, ButtonHTMLAttributes, CSSProperties, MouseEventHandler, 
 import { Loader } from '../Loader'
 import { Tooltip } from '../Tooltip'
 import { buttonStyle } from './styles.css'
-import type { ButtonVariants } from './styles.css'
 
 type CommonProps = {
   type?: ButtonHTMLAttributes<HTMLButtonElement>['type']
@@ -44,7 +43,12 @@ type CommonProps = {
   onPointerDown?: ButtonHTMLAttributes<HTMLButtonElement>['onPointerDown']
   onKeyDown?: ButtonHTMLAttributes<HTMLButtonElement>['onKeyDown']
   style?: CSSProperties
-} & ButtonVariants
+  disabled?: boolean
+  fullWidth?: boolean
+  sentiment?: 'danger' | 'info' | 'neutral' | 'primary' | 'secondary' | 'success' | 'warning' | 'black' | 'white'
+  size?: 'small' | 'medium' | 'large' | 'xsmall'
+  variant?: 'filled' | 'outlined' | 'ghost'
+}
 
 type BaseButtonProps = CommonProps & {
   children: ReactNode

--- a/packages/ui/src/components/Button/styles.css.ts
+++ b/packages/ui/src/components/Button/styles.css.ts
@@ -1,6 +1,5 @@
 import { theme } from '@ultraviolet/themes'
 import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
 import { SIZE_GAP_KEY, SIZE_HEIGHT, SIZE_PADDING_KEY } from './constants'
 
 const { monochrome } = theme.colors.other
@@ -378,7 +377,5 @@ const button = recipe({
     },
   },
 })
-
-export type ButtonVariants = NonNullable<RecipeVariants<typeof button>>
 
 export const buttonStyle = { button }

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -4,9 +4,10 @@ import { cn } from '@ultraviolet/utils'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import type { CSSProperties, ReactNode } from 'react'
 import { separatorStyle, thicknessSeparator } from './styles.css'
-import type { SeparatorVariants } from './styles.css'
 
 type SeparatorProps = {
+  direction?: 'horizontal' | 'vertical'
+  sentiment?: 'danger' | 'info' | 'neutral' | 'primary' | 'secondary' | 'success' | 'warning'
   thickness?: number
   className?: string
   'data-testid'?: string
@@ -16,7 +17,7 @@ type SeparatorProps = {
   'data-flip-id'?: string
   children?: ReactNode
   style?: CSSProperties
-} & SeparatorVariants
+}
 
 /**
  * Separator component used to separate content with a horizontal or vertical line.

--- a/packages/ui/src/components/Separator/styles.css.ts
+++ b/packages/ui/src/components/Separator/styles.css.ts
@@ -1,7 +1,6 @@
 import { theme } from '@ultraviolet/themes'
 import { createVar } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
 import type { Color } from '../../theme'
 import { drawerStyle } from '../Drawer/styles.css'
 import { tagStyle } from '../Tag/styles.css'
@@ -98,8 +97,6 @@ const hr = recipe({
     },
   },
 })
-
-export type SeparatorVariants = NonNullable<RecipeVariants<typeof iconWraper>>
 
 export const separatorStyle = {
   thicknessSeparator,

--- a/packages/ui/src/components/Text/style.css.ts
+++ b/packages/ui/src/components/Text/style.css.ts
@@ -3,7 +3,6 @@ import type { ExtendedColor, TextStyleObject, TextVariant } from '@ultraviolet/t
 import { capitalize, filterByProperty } from '@ultraviolet/utils'
 import { style } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
 import { PROMINENCES } from './constants'
 import { textVars } from './variables.css'
 
@@ -174,6 +173,5 @@ const text = recipe({
 })
 
 const oneLine = style({})
-export type TextVariants = NonNullable<RecipeVariants<typeof text>>
 
 export const textStyle = { text, oneLine }


### PR DESCRIPTION
## Summary

## Type

- Enhancement


### Summarize concisely:

#### What is expected?
`Badge`, `Banner`, `Button` & `Separator`: define props directly instead of inferring from vanilla-extract recipes. This should fix stories controls.

`Text`, `Alert`: remove unused vanilla-extract type export


## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| Badge  | <img width="621" height="188" alt="Capture d’écran 2026-08-18 à 15 52 37" src="https://github.com/user-attachments/assets/aa864ad2-7570-414d-b113-3e2935b805bd" />| <img width="599" height="284" alt="Capture d’écran 2026-08-18 à 15 52 17" src="https://github.com/user-attachments/assets/5803dfb5-b7f2-4292-a503-903351ee0dc8" /> |
| Banner  | <img width="538" height="79" alt="Capture d’écran 2026-08-18 à 15 51 38" src="https://github.com/user-attachments/assets/62725587-f8d0-41d9-b0be-593668dfa961" /> |<img width="529" height="126" alt="Capture d’écran 2026-08-18 à 15 51 15" src="https://github.com/user-attachments/assets/615a6b46-60dd-4645-89ca-0fc68d57b40d" />
| Button  | <img width="583" height="231" alt="Capture d’écran 2026-08-18 à 15 50 51" src="https://github.com/user-attachments/assets/ac56a6f9-e0d4-473b-a213-a0b871a3c7d8" />| <img width="602" height="371" alt="Capture d’écran 2026-08-18 à 15 50 34" src="https://github.com/user-attachments/assets/b32aec3e-cee4-4d26-bc82-d3f10dfb8404" /> |
| Separator  |  <img width="592" height="91" alt="Capture d’écran 2026-08-18 à 15 50 00" src="https://github.com/user-attachments/assets/6906841f-9eb1-4d83-a993-1f1d1eb252af" />| <img width="605" height="116" alt="Capture d’écran 2026-08-18 à 15 49 20" src="https://github.com/user-attachments/assets/7cf87215-8f73-4c8c-ae02-533d57f20fda" /> |

