### PR TITLE
fix(renovate): include pnpm catalog deps in test deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,6 @@
     {
       "extends": ["packages:jsUnitTest"],
       "matchPackageNames": ["happy-dom", "jsdom"],
-      "matchDepTypes": ["devDependencies", "dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "non-major tests dependencies",
       "groupSlug": "non-major-tests-deps",


### PR DESCRIPTION
### Summary
Our config to group test packages matches depTypes `devDependencies` and `dependencies` but for pnpm catalogs Renovate uses [another kind of depType](https://docs.renovatebot.com/modules/manager/npm/#dependency-types), so vitest was not included in our group and was [incorrectly marked as a `dependency`](https://github.com/scaleway/ultraviolet/pull/6816)