### PR TITLE
fix(Fonts): separate woff2 files instead of inlining

### DIFF
--- a/.changeset/new-states-think.md
+++ b/.changeset/new-states-think.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/fonts": patch
+---
+
+Reference `.woff2` font files as separate assets instead of inlining them in `fonts-bundled.css`.

--- a/packages/fonts/vite.config.ts
+++ b/packages/fonts/vite.config.ts
@@ -4,7 +4,10 @@ import { defineConfig, mergeConfig } from 'vite'
 export const config = mergeConfig(defineConfig(defaultConfig), {
   base: './',
   build: {
+    assetsInlineLimit: 0,
     cssCodeSplit: true,
+    cssMinify: true,
+    lib: false,
     rolldownOptions: {
       input: {
         'fonts-cdn': 'src/fonts-cdn.css',
@@ -14,6 +17,7 @@ export const config = mergeConfig(defineConfig(defaultConfig), {
         assetFileNames: '[name][extname]',
       },
     },
+    ssr: false,
   },
 })
 


### PR DESCRIPTION
## Summary

## Type
- Enhancement

### Summarize concisely:

#### What is expected?
Reference `.woff2` font files as separate assets instead of inlining them in `fonts-bundled.css`. (update vite config)

-> Add `assetsInlineLimit` to avoid inlining the font files (must remove `lib`, otherwise it is [ignored](https://vite.dev/config/build-options#build-assetsinlinelimit:~:text=If%20you%20specify%20build%2Elib%2C%20build%2EassetsInlineLimit%20will%20be%20ignored%20and%20assets%20will%20always%20be%20inlined%2C%20regardless%20of%20file%20size%20or%20being%20a%20Git%20LFS%20placeholder)).
Added `ssr false` for a correct path . Not needed since this package only export css & woff2 files 

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | :--------: |
| font-bundled.css (dist)  |<img width="851" height="397" alt="Capture d’écran 2026-08-25 à 11 31 27" src="https://github.com/user-attachments/assets/f7c03785-8e0a-4607-afec-fe8a220d7765" /> |  <img width="868" height="113" alt="Capture d’écran 2026-08-25 à 11 31 14" src="https://github.com/user-attachments/assets/83b6b837-480f-477d-a67e-445473191648" />|

