### PR TITLE
chore: add create-pr skill and simplify PR template

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,28 +1,23 @@
 ---
 name: create-pr
-description: Helps create GitHub Pull Requests based on the PR template and git diff analysis. Use when the user wants to create or update a PR.
+description: Create or update a GitHub Pull Request — analyze the diff, draft the description from the repo template, push with gh. Use when the user wants to create or update a PR.
 ---
 
 # Pull Request Creation
 
-When this skill is invoked, help the user create a well-formed Pull Request description and push it to GitHub.
-
 ## Step 1 — Analyze the diff
 
-See the git diff to understand what changes were made. Filter out noise — ignore generated/build artifacts, lockfiles, snapshots, and dist folders so the analysis focuses on meaningful source changes.
+Read the git diff to understand the change. Filter out generated/build artifacts, lockfiles, snapshots, and dist folders so the analysis focuses on meaningful source changes.
 
-Analyze the diff to infer:
+Infer:
 
-- **Scope**: Which parts of the codebase are affected (components, config, etc.)
-- **Type of changes**: Feature, bugfix, refactor, chore, etc.
-- **Files modified**: What packages are affected
-- **Key decisions**: Why something was done a certain way, alternatives considered, trade-offs.
+- **Scope**: which parts of the codebase are affected
+- **Type**: feature, bugfix, refactor, chore, etc.
+- **Key decisions**: why something was done a certain way, alternatives considered, trade-offs
 
-> ⚠️ The diff analysis is for **your understanding only**. Do **not** transcribe it into the PR description.
+## Step 2 — Pick labels
 
