### PR TITLE
fix(Filters): treat empty filters as inactive even when their default value is undefined

### DIFF
--- a/.changeset/three-signs-peel.md
+++ b/.changeset/three-signs-peel.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Filters`:
+- treat empty filters ('') as inactive even when their default value is undefined 
+- add `clearable` option on the text filter

--- a/packages/ui/src/compositions/Filters/__stories__/demo.config.tsx
+++ b/packages/ui/src/compositions/Filters/__stories__/demo.config.tsx
@@ -3,8 +3,8 @@ import { Tooltip } from '../../../components'
 import type { FilterConfig } from '../types'
 
 export type FilterValues = {
-  name: string
-  status: string
+  name: string | undefined
+  status: string | undefined
   env: string[]
   price: [number, number]
   ram: [number, number]
@@ -22,8 +22,8 @@ const labelDescription = (
 )
 
 export const demoDefaultValues: FilterValues = {
-  name: '',
-  status: '',
+  name: undefined,
+  status: undefined,
   env: [],
   price: [0, 1000],
   ram: [0, 64],
@@ -52,6 +52,7 @@ export const demoFilters: FilterConfig<FilterValues>[] = [
         type: 'select',
         name: 'status',
         label: 'Status',
+        clearable: true,
         placeholder: 'Select status',
         options: [
           { label: 'Active', value: 'active' },

--- a/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
@@ -164,6 +164,59 @@ describe('filters', () => {
     expect(onSubmit).toHaveBeenLastCalledWith(defaultValues)
   })
 
+  it('should treat empty fields as inactive even when their default value is undefined', async () => {
+    type Values = { name?: string; status?: string }
+
+    const selectAndTextConfig: FilterConfig<Values>[] = [
+      {
+        type: 'search',
+        name: 'name',
+        label: 'Name',
+        debounceDuration: 0,
+      },
+      {
+        type: 'select',
+        name: 'status',
+        label: 'Status',
+        clearable: true,
+        options: [
+          { label: 'Active', value: 'active' },
+          { label: 'Inactive', value: 'inactive' },
+        ],
+      },
+      {
+        type: 'text',
+        name: 'drawer',
+        label: 'drawer',
+      },
+    ]
+
+    renderWithTheme(
+      <Filters
+        layout={{ mainFilters: ['name', 'status'] }}
+        config={selectAndTextConfig}
+        defaultValues={{ name: undefined, status: undefined }}
+        labels={labels}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Clear all' })).toBeDisabled()
+
+    await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'John')
+    await userEvent.click(screen.getByRole('combobox', { name: 'Status' }))
+    await userEvent.click(screen.getByRole('option', { name: 'active' }))
+
+    expect(screen.getByRole('button', { name: 'Clear all' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'All filters (2)' })).toBeVisible()
+
+    const clearButtons = screen.getAllByRole('button', { name: 'clear value' })
+    await userEvent.click(clearButtons[0])
+    await userEvent.click(clearButtons[1])
+
+    expect(screen.getByRole('button', { name: 'All filters' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Clear all' })).toBeDisabled()
+  })
+
   it('should submit only after clicking the submit button in the drawer', async () => {
     const onSubmit = vi.fn()
     const onChange = vi.fn()

--- a/packages/ui/src/compositions/Filters/filterTypes/FilterText.tsx
+++ b/packages/ui/src/compositions/Filters/filterTypes/FilterText.tsx
@@ -17,6 +17,7 @@ export const FilterText = ({ config, hideLabel, onChange, value, size }: FilterT
   return (
     <TextInput
       aria-label={hideLabel ? config.label : undefined}
+      clearable={config.clearable}
       label={hideLabel ? undefined : config.label}
       labelDescription={hideLabel ? undefined : config.labelDescription}
       loading={tempValue !== value}

--- a/packages/ui/src/compositions/Filters/parts/helpers.ts
+++ b/packages/ui/src/compositions/Filters/parts/helpers.ts
@@ -3,6 +3,8 @@ import type { AnyObject, FilterConfig, FilterConfigGroup } from '../types'
 export const isFilterConfigGroup = <V extends AnyObject>(item: FilterConfig<V>): item is FilterConfigGroup<V> =>
   item.type === 'group'
 
+const isEmpty = (value: unknown) => value === undefined || value === null || value === ''
+
 export const getKeysWithDifferentValues = <Values extends AnyObject>(a?: Values, b?: Values): (keyof Values)[] => {
   if (a === b) {
     return []
@@ -29,7 +31,11 @@ export const getKeysWithDifferentValues = <Values extends AnyObject>(a?: Values,
     const valueA = a[keyA]
     const valueB = b[keyA]
 
-    // Typical cse for string | number
+    if (isEmpty(valueA) && isEmpty(valueB)) {
+      return false
+    }
+
+    // Typical case for string | number
     if (valueA === valueB) {
       return false
     }

--- a/packages/ui/src/compositions/Filters/types.ts
+++ b/packages/ui/src/compositions/Filters/types.ts
@@ -31,6 +31,7 @@ export type FilterConfigItemText = FilterConfigItemBase & {
   type: 'text'
   regexp?: RegExp
   debounceDuration?: number
+  clearable?: boolean
 }
 
 export type FilterConfigItemSearch = FilterConfigItemBase & {


### PR DESCRIPTION
### Summary

`Filters` now treats empty values (`''`) as inactive even when their default value is `undefined`, so "Clear all" correctly disables when all filters are empty. Also adds a `clearable` option on the text filter.