### PR TITLE
fix(Text): tooltip container width

### DIFF
--- a/.changeset/grumpy-weeks-raise.md
+++ b/.changeset/grumpy-weeks-raise.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Text`: add `min-width` to tooltip container (`oneLine` variant) to stabilize div width

--- a/packages/ui/src/components/Tooltip/styles.css.ts
+++ b/packages/ui/src/components/Tooltip/styles.css.ts
@@ -2,6 +2,7 @@ import { theme } from '@ultraviolet/themes'
 import { style, styleVariants } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 import { fadeIn, fadeOut } from '../../utils'
+import { textStyle } from '../Text/style.css'
 
 export const ARROW_SIZE = 8
 const ARROW_RADIUS = 2
@@ -60,6 +61,11 @@ const childrenContainer = recipe({
   base: {
     display: 'inherit',
     maxWidth: '100%',
+    selectors: {
+      [`&:has(.${textStyle.oneLine})`]: {
+        minWidth: 0,
+      },
+    },
   },
   variants: {
     fullHeight: {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`Text`: add `min-width` to tooltip container (`oneLine` variant) to stabilize div width