### PR TITLE
ci: add pkg-pr-new workflow for continuous preview releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,25 @@
+name: pkg-pr-new
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_CACHE: 'remote:rw'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm exec pkg-pr-new publish --pnpm --commentWithSha './packages/*'

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -2,6 +2,10 @@ name: pkg-pr-new
 
 on:
   pull_request:
+    types:
+      - labeled
+      - synchronize
+      - opened
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -9,6 +13,7 @@ concurrency:
 
 jobs:
   publish:
+    if: contains(github.event.pull_request.labels.*.name, 'pkg-pr-new')
     runs-on: ubuntu-24.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "oxfmt": "0.66.0",
     "oxlint": "1.81.0",
     "oxlint-tsgolint": "7.0.2001",
+    "pkg-pr-new": "0.0.88",
     "postcss": "8.5.26",
     "publint": "0.3.24",
     "react": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
+      pkg-pr-new:
+        specifier: 0.0.88
+        version: 0.0.88
       postcss:
         specifier: 8.5.26
         version: 8.5.26
@@ -7310,6 +7313,10 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-pr-new@0.0.88:
+    resolution: {integrity: sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -15139,6 +15146,8 @@ snapshots:
   picomatch@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
+
+  pkg-pr-new@0.0.88: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## What

Adds a [`pkg.pr.new`](https://github.com/stackblitz-labs/pkg.pr.new) workflow that publishes preview builds of all `./packages/*` on every pull request. Preview packages are installable via `npm i https://pkg.pr.new/scaleway/ultraviolet/<pkg>@<sha>` without waiting for an npm release.

## Changes

- `.github/workflows/pkg-pr-new.yml` — new workflow triggered on `pull_request`, with concurrency to cancel superseded runs. Builds the workspace then runs `pnpm exec pkg-pr-new publish --pnpm --commentWithSha './packages/*'`.
- `package.json` / `pnpm-lock.yaml` — add `pkg-pr-new` as a workspace devDependency (the docs warn against `npx`/`pnpm dlx`/`bunx` in CI; run from the lockfile via `pnpm exec`).

## Notes

- `--pnpm` is required because this workspace uses pnpm `catalog:` — `npm pack` cannot resolve it.
- `--commentWithSha` makes the bot comment link to the commit SHA so each push gets a stable URL.
- One-time setup outside this repo: install the [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) on `scaleway/ultraviolet` before the first run.