### PR TITLE
fix(Alert): fix vertical alignment of the title with long content in the row direction

### DIFF
--- a/.changeset/seven-garlics-post.md
+++ b/.changeset/seven-garlics-post.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Alert`: fix vertical alignment of the title with long content in the row direction

--- a/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`submitErrorAlert > should display an alert when submitError is present 
               />
             </svg>
             <div
-              class="uv_1b838gx9 uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u37 uv_toi52u3p"
+              class="uv_1b838gx9 uv_toi52u0 uv_toi52u2j uv_toi52u37 uv_toi52u3p"
               style="--uv_4k0ekn3: 1 1 auto;"
             >
               <p

--- a/packages/ui/src/components/Alert/__stories__/LongChildren.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/LongChildren.stories.tsx
@@ -1,16 +1,36 @@
-import { Template } from './Template.stories'
+import type { ComponentProps } from 'react'
+import { Alert } from '..'
+import { Stack } from '../../Stack'
 
-export const LongChildren = Template.bind({})
+export const LongChildren = (props: ComponentProps<typeof Alert>) => (
+  <Stack gap="3">
+    <Alert
+      {...props}
+      sentiment="info"
+      closable
+      buttonText="More info"
+      onClickButton={() => alert('Button clicked')}
+      title="Information"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </Alert>
 
-LongChildren.args = {
-  buttonText: 'More info',
-  children:
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-  closable: true,
-  onClickButton: () => alert('Button clicked'),
-  sentiment: 'info',
-  title: 'Information',
-}
+    <Alert {...props} sentiment="info" closable onClickButton={() => alert('Button clicked')} title="Note">
+      <ul style={{ margin: 0 }}>
+        <li>
+          Hubble must be deployed in the <code>kube-system</code> namespace.
+        </li>
+        <li>
+          Do not enable <code>operator/envoy/agent</code> as it may break the managed Cilium.
+        </li>
+        <li>Costs may arise based on usage.</li>
+      </ul>
+    </Alert>
+  </Stack>
+)
 
 LongChildren.parameters = {
   docs: {

--- a/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`alert > renders correctly small 1`] = `
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.25rem_xxsmall__toi52u5j"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.25rem_xxsmall__toi52u5j"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <span
@@ -85,7 +85,7 @@ exports[`alert > renders correctly with all sentiments > renders correctly senti
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -133,7 +133,7 @@ exports[`alert > renders correctly with all sentiments > renders correctly senti
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -183,7 +183,7 @@ exports[`alert > renders correctly with all sentiments > renders correctly senti
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -231,7 +231,7 @@ exports[`alert > renders correctly with all sentiments > renders correctly senti
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -279,7 +279,7 @@ exports[`alert > renders correctly with all sentiments > renders correctly senti
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -327,7 +327,7 @@ exports[`alert > renders correctly with buttonText and onClickButton 1`] = `
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -381,7 +381,7 @@ exports[`alert > renders correctly with children as component 1`] = `
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p>
@@ -427,7 +427,7 @@ exports[`alert > renders correctly with closable and onClose 1`] = `
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -494,7 +494,7 @@ exports[`alert > renders correctly with default values 1`] = `
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -542,7 +542,7 @@ exports[`alert > renders correctly with disabled 1`] = `
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <p
@@ -597,7 +597,7 @@ exports[`alert > renders correctly with title 1`] = `
             />
           </svg>
           <div
-            class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+            class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
             style="--_4k0ekn3: 1 1 auto;"
           >
             <span

--- a/packages/ui/src/components/Alert/index.tsx
+++ b/packages/ui/src/components/Alert/index.tsx
@@ -91,14 +91,7 @@ export const Alert = ({
             sentiment={sentiment}
             size={size === 'small' ? 'small' : 'medium'}
           />
-          <Stack
-            alignItems="center"
-            className={alertStyle.text}
-            direction="row"
-            flex="1 1 auto"
-            gap={size === 'small' ? 0.5 : 1}
-            wrap
-          >
+          <Stack className={alertStyle.text} direction="row" flex="1 1 auto" gap={size === 'small' ? 0.5 : 1} wrap>
             {title ? (
               <Text as="span" sentiment={sentiment} variant={size === 'small' ? 'bodySmallStronger' : 'bodyStronger'}>
                 {title}

--- a/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
+++ b/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
@@ -3440,7 +3440,7 @@ exports[`estimateCost - Regular Item > render with alert 1`] = `
               />
             </svg>
             <div
-              class="styles__1b838gx9 styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
+              class="styles__1b838gx9 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_wrap_xxsmall__toi52u37 styles_gap_0.5rem_xxsmall__toi52u3p"
               style="--_4k0ekn3: 1 1 auto;"
             >
               <span


### PR DESCRIPTION
### Summary

The `align-items: center` centered the title in a wrong way with a multi-line content and is not needed when there is only one line

### Screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="911" height="140" alt="image" src="https://github.com/user-attachments/assets/fe6aabce-8955-4d0f-9718-e201f2402a25" /> | <img width="907" height="142" alt="image" src="https://github.com/user-attachments/assets/150f7024-5ec6-479e-8aca-5dd4f37a4034" /> |