-## Step 2 — Find relevant labels
-
-Based on the type of changes, identify one or more label(s) to add to the PR amongst the followings (this is an exhaustive list, don't invent labels that are not in it):
+Add one or more labels from this exhaustive list, matching the type of change (don't invent others):
 
 - accessibility
 - breaking changes
@@ -33,48 +28,31 @@ Based on the type of changes, identify one or more label(s) to add to the PR amo
 - enhancement
 - refactor
 
-## Step 3 — Check requirements before opening a PR
+## Step 3 — Check requirements
 
-If you identified that the changes in this branch are a new feature or a bugfix, there are two requirements before opening a PR:
+If this is a new feature or bugfix, two requirements must be met before opening the PR:
 
-1. there must be at least one test of the new feature or of the bug that was fixed
-2. there must be a changeset added in the `.changeset` folder
+1. at least one test of the feature / fixed bug
+2. a changeset in the `.changeset` folder
 
-If one of these requirements is not met, tell the user and ask them if they really want to continue. When they are ready you can move on to the next step.
+If either is missing, tell the user and confirm they want to continue.
 
-## Step 4 — Find a PR title
+## Step 4 — Find a title
 
-Find a short PR title, reusing the name of the commit if there is only one in the branch, or following the conventional commit naming convention:
+Short, conventional-commit style: `type(scope): summary`. Reuse the commit name if the branch has one. Scope is a package or component (`ui`, `form`, `SelectInput`). Example: `feat(icons): add ResourceExplorer product icon`.
 
-- Type: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, ...
-- Scope: the name of a package or a component (`ui`, `form`, `SelectInput`, ...)
-- Keep it short and human-readable.
+## Step 5 — Draft the description
 
-Example: `feat(icons): add ResourceExplorer product icon`
+Write a complete draft following the [GitHub Pull Request Template](../../../.github/pull_request_template.md). Scale its length to the diff: tight for a small change, fuller for a large one — and when the diff is large, cover only the significant changes.
 
-## Step 5 — Draft the PR description
+## Step 6 — Validate
 
-Using the diff analysis, **write a complete draft** of the PR description following the [GitHub Pull Request Template](../../../.github/pull_request_template.md).
-
-## Step 6 — Validate the draft
-
-Show the PR draft to the user with the PR title, description and label(s). Then, ask the user:
+Show the draft (title, description, labels) and ask:
 
 > "Does this look good, or would you like to change anything?"
 
-If the user says it's good → go to the next step.
-If the user requests changes → apply them to the draft, show the updated version, and ask again.
-Repeat until the user is satisfied.
+Apply requested changes and re-show until approved. Only after approval, go to Step 7.
 
-## Step 7 — Push to GitHub
+## Step 7 — Push
 
-Once the user approves the draft, create the PR on GitHub using the `gh` CLI, and give the user the link to the PR.
-
-## Rules
-
-- PR description content must be in English. The user may give input in French or English.
-- Don't be verbose, get straight to the point. Keep the description as short as possible.
-- Scale the description length proportionally to the diff size (small changes = short description, large changes = more detail).
-- Show the draft in the conversation **before** pushing to GitHub — the user must approve first.
-- If the diff is too large or complex, focus on the most significant changes.
-- **Never produce a file-by-file inventory of the diff.** Describe decisions and intent, not line-level changes.
+Create the PR with `gh` and give the user the link.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: create-pr
+description: Helps create GitHub Pull Requests based on the PR template and git diff analysis. Use when the user wants to create or update a PR.
+---
+
+# Pull Request Creation
+
+When this skill is invoked, help the user create a well-formed Pull Request description and push it to GitHub.
+
+## Step 1 — Analyze the diff
+
+Run `git diff` (or `git diff <base-branch>` if specified) to understand what changes were made.
+
+Filter out noise — ignore generated/build artifacts, lockfiles, snapshots, and dist folders so the analysis focuses on meaningful source changes.
+
+Analyze the diff to infer:
+
+- **Scope**: Which parts of the codebase are affected (components, config, etc.)
+- **Type of changes**: Feature, bugfix, refactor, chore, etc.
+- **Files modified**: What packages are affected
+- **Key decisions**: Why something was done a certain way, alternatives considered, trade-offs.
+
+> ⚠️ The diff analysis is for **your understanding only**. Do **not** transcribe it into the PR description — see the anti-pattern below.
+
+## Step 2 — Check requirements before opening a PR
+
+If you identified that the changes in this branch are a new feature or a bugfix, there are two requirements before opening a PR:
+
+1. there must be at least one test of the new feature or of the bug that was fixed
+2. there must be a changeset added in the `.changeset` folder
+
+If one of these requirements is not met, suggest the user add it and ask if they want to fix it or continue. When they are ready you can move on to the next step.
+
+## Step 3 — Suggest a PR title
+
+Before the description, propose a short PR title, reusing the name of the commit if there is only one in the branch, or following the conventional commit naming convention:
+
+- Type: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, ...
+- Scope: the name of a package or a component (`ui`, `form`, `SelectInput`, ...)
+- Keep it short and human-readable.
+
+Example: `feat(icons): add ResourceExplorer product icon`
+
+## Step 4 — Draft the PR description
+
+Using the diff analysis, **write a complete draft** of the PR description following the [GitHub Pull Request Template](../../../.github/pull_request_template.md).
+
+### ⚠️ Anti-pattern: do NOT write a diff inventory
+
+The most common mistake is turning the `The following changes were made` section (or any section) into a file-by-file or chunk-by-chunk transcription of the diff. This produces a wall of text that adds **no value** - reviewers can already read the diff.
+
+❌ Bad (wall of text, zero value):
+
+```
+## The following changes were made:
+
+- Set sideEffects to ["**/*.css", "**/index.js"] in packages/illustrations/package.json
+- Added @ultraviolet/illustrations to examples/vite
+- Updated `src/components/Header.tsx` to add a `user` prop
+- Updated `package.json` to add `lodash` dependency
+```
+
+✅ Good (focus on intent and decisions):
+
+```
+## The following changes were made:
+
+- Update the `sideEffects` config in `packages/illustrations/package.json` so rolldown init_* calls in the `_virtual` folder aren't removed
+- Verify the fix by building the `vite` example project using an illustration
+- Pass the current user down to `Header` so it can render the avatar without a new API call.
+- Leverage `lodash` for deep-merge to avoid reimplementing edge cases.
+```
+
+**Rule of thumb:** describe _what was decided and why_, not _which lines changed_. If a reviewer could guess it just by reading the diff, don't include it.
+
+## Step 5 — Validate the draft
+
+After showing the draft, ask the user:
+
+> "Does this look good, or would you like to change anything?"
+
+If the user says it's good → go to the next step.
+If the user requests changes → apply them to the draft, show the updated version, and ask again.
+Repeat until the user is satisfied.
+
+## Step 6 — Push to GitHub
+
+Once the user approves the draft, create the PR on GitHub using the `gh` CLI, and give the user the link to the PR.
+
+## Rules
+
+- PR description content must be in English. The user may give input in French or English.
+- Don't be verbose, get straight to the point. Keep the description as short as possible.
+- Avoid repeating the same information across sections — each section should have a distinct purpose.
+- Scale the description length proportionally to the diff size (small changes = short description, large changes = more detail).
+- Show the draft in the conversation **before** pushing to GitHub — the user must approve first.
+- When pushing to GitHub, ensure the description is properly escaped for the shell command.
+- If the diff is too large or complex, focus on the most significant changes.
+- **Never produce a file-by-file inventory of the diff.** Describe decisions and intent, not line-level changes.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -9,9 +9,7 @@ When this skill is invoked, help the user create a well-formed Pull Request desc
 
 ## Step 1 — Analyze the diff
 
-Run `git diff` (or `git diff <base-branch>` if specified) to understand what changes were made.
-
-Filter out noise — ignore generated/build artifacts, lockfiles, snapshots, and dist folders so the analysis focuses on meaningful source changes.
+See the git diff to understand what changes were made. Filter out noise — ignore generated/build artifacts, lockfiles, snapshots, and dist folders so the analysis focuses on meaningful source changes.
 
 Analyze the diff to infer:
 
@@ -20,20 +18,33 @@ Analyze the diff to infer:
 - **Files modified**: What packages are affected
 - **Key decisions**: Why something was done a certain way, alternatives considered, trade-offs.
 
-> ⚠️ The diff analysis is for **your understanding only**. Do **not** transcribe it into the PR description — see the anti-pattern below.
+> ⚠️ The diff analysis is for **your understanding only**. Do **not** transcribe it into the PR description.
 
-## Step 2 — Check requirements before opening a PR
+## Step 2 — Find relevant labels
+
+Based on the type of changes, identify one or more label(s) to add to the PR amongst the followings (this is an exhaustive list, don't invent labels that are not in it):
+
+- accessibility
+- breaking changes
+- bug
+- ci
+- dependencies
+- documentation
+- enhancement
+- refactor
+
+## Step 3 — Check requirements before opening a PR
 
 If you identified that the changes in this branch are a new feature or a bugfix, there are two requirements before opening a PR:
 
 1. there must be at least one test of the new feature or of the bug that was fixed
 2. there must be a changeset added in the `.changeset` folder
 
-If one of these requirements is not met, suggest the user add it and ask if they want to fix it or continue. When they are ready you can move on to the next step.
+If one of these requirements is not met, tell the user and ask them if they really want to continue. When they are ready you can move on to the next step.
 
-## Step 3 — Suggest a PR title
+## Step 4 — Find a PR title
 
-Before the description, propose a short PR title, reusing the name of the commit if there is only one in the branch, or following the conventional commit naming convention:
+Find a short PR title, reusing the name of the commit if there is only one in the branch, or following the conventional commit naming convention:
 
 - Type: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, ...
 - Scope: the name of a package or a component (`ui`, `form`, `SelectInput`, ...)
@@ -41,41 +52,13 @@ Before the description, propose a short PR title, reusing the name of the commit
 
 Example: `feat(icons): add ResourceExplorer product icon`
 
-## Step 4 — Draft the PR description
+## Step 5 — Draft the PR description
 
 Using the diff analysis, **write a complete draft** of the PR description following the [GitHub Pull Request Template](../../../.github/pull_request_template.md).
 
-### ⚠️ Anti-pattern: do NOT write a diff inventory
+## Step 6 — Validate the draft
 
-The most common mistake is turning the `The following changes were made` section (or any section) into a file-by-file or chunk-by-chunk transcription of the diff. This produces a wall of text that adds **no value** - reviewers can already read the diff.
-
-❌ Bad (wall of text, zero value):
-
-```
-## The following changes were made:
-
-- Set sideEffects to ["**/*.css", "**/index.js"] in packages/illustrations/package.json
-- Added @ultraviolet/illustrations to examples/vite
-- Updated `src/components/Header.tsx` to add a `user` prop
-- Updated `package.json` to add `lodash` dependency
-```
-
-✅ Good (focus on intent and decisions):
-
-```
-## The following changes were made:
-
-- Update the `sideEffects` config in `packages/illustrations/package.json` so rolldown init_* calls in the `_virtual` folder aren't removed
-- Verify the fix by building the `vite` example project using an illustration
-- Pass the current user down to `Header` so it can render the avatar without a new API call.
-- Leverage `lodash` for deep-merge to avoid reimplementing edge cases.
-```
-
-**Rule of thumb:** describe _what was decided and why_, not _which lines changed_. If a reviewer could guess it just by reading the diff, don't include it.
-
-## Step 5 — Validate the draft
-
-After showing the draft, ask the user:
+Show the PR draft to the user with the PR title, description and label(s). Then, ask the user:
 
 > "Does this look good, or would you like to change anything?"
 
@@ -83,7 +66,7 @@ If the user says it's good → go to the next step.
 If the user requests changes → apply them to the draft, show the updated version, and ask again.
 Repeat until the user is satisfied.
 
-## Step 6 — Push to GitHub
+## Step 7 — Push to GitHub
 
 Once the user approves the draft, create the PR on GitHub using the `gh` CLI, and give the user the link to the PR.
 
@@ -91,9 +74,7 @@ Once the user approves the draft, create the PR on GitHub using the `gh` CLI, an
 
 - PR description content must be in English. The user may give input in French or English.
 - Don't be verbose, get straight to the point. Keep the description as short as possible.
-- Avoid repeating the same information across sections — each section should have a distinct purpose.
 - Scale the description length proportionally to the diff size (small changes = short description, large changes = more detail).
 - Show the draft in the conversation **before** pushing to GitHub — the user must approve first.
-- When pushing to GitHub, ensure the description is properly escaped for the shell command.
 - If the diff is too large or complex, focus on the most significant changes.
 - **Never produce a file-by-file inventory of the diff.** Describe decisions and intent, not line-level changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,20 @@
-## Summary
+### Summary
 
-## Type
+**Type:** `Bug / Feature / Enhancement / Documentation / Migration / Refactor`
 
-- Bug
-- Feature
-- Enhancement
-- Documentation
-- Migration
-- Refactor
+(Explain briefly the purpose of this PR)
 
-### Summarize concisely:
+### What is expected?
 
-#### What is expected?
+(Short description of the new behavior)
 
-(Description of the new behavior)
+### The following changes were made:
 
-#### The following changes were made:
+- change 1
+- change 2
+- ...
 
-(Describe what you did)
-
-1.
-
-2.
-
-3.
-
-## Relevant logs and/or screenshots
+### Relevant logs and/or screenshots
 
 | Page |   Before   |      After |
 | :--- | :--------: | ---------: |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,10 @@
 ### Summary
 
-**Type:** `Bug / Feature / Enhancement / Documentation / Migration / Refactor`
-
 (Explain briefly the purpose of this PR)
 
-### What is expected?
+### Screenshots
 
-(Short description of the new behavior)
-
-### The following changes were made:
-
-- change 1
-- change 2
-- ...
-
-### Relevant logs and/or screenshots
-
-| Page |   Before   |      After |
-| :--- | :--------: | ---------: |
-| url  | screenshot | screenshot |
-| url  | screenshot | screenshot |
+|   Before   |      After |
+| :--------: | ---------: |
+| screenshot | screenshot |
+| screenshot | screenshot |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,3 @@
 ### Summary
 
 (Explain briefly the purpose of this PR)
-
-### Screenshots
-
-|   Before   |      After |
-| :--------: | ---------: |
-| screenshot | screenshot |
-| screenshot | screenshot |


### PR DESCRIPTION
### Summary

Add a `create-pr` agent skill that guides PR creation (analyze the diff, pick labels, draft the description from the template, push with `gh`), and simplify the GitHub PR template into a lightweight summary-only format.
