### PR TITLE
fix(Text): correctly recompute the overflow for the Tooltip when the text is resized

### DIFF
--- a/.changeset/fresh-cases-mate.md
+++ b/.changeset/fresh-cases-mate.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Text`: 
+- fix: correctly update the Tooltip display when the text is resized
+- perf: avoid adding a resize event listener for each Text component

--- a/packages/ui/src/components/Text/index.tsx
+++ b/packages/ui/src/components/Text/index.tsx
@@ -3,7 +3,6 @@
 import type { TextVariant } from '@ultraviolet/themes'
 import { cn } from '@ultraviolet/utils'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
-import { useRef } from 'react'
 import type { CSSProperties, AriaRole, ElementType, ReactNode } from 'react'
 import recursivelyGetChildrenString from '../../helpers/recursivelyGetChildrenString'
 import { useIsOverflowing } from '../../hooks/useIsOverflowing'
@@ -65,13 +64,12 @@ export const Text = ({
   'aria-hidden': ariaHidden,
   style,
 }: TextProps) => {
-  const elementRef = useRef(null)
-  const isOverflowing = useIsOverflowing(elementRef)
+  const [setElement, isOverflowing] = useIsOverflowing({ enabled: oneLine === true })
 
   const finalStringChildren = recursivelyGetChildrenString(children)
 
   return (
-    <Tooltip text={oneLine && isOverflowing ? finalStringChildren : ''}>
+    <Tooltip text={isOverflowing ? finalStringChildren : ''}>
       <Component
         role={role}
         aria-hidden={ariaHidden}
@@ -93,7 +91,7 @@ export const Text = ({
         dir={dir}
         htmlFor={htmlFor}
         id={id}
-        ref={elementRef}
+        ref={setElement}
         style={{
           ...assignInlineVars(textVars, {
             textAlign: placement ?? '',

--- a/packages/ui/src/hooks/__tests__/useIsOverflowing.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useIsOverflowing.test.tsx
@@ -1,83 +1,125 @@
-import { renderHook, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useIsOverflowing } from '../useIsOverflowing'
 
+class MockResizeObserver {
+  static disconnect = vi.fn()
+
+  callback: ResizeObserverCallback
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+  }
+
+  observe() {
+    this.callback([], this as unknown as ResizeObserver)
+  }
+
+  unobserve() {}
+
+  disconnect() {
+    MockResizeObserver.disconnect()
+  }
+}
+
 describe(useIsOverflowing, () => {
-  it('should be false with no overflow', async () => {
-    const { result } = renderHook(() => useIsOverflowing({ current: document.createElement('div') }))
-    await waitFor(() => {
-      expect(result.current).toBe(false)
-    })
+  beforeEach(() => {
+    MockResizeObserver.disconnect.mockClear()
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
   })
 
-  it('should be false with no overflow and callback at false too', async () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('should be false with no overflow', () => {
     const callback = vi.fn()
-    const { result } = renderHook(() => useIsOverflowing({ current: document.createElement('div') }, callback))
-    await waitFor(() => {
-      expect(result.current).toBe(false)
+    const { result } = renderHook(() => useIsOverflowing({ callback }))
+    const [setElement, isOverflowing] = result.current
+
+    act(() => {
+      setElement(document.createElement('div'))
     })
 
-    expect(callback).toHaveBeenCalledOnce()
+    expect(isOverflowing).toBe(false)
+    expect(callback).toHaveBeenCalledWith(false)
   })
 
-  it('should be true with overflow', async () => {
-    const element = document.createElement('div')
-
-    const { result } = renderHook(() =>
-      useIsOverflowing({
-        current: {
-          ...element,
-          clientWidth: 100,
-          scrollWidth: 200,
-        },
-      }),
-    )
-
-    await waitFor(() => {
-      expect(result.current).toBe(true)
-    })
-  })
-
-  it('should be true with overflow and callback at true too', async () => {
+  it('should be true with overflow', () => {
     const callback = vi.fn()
+    const { result } = renderHook(() => useIsOverflowing({ callback }))
+    const [setElement] = result.current
+
     const element = document.createElement('div')
+    Object.defineProperty(element, 'clientWidth', { value: 100 })
+    Object.defineProperty(element, 'scrollWidth', { value: 200 })
 
-    const { result } = renderHook(() =>
-      useIsOverflowing(
-        {
-          current: {
-            ...element,
-            clientWidth: 100,
-            scrollWidth: 200,
-          },
-        },
-        callback,
-      ),
-    )
-
-    await waitFor(() => {
-      expect(result.current).toBe(true)
+    act(() => {
+      setElement(element)
     })
 
+    expect(result.current[1]).toBe(true)
     expect(callback).toHaveBeenCalledWith(true)
-    expect(callback).toHaveBeenCalledTimes(2) // 1 for initial render, 1 for overflow
   })
 
-  it('should cleanup event listener', () => {
-    const { unmount } = renderHook(() => useIsOverflowing({ current: document.createElement('div') }))
+  it('should recompute when the element changes', () => {
+    const { result } = renderHook(() => useIsOverflowing())
+    const [setElement] = result.current
 
-    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+    const overflowElement = document.createElement('div')
+    Object.defineProperty(overflowElement, 'clientWidth', { value: 100 })
+    Object.defineProperty(overflowElement, 'scrollWidth', { value: 200 })
+
+    act(() => {
+      setElement(overflowElement)
+    })
+    expect(result.current[1]).toBe(true)
+
+    act(() => {
+      setElement(document.createElement('div'))
+    })
+    expect(result.current[1]).toBe(false)
+  })
+
+  it('should cleanup the ResizeObserver', () => {
+    const { result, unmount } = renderHook(() => useIsOverflowing())
+    const [setElement] = result.current
+
+    act(() => {
+      setElement(document.createElement('div'))
+    })
     unmount()
 
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
-    removeEventListenerSpy.mockRestore()
+    expect(MockResizeObserver.disconnect).toHaveBeenCalled()
   })
 
-  it('should handle undefined ref', async () => {
-    const { result } = renderHook(() => useIsOverflowing({ current: undefined }))
+  it('should not create the observer when disabled', () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useIsOverflowing({ callback, enabled: false }))
+    const [setElement, isOverflowing] = result.current
 
-    await waitFor(() => {
-      expect(result.current).toBe(false)
+    act(() => {
+      setElement(document.createElement('div'))
     })
+
+    expect(isOverflowing).toBe(false)
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('should handle no element', () => {
+    const { result } = renderHook(() => useIsOverflowing())
+
+    expect(result.current[1]).toBe(false)
+  })
+
+  it('should not throw error if ResizeObserver is not defined', () => {
+    vi.unstubAllGlobals()
+    const { result } = renderHook(() => useIsOverflowing())
+    const [setElement, isOverflowing] = result.current
+
+    act(() => {
+      setElement(document.createElement('div'))
+    })
+    expect(isOverflowing).toBe(false)
   })
 })

--- a/packages/ui/src/hooks/useIsOverflowing.ts
+++ b/packages/ui/src/hooks/useIsOverflowing.ts
@@ -1,43 +1,38 @@
 import { useEffect, useState } from 'react'
-import type { RefObject } from 'react'
+
+type UseIsOverflowingOptions = {
+  callback?: (hasOverflow: boolean) => void
+  enabled?: boolean
+}
 
 /**
- * This hook checks if the element has overflow based on the offsetWidth and scrollWidth of the element.
+ * Check if the element has overflow based on the clientWidth and scrollWidth of the element.
  */
-export const useIsOverflowing = (
-  ref: RefObject<HTMLElement | HTMLDivElement | undefined | null>,
-  callback?: (hasOverflow: boolean) => void,
-) => {
+export const useIsOverflowing = ({ callback, enabled = true }: UseIsOverflowingOptions = {}) => {
+  const [element, setElement] = useState<HTMLElement | null>(null)
   const [isOverflowing, setIsOverflowing] = useState(false)
 
   useEffect(() => {
+    if (!enabled || !element || typeof ResizeObserver === 'undefined') {
+      return
+    }
+
     const handleResize = () => {
-      if (!ref.current) {
-        return
-      }
+      const hasOverflow = element.scrollWidth > element.clientWidth
 
-      const element = ref.current
-
-      const hasOverflow = element.clientWidth < element.scrollWidth
       setIsOverflowing(hasOverflow)
       if (callback) {
         callback(hasOverflow)
       }
     }
 
-    // This will add the function into the browser event queue after the DOM is painted
-    // which is needed to get the correct offsetWidth and scrollWidth
-    const timeout = setTimeout(() => handleResize(), 0)
+    const resizeObserver = new ResizeObserver(handleResize)
+    resizeObserver.observe(element)
 
-    // Listen for resize events
-    window.addEventListener('resize', handleResize)
-
-    // Cleanup the event listener
     return () => {
-      window.removeEventListener('resize', handleResize)
-      clearTimeout(timeout)
+      resizeObserver.disconnect()
     }
-  }, [ref, callback])
+  }, [element, callback, enabled])
 
-  return isOverflowing
+  return [setElement, isOverflowing] as const
 }


### PR DESCRIPTION
### Summary

Fix the computation of the overflow in the Text component.
- use a `ResizeObserver` instead of the `resize` event listener on the window because:
  - the window could be resized without the Text to be resized (unnecessary computation)
  - the Text could be resized without the window to be resized (visual bug)
- register the `ResizeObserver` _only_ if the Text is `oneLine` since we don't need it otherwise

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| resize handlers in the `Text / Showcase` story  | <img width="282" height="1066" alt="image" src="https://github.com/user-attachments/assets/306717be-60a6-456e-bd77-60e00477dea3" /> | <img width="320" height="361" alt="image" src="https://github.com/user-attachments/assets/073fa539-ee7c-45cf-8487-53167cc28dea" /> |
| performance during resize  | <img width="590" height="131" alt="image" src="https://github.com/user-attachments/assets/4d64cc2f-55c6-4784-b18c-b3df66f3d68c" /> | <img width="353" height="111" alt="image" src="https://github.com/user-attachments/assets/61c30f95-d62a-4ce4-9d9a-6784df7cb07f" />|
