### PR TITLE
fix(Popup): css specificity

### DIFF
--- a/.changeset/brown-badgers-raise.md
+++ b/.changeset/brown-badgers-raise.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`DateInput`, `SearchInput`: increase popup style specificity to ensure that it overrides Popup's default style

--- a/packages/ui/src/components/DateInput/styles.css.ts
+++ b/packages/ui/src/components/DateInput/styles.css.ts
@@ -10,11 +10,15 @@ const container = style({
 
 const calendarContentWrapper = recipe({
   base: {
-    backgroundColor: theme.colors.other.elevation.background.raised,
-    borderRadius: theme.radii.default,
-    color: theme.colors.neutral.text,
-    padding: theme.space[2],
-    width: '16.5rem',
+    selectors: {
+      '&&': {
+        backgroundColor: theme.colors.other.elevation.background.raised,
+        borderRadius: theme.radii.default,
+        color: theme.colors.neutral.text,
+        padding: theme.space[2],
+        width: '16.5rem',
+      },
+    },
   },
   variants: {
     disabled: {

--- a/packages/ui/src/components/SearchInput/styles.css.ts
+++ b/packages/ui/src/components/SearchInput/styles.css.ts
@@ -2,12 +2,16 @@ import { theme } from '@ultraviolet/themes'
 import { style } from '@vanilla-extract/css'
 
 const popup = style({
-  background: theme.colors.other.elevation.background.raised,
-  boxShadow: `${theme.shadows.raised[0]}, ${theme.shadows.raised[1]}`,
-  minWidth: '38.125rem',
-  padding: `${theme.space['2']} ${theme.space['1']}`,
-  textAlign: 'initial',
-  width: '100%',
+  selectors: {
+    '&&': {
+      background: theme.colors.other.elevation.background.raised,
+      boxShadow: `${theme.shadows.raised[0]}, ${theme.shadows.raised[1]}`,
+      minWidth: '38.125rem',
+      padding: `${theme.space['2']} ${theme.space['1']}`,
+      textAlign: 'initial',
+      width: '100%',
+    },
+  },
 })
 
 const searchInput = style({})


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

`DateInput`, `SearchInput`: increase popup style specificity to ensure that it overrides Popup's default style

**It seemed to be an issue on Storybook only (no problem on examples for instance).**

| Page |   Before   |      After |
| :--- | :--------: | :--------: |
| SearchInput  |  <img width="514" height="102" alt="Capture d’écran 2026-08-24 à 17 31 59" src="https://github.com/user-attachments/assets/5196fcea-ca95-4e0d-a058-d2e992951ae1" />| <img width="416" height="152" alt="Capture d’écran 2026-08-24 à 17 31 20" src="https://github.com/user-attachments/assets/baa9a5de-40f7-4a2f-b086-68d217e91b85" /> |
| DateInput  | <img width="294" height="361" alt="Capture d’écran 2026-08-24 à 17 32 24" src="https://github.com/user-attachments/assets/b0061244-eb97-4106-b6be-70c3464e4e51" /> | <img width="328" height="377" alt="Capture d’écran 2026-08-24 à 17 32 45" src="https://github.com/user-attachments/assets/3e4f99ba-5f06-4fb0-b5e9-09ffe016b7c5" />|
