### PR TITLE
chore(deploy): use new scaleway action for container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           fi
 
       - name: Deploy Serverless Container Scaleway
-        uses: philibea/scaleway-containers-deploy@0d640c31f4e7d2e3c7b830e89d19b9253624c40f # v1.1.5
+        uses: scaleway/scw-serverless-container-action@7ae007211c694cc6928a2f09be77a9f1cf19b6a1 # v0.0.4
         id: deploy
         with:
           type: 'deploy'

--- a/.github/workflows/teardown_pull_request.yml
+++ b/.github/workflows/teardown_pull_request.yml
@@ -23,7 +23,7 @@ jobs:
           echo "STORYBOOK_BRANCH_SLUG=$SAFE_GITHUB_HEAD_REF_SLUG_URL" >> $GITHUB_ENV
 
       - name: Deploy Serverless Container Scaleway
-        uses: philibea/scaleway-containers-deploy@0d640c31f4e7d2e3c7b830e89d19b9253624c40f # v1.1.5
+        uses: scaleway/scw-serverless-container-action@7ae007211c694cc6928a2f09be77a9f1cf19b6a1 # v0.0.4
         id: deploy
         with:
           type: 'teardown'


### PR DESCRIPTION
## Summary

## Type

- Migration


### Summarize concisely:

#### What is expected?


Migrate deploy container action to the new scaleway container action.

This remove the build step and we win at least 30s of build
 <img width="1100" height="368" alt="Capture d’écran 2026-08-27 à 14 03 08" src="https://github.com/user-attachments/assets/178b2d86-e5d9-40f3-b477-00ed5e43c989" />

 
