### PR TITLE
fix(SelectInput): isLoading vs empty state

### DIFF
--- a/.changeset/metal-camels-feel.md
+++ b/.changeset/metal-camels-feel.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`SelectInput`: empty state should not override isLoading state

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -4654,8 +4654,8 @@ exports[`selectInput > renders correctly with function footer 1`] = `
       class="styles__uf6pag0"
     >
       <div
-        aria-controls="_r_4ai_"
-        aria-describedby="_r_4ai_"
+        aria-controls="_r_4aq_"
+        aria-describedby="_r_4aq_"
         class="styles__w40vpo9 styles_fullWidth_true__w40vpob"
         tabindex="-1"
       >
@@ -4663,13 +4663,13 @@ exports[`selectInput > renders correctly with function footer 1`] = `
           class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
         >
           <div
-            aria-controls="_r_4ai_"
+            aria-controls="_r_4aq_"
             aria-expanded="false"
             class="selectBar__r8qe46 selectBar__r8qe45 selectBar_size_large__r8qe4a selectBar_state_neutral__r8qe4e"
             data-disabled="false"
             data-readonly="false"
             data-testid="select-input-test"
-            id="_r_4ag_"
+            id="_r_4ao_"
             role="combobox"
             tabindex="0"
           >

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -711,7 +711,6 @@ exports[`selectInput > renders correctly loading - grouped data 1`] = `
             >
               <div
                 class="dropdown__igqisu2 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
-                data-grouped="true"
                 id="select-dropdown"
                 role="listbox"
               >
@@ -846,55 +845,50 @@ exports[`selectInput > renders correctly loading - ungrouped data 1`] = `
                 role="listbox"
               >
                 <div
-                  class="dropdown__igqisu8 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.125rem_xxsmall__toi52u5d"
-                  id="items"
+                  aria-busy="true"
+                  aria-live="polite"
+                  class="styles__c2hb451"
                 >
-                  <div
-                    aria-busy="true"
-                    aria-live="polite"
-                    class="styles__c2hb451"
+                  <ul
+                    class="stylesVariants__fr4c0t4"
                   >
-                    <ul
-                      class="stylesVariants__fr4c0t4"
+                    <li
+                      class="stylesVariants__fr4c0t3"
                     >
-                      <li
-                        class="stylesVariants__fr4c0t3"
-                      >
-                        <div
-                          class="stylesVariants__fr4c0tc"
-                        />
-                        <div
-                          class="stylesVariants__fr4c0td"
-                          style="--fr4c0t1: 7.5rem;"
-                        />
-                      </li>
-                      <li
-                        class="stylesVariants__fr4c0t3"
-                      >
-                        <div
-                          class="stylesVariants__fr4c0tc"
-                        />
-                        <div
-                          class="stylesVariants__fr4c0td"
-                          style="--fr4c0t1: 7.5rem;"
-                        />
-                      </li>
-                      <li
-                        class="stylesVariants__fr4c0t3"
-                      >
-                        <div
-                          class="stylesVariants__fr4c0tc"
-                        />
-                        <div
-                          class="stylesVariants__fr4c0td"
-                          style="--fr4c0t1: 7.5rem;"
-                        />
-                      </li>
-                    </ul>
-                    <div
-                      class="styles__c2hb452"
-                    />
-                  </div>
+                      <div
+                        class="stylesVariants__fr4c0tc"
+                      />
+                      <div
+                        class="stylesVariants__fr4c0td"
+                        style="--fr4c0t1: 7.5rem;"
+                      />
+                    </li>
+                    <li
+                      class="stylesVariants__fr4c0t3"
+                    >
+                      <div
+                        class="stylesVariants__fr4c0tc"
+                      />
+                      <div
+                        class="stylesVariants__fr4c0td"
+                        style="--fr4c0t1: 7.5rem;"
+                      />
+                    </li>
+                    <li
+                      class="stylesVariants__fr4c0t3"
+                    >
+                      <div
+                        class="stylesVariants__fr4c0tc"
+                      />
+                      <div
+                        class="stylesVariants__fr4c0td"
+                        style="--fr4c0t1: 7.5rem;"
+                      />
+                    </li>
+                  </ul>
+                  <div
+                    class="styles__c2hb452"
+                  />
                 </div>
               </div>
             </div>

