### PR TITLE
fix(Navigation): fix CSS specificity issues

### DIFF
--- a/.changeset/bold-shirts-feel.md
+++ b/.changeset/bold-shirts-feel.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Navigation`: fix CSS specificity issues breaking the styles on the separators and collapsed items

--- a/packages/ui/src/compositions/Navigation/components/items.css.ts
+++ b/packages/ui/src/compositions/Navigation/components/items.css.ts
@@ -11,9 +11,13 @@ export const itemRelative = style({ position: 'relative' })
 export const itemPadded = style({ paddingLeft: theme.space[1] })
 
 export const itemCollapsed = style({
-  height: theme.sizing['400'],
-  width: theme.sizing['400'],
-  padding: 0,
+  selectors: {
+    '&&': {
+      height: theme.sizing['400'],
+      width: theme.sizing['400'],
+      padding: 0,
+    },
+  },
 })
 
 const itemPinIconBase = style({

--- a/packages/ui/src/compositions/Navigation/components/styles.css.ts
+++ b/packages/ui/src/compositions/Navigation/components/styles.css.ts
@@ -64,10 +64,14 @@ export const pinnedItemContainer = recipe({
 })
 
 export const separator = style({
-  margin: `${theme.space['2']} calc(${theme.space['2']} * -1)`,
-  flexShrink: 0,
-  width: widthNavigationContainer,
-  transition: `width ${ANIMATION_DURATION}ms ${ANIMATION_EASING}`,
+  selectors: {
+    '&&': {
+      margin: `${theme.space['2']} calc(${theme.space['2']} * -1)`,
+      flexShrink: 0,
+      width: widthNavigationContainer,
+      transition: `width ${ANIMATION_DURATION}ms ${ANIMATION_EASING}`,
+    },
+  },
 })
 
 export const showHideStack = recipe({


### PR DESCRIPTION
### Summary

Fix CSS specificity issues in `Navigation` that were breaking styles on the separators and collapsed items. The styles now use doubled `&&` selectors to ensure they win over other rules with equal/higher specificity.

### Screenshots

This was visible on the console, not on Storybook

|   Before   |      After |
| :--------: | ---------: |
| <img width="66" height="895" alt="image" src="https://github.com/user-attachments/assets/2ecdcb76-aa69-44ee-aa12-bcd7560b6545" /> | <img width="64" height="896" alt="image" src="https://github.com/user-attachments/assets/9ced0104-ad9e-4576-9a21-92836a23ecbc" /> |