### PR TITLE
fix(TagList): empty tags

### DIFF
--- a/.changeset/tricky-tires-say.md
+++ b/.changeset/tricky-tires-say.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`TagList`: avoid adding empty tags when tags.length = 0

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -74,8 +74,8 @@ exports[`tagList > hide items after maxLength 1`] = `
           </span>
         </div>
         <div
-          aria-controls="_r_41_"
-          aria-describedby="_r_41_"
+          aria-controls="_r_3t_"
+          aria-describedby="_r_3t_"
           class="styles__w40vpo9"
           tabindex="-1"
         >
@@ -335,8 +335,8 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           </span>
         </div>
         <div
-          aria-controls="_r_8j_"
-          aria-describedby="_r_8j_"
+          aria-controls="_r_8f_"
+          aria-describedby="_r_8f_"
           class="styles__w40vpo9"
           tabindex="-1"
         >
@@ -552,8 +552,8 @@ exports[`tagList > renders correctly and ignore custom threshold as it does not 
           </span>
         </div>
         <div
-          aria-controls="_r_27_"
-          aria-describedby="_r_27_"
+          aria-controls="_r_23_"
+          aria-describedby="_r_23_"
           class="styles__w40vpo9"
           tabindex="-1"
         >
@@ -928,8 +928,8 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
           </span>
         </div>
         <div
-          aria-controls="_r_1m_"
-          aria-describedby="_r_1m_"
+          aria-controls="_r_1i_"
+          aria-describedby="_r_1i_"
           class="styles__w40vpo9"
           tabindex="-1"
         >
@@ -1021,8 +1021,8 @@ exports[`tagList > renders correctly with custom threshold and extra tags and ma
           </span>
         </div>
         <div
-          aria-controls="_r_2o_"
-          aria-describedby="_r_2o_"
+          aria-controls="_r_2k_"
+          aria-describedby="_r_2k_"
           class="styles__w40vpo9"
           tabindex="-1"
         >
@@ -1224,8 +1224,8 @@ exports[`tagList > renders correctly with multiline 1`] = `
           </span>
         </div>
         <div
-          aria-controls="_r_4i_"
-          aria-describedby="_r_4i_"
+          aria-controls="_r_4e_"
+          aria-describedby="_r_4e_"
           class="styles__w40vpo9"
           tabindex="-1"
         >
@@ -1300,21 +1300,7 @@ exports[`tagList > renders correctly with no tags 1`] = `
       <div
         class="styles__1f9zr5y3"
         data-testid="taglist-container"
-      >
-        <div
-          class="styles_notCopiable__d6zknp2 styles__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
-        >
-          <span
-            class="styles__1f9zr5y5 styles_notCopiable__d6zknp5 styles__d6zknp6 styles_sentiment_neutral__d6zknpc styles_isButton_false__d6zknpi"
-            data-testid=""
-          >
-            <span
-              class="styles__d6zknp14 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
-            />
-          </span>
-        </div>
-      </div>
+      />
       <div
         aria-hidden="true"
         class="styles__1f9zr5y2"
@@ -1363,8 +1349,8 @@ exports[`tagList > renders correctly with placement 1`] = `
           </span>
         </div>
         <div
-          aria-controls="_r_l_"
-          aria-describedby="_r_l_"
+          aria-controls="_r_h_"
+          aria-describedby="_r_h_"
           class="styles__w40vpo9"
           tabindex="-1"
         >

--- a/packages/ui/src/components/TagList/__tests__/index.test.tsx
+++ b/packages/ui/src/components/TagList/__tests__/index.test.tsx
@@ -92,6 +92,8 @@ describe('tagList', () => {
 
     const { asFragment } = renderWithTheme(<TagList data-testid="taglist" popoverTitle="Additional" />)
 
+    const tagWrapper = screen.getByTestId('taglist-container')
+    expect(tagWrapper).toBeEmptyDOMElement()
     expect(asFragment()).toMatchSnapshot()
   })
 

--- a/packages/ui/src/components/TagList/index.tsx
+++ b/packages/ui/src/components/TagList/index.tsx
@@ -185,11 +185,6 @@ export const TagList = ({
       sentiment: sentiment,
     }
 
-    // Avoid displaying an empty tag
-    if (!tag) {
-      return
-    }
-
     if (isKeyValueTag(tag)) {
       return <Tag keyValue={tag} {...commonProps} key={`${tagLabel}-${index}`} />
     }

--- a/packages/ui/src/components/TagList/index.tsx
+++ b/packages/ui/src/components/TagList/index.tsx
@@ -90,7 +90,8 @@ export const TagList = ({
   const popoverTriggerRef = useRef<HTMLButtonElement>(null)
 
   const [isPopoverVisible, setIsPopoverVisible] = useState(false)
-  const [visibleTags, setVisibleTags] = useState<TagType[]>([tags[0]])
+  // Avoid adding undefined to default visibleTags
+  const [visibleTags, setVisibleTags] = useState<TagType[]>(tags[0] ? [tags[0]] : [])
   const [hiddenTags, setHiddenTags] = useState<TagType[]>([])
 
   const [potentiallyVisibleTags, surelyHiddenTags] = useMemo(() => {
@@ -182,6 +183,11 @@ export const TagList = ({
       'data-testid': hidden ? '' : tagLabel,
       variant: variant,
       sentiment: sentiment,
+    }
+
+    // Avoid displaying an empty tag
+    if (!tag) {
+      return
     }
 
     if (isKeyValueTag(tag)) {


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

`TagList`: avoid adding empty tags when tags.length = 0

## Relevant logs and/or screenshots

| Page |   After   |      Before |
| :--- | :--------: | ---------: |
| TagList, tags=[]  |<img width="274" height="81" alt="Capture d’écran 2026-08-26 à 16 10 07" src="https://github.com/user-attachments/assets/1b084151-a926-4364-af64-c337aff63b99" /> (no empty tag) | <img width="274" height="81" alt="Capture d’écran 2026-08-26 à 16 10 34" src="https://github.com/user-attachments/assets/403ff2d2-438a-4105-b4f7-997e1f3eb504" /> (empty tag)|