--- a/packages/ui/src/components/SelectInput/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectInput/__tests__/index.test.tsx
@@ -1498,6 +1498,28 @@ describe('selectInput', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
+  it('renders skeleton instead of empty state when loading with empty data', async () => {
+    renderWithTheme(
+      <SelectInput
+        isLoading
+        name="test"
+        options={{}}
+        placeholder="placeholder"
+        placeholderSearch="placeholdersearch"
+      />,
+    )
+    const input = screen.getByText('placeholder')
+    await userEvent.click(input)
+    const dropdown = screen.getByRole('dialog')
+
+    await waitFor(() => {
+      expect(dropdown).toBeVisible()
+    })
+
+    expect(dropdown.querySelector('[aria-busy="true"]')).not.toBeNull()
+    expect(screen.queryByText('No options')).not.toBeInTheDocument()
+  })
+
   it('renders correctly with function footer', async () => {
     const f = vi.fn(() => {})
 

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Content.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Content.tsx
@@ -110,6 +110,19 @@ export const CreateDropdown = ({
     </Stack>
   )
 
+  if (isLoading) {
+    return (
+      <Stack
+        className={selectInputStyle.dropdownContainer}
+        id="select-dropdown"
+        onKeyDown={handleKeyDownSelect}
+        role="listbox"
+      >
+        <Skeleton variant="block" />
+      </Stack>
+    )
+  }
+
   if (isEmpty && !addOption) {
     return (
       <Stack alignItems="center" className={selectInputStyle.dropdownEmptyState} gap={2}>
@@ -156,22 +169,18 @@ export const CreateDropdown = ({
       <SelectAll textVariant={textVariant} />
 
       <Stack gap={0.25} id="items" className={selectInputStyle.dropdownSection}>
-        {isLoading ? (
-          <Skeleton variant="block" />
-        ) : (
-          displayedOptions.map((option, index) => (
-            <Item
-              defaultSearchValue={defaultSearchValue}
-              descriptionDirection={descriptionDirection}
-              focusedItemRef={focusedItemRef}
-              indexOption={index}
-              key={option.value}
-              option={option}
-              optionalInfoPlacement={optionalInfoPlacement}
-              textVariant={textVariant}
-            />
-          ))
-        )}
+        {displayedOptions.map((option, index) => (
+          <Item
+            defaultSearchValue={defaultSearchValue}
+            descriptionDirection={descriptionDirection}
+            focusedItemRef={focusedItemRef}
+            indexOption={index}
+            key={option.value}
+            option={option}
+            optionalInfoPlacement={optionalInfoPlacement}
+            textVariant={textVariant}
+          />
+        ))}
         {loadMore ? <Stack className={selectInputStyle.dropdownLoadMore}>{loadMore}</Stack> : null}
       </Stack>
     </Stack>
@@ -183,73 +192,67 @@ export const CreateDropdown = ({
       onKeyDown={handleKeyDownSelect}
       role="listbox"
     >
-      {isLoading ? (
-        <Skeleton variant="block" />
-      ) : (
-        <>
-          <AddOption
-            addOption={addOption}
-            option={{
-              label: addOptionLabel,
-              searchText: searchInput,
-              value: `${addOption?.text} ${searchInput}`,
-            }}
-            searchable={searchable}
-            textVariant={textVariant}
-          />
-          <SelectAll textVariant={textVariant} />
+      <AddOption
+        addOption={addOption}
+        option={{
+          label: addOptionLabel,
+          searchText: searchInput,
+          value: `${addOption?.text} ${searchInput}`,
+        }}
+        searchable={searchable}
+        textVariant={textVariant}
+      />
+      <SelectAll textVariant={textVariant} />
 
-          {Object.keys(displayedOptions).map((group, index) => {
-            const hasElements = displayedOptions[group].length > 0
-            const emptyStateGroup = groupEmptyState?.[group] ?? null
-            const errorGroup = groupError?.[group] ?? null
+      {Object.keys(displayedOptions).map((group, index) => {
+        const hasElements = displayedOptions[group].length > 0
+        const emptyStateGroup = groupEmptyState?.[group] ?? null
+        const errorGroup = groupError?.[group] ?? null
 
-            return (
-              <Stack gap={0.25} key={group} className={selectInputStyle.dropdownSection}>
-                {hasElements || emptyStateGroup ? <Group group={group} index={index} /> : null}
-                <Stack gap="0.25" id="items">
-                  {!hasElements && emptyStateGroup ? (
-                    <Text
-                      as="span"
-                      className={selectInputStyle.emptyStateGroupStyle}
-                      prominence="weak"
-                      sentiment="neutral"
-                      variant={textVariant}
-                    >
-                      {emptyStateGroup}
-                    </Text>
-                  ) : null}
-                  {errorGroup ? (
-                    <Text
-                      as="span"
-                      className={selectInputStyle.emptyStateGroupStyle}
-                      sentiment="danger"
-                      variant={textVariant}
-                    >
-                      {errorGroup}
-                    </Text>
-                  ) : null}
-                  {displayedOptions[group].map((option, indexOption) =>
-                    errorGroup ? null : (
-                      <Item
-                        defaultSearchValue={defaultSearchValue}
-                        descriptionDirection={descriptionDirection}
-                        focusedItemRef={focusedItemRef}
-                        group={group}
-                        indexOption={indexOption}
-                        key={option.value}
-                        option={option}
-                        optionalInfoPlacement={optionalInfoPlacement}
-                        textVariant={textVariant}
-                      />
-                    ),
-                  )}
-                </Stack>
-              </Stack>
-            )
-          })}
-        </>
-      )}
+        return (
+          <Stack gap={0.25} key={group} className={selectInputStyle.dropdownSection}>
+            {hasElements || emptyStateGroup ? <Group group={group} index={index} /> : null}
+            <Stack gap="0.25" id="items">
+              {!hasElements && emptyStateGroup ? (
+                <Text
+                  as="span"
+                  className={selectInputStyle.emptyStateGroupStyle}
+                  prominence="weak"
+                  sentiment="neutral"
+                  variant={textVariant}
+                >
+                  {emptyStateGroup}
+                </Text>
+              ) : null}
+              {errorGroup ? (
+                <Text
+                  as="span"
+                  className={selectInputStyle.emptyStateGroupStyle}
+                  sentiment="danger"
+                  variant={textVariant}
+                >
+                  {errorGroup}
+                </Text>
+              ) : null}
+              {displayedOptions[group].map((option, indexOption) =>
+                errorGroup ? null : (
+                  <Item
+                    defaultSearchValue={defaultSearchValue}
+                    descriptionDirection={descriptionDirection}
+                    focusedItemRef={focusedItemRef}
+                    group={group}
+                    indexOption={indexOption}
+                    key={option.value}
+                    option={option}
+                    optionalInfoPlacement={optionalInfoPlacement}
+                    textVariant={textVariant}
+                  />
+                ),
+              )}
+            </Stack>
+          </Stack>
+        )
+      })}
       {loadMore ? <Stack className={selectInputStyle.dropdownLoadMore}>{loadMore}</Stack> : null}
     </Stack>
   )


### PR DESCRIPTION
## Summary

### Concisely:
`SelectInput`: empty state should no longer override `isLoading`.

### Behavior change
When `isLoading` is set, the dropdown now renders a loading skeleton as the sole content. For **ungrouped** options this means `AddOption` / `SelectAll` are no longer shown above the skeleton while loading (previously they were rendered alongside it). This makes ungrouped consistent with grouped, which already showed only the skeleton during loading.

## Type

- Bug
