### PR TITLE
fix(InfoTable): avoid clipping an animated Status at the start of a cell

### DIFF
--- a/.changeset/soft-hornets-agree.md
+++ b/.changeset/soft-hornets-agree.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`InfoTable`: avoid clipping an animated Status at the start of a cell

--- a/packages/ui/src/compositions/InfoTable/__stories__/ComplexExample.stories.tsx
+++ b/packages/ui/src/compositions/InfoTable/__stories__/ComplexExample.stories.tsx
@@ -11,8 +11,8 @@ export const ComplexExample: StoryFn<ComponentProps<typeof InfoTable>> = props =
   <InfoTable {...props} header="Instance information">
     <InfoTable.Row templateColumns="repeat(4, 1fr)">
       <InfoTable.Cell title="Status">
-        <Status sentiment="success" />
-        Ready
+        <Status animated sentiment="info" />
+        Starting
       </InfoTable.Cell>
       <InfoTable.Cell title="Type">
         GP1-S{' '}

--- a/packages/ui/src/compositions/InfoTable/styles.css.ts
+++ b/packages/ui/src/compositions/InfoTable/styles.css.ts
@@ -1,7 +1,7 @@
 import { theme } from '@ultraviolet/themes'
 import { createVar, globalStyle, style, styleVariants } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
-import { cardStyle } from '../../components/styles'
+import { cardStyle, statusStyle } from '../../components/styles'
 
 export const rowWidth = createVar()
 
@@ -51,6 +51,12 @@ const desc = style({
   minWidth: 0,
   width: '100%',
   maxWidth: '100%',
+  selectors: {
+    [`&:has(${statusStyle.animatedCircle()})`]: {
+      marginLeft: `calc(-1 * ${theme.space[1]})`,
+      paddingLeft: theme.space[1],
+    },
+  },
 })
 
 const descFlex = style({


### PR DESCRIPTION
### Summary

Animated Status circles were getting clipped at the start of an `InfoTable` cell. Added a `:has()` rule on the description to offset and pad the cell content when it contains an animated Status.

### Screenshots

|   Before   |      After |
| :--------: | ---------: |
| <img width="117" height="72" alt="image" src="https://github.com/user-attachments/assets/896b6139-2e01-4ae1-abb4-518100d91d98" /> | <img width="131" height="73" alt="image" src="https://github.com/user-attachments/assets/6d11f39f-516b-482f-8627-7035a2392911" /> |