### PR TITLE
feat(storybook): distinguish unaudited components in a11y audit

### DIFF
--- a/packages/ui/src/components/Action/CopyButton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Action/CopyButton/__stories__/index.stories.tsx
@@ -14,10 +14,10 @@ export default {
   title: 'UI/Action/CopyButton',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof CopyButton>

--- a/packages/ui/src/components/Action/Expandable/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Action/Expandable/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Action/Expandable',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Action/Link/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Action/Link/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Action/Link',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Action/SwitchButton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Action/SwitchButton/__stories__/index.stories.tsx
@@ -9,10 +9,10 @@ export default {
   title: 'UI/Action/SwitchButton',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Badges/Chip/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Badges/Chip/__stories__/index.stories.tsx
@@ -16,10 +16,10 @@ export default {
   title: 'UI/Badges/Chip',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Chip>

--- a/packages/ui/src/components/Data Display/BarStack/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/BarStack/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Display/BarStack',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof BarStack>

--- a/packages/ui/src/components/Data Display/Carousel/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/Carousel/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   subcomponents: { 'Carousel.Item': Carousel.Item },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Carousel>

--- a/packages/ui/src/components/Data Display/Chart/BarChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/Chart/BarChart/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Display/Chart/BarChart',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof BarChart>

--- a/packages/ui/src/components/Data Display/Chart/LineChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/Chart/LineChart/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   parameters: {
     a11y: false,
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/Data Display/Chart/PieChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/Chart/PieChart/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   parameters: {
     a11y: false,
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/Data Display/Chart/TreeMapChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/Chart/TreeMapChart/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   parameters: {
     a11y: false,
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/Data Display/EmptyState/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/EmptyState/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Display/EmptyState',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof EmptyState>

--- a/packages/ui/src/components/Data Display/InfiniteScroll/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/InfiniteScroll/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Display/InfiniteScroll',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Data Display/List/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/List/__stories__/index.stories.tsx
@@ -10,10 +10,10 @@ export default {
   },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof List>

--- a/packages/ui/src/components/Data Display/Snippet/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/Snippet/__stories__/index.stories.tsx
@@ -14,10 +14,10 @@ export default {
   title: 'UI/Data Display/Snippet',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Snippet>

--- a/packages/ui/src/components/Data Display/StepList/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/StepList/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   parameters: {
     a11y: false,
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/Data Display/Table/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Display/Table/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   subcomponents: { 'Table.Row': Table.Row, 'Table.Cell': Table.Cell },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Data Entry/KeyValueInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/KeyValueInput/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Entry/KeyValueInput',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof KeyValueInput>

--- a/packages/ui/src/components/Data Entry/SearchInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/SearchInput/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Entry/SearchInput',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof SearchInput>

--- a/packages/ui/src/components/Data Entry/SelectableCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/SelectableCard/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Entry/SelectableCard',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof SelectableCard>

--- a/packages/ui/src/components/Data Entry/SelectableCardGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/SelectableCardGroup/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Entry/SelectableCardGroup',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof SelectableCardGroup>

--- a/packages/ui/src/components/Data Entry/SelectableCardOptionGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/SelectableCardOptionGroup/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Entry/SelectableCardOptionGroup',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof SelectableCardOptionGroup>

--- a/packages/ui/src/components/Data Entry/TagInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/TagInput/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Entry/TagInput',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Data Entry/TimeInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/TimeInput/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   decorators: [Story => <Story />],
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof TimeInput>

--- a/packages/ui/src/components/Data Entry/Toggle/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/Toggle/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Data Entry/Toggle',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Toggle>

--- a/packages/ui/src/components/Data Entry/ToggleGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/ToggleGroup/__stories__/index.stories.tsx
@@ -18,10 +18,10 @@ export default {
   },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof ToggleGroup>

--- a/packages/ui/src/components/Data Entry/UnitInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Data Entry/UnitInput/__stories__/index.stories.tsx
@@ -13,10 +13,10 @@ export default {
   ],
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Feedback/GlobalAlert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/GlobalAlert/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   subcomponents: { 'GlobalAlert.Link': GlobalAlert.Link },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Feedback/Loader/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/Loader/__stories__/index.stories.tsx
@@ -14,10 +14,10 @@ export default {
   ],
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Feedback/Meter/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/Meter/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Feedback/Meter',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Meter>

--- a/packages/ui/src/components/Feedback/Notice/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/Notice/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Feedback/Notice',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Notice>

--- a/packages/ui/src/components/Feedback/Notification/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/Notification/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Feedback/Notification',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof NotificationContainer>

--- a/packages/ui/src/components/Feedback/PasswordCheck/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/PasswordCheck/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Feedback/PasswordCheck',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof PasswordCheck>

--- a/packages/ui/src/components/Feedback/ProgressBar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/ProgressBar/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Feedback/ProgressBar',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof ProgressBar>

--- a/packages/ui/src/components/Feedback/Skeleton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/Skeleton/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Feedback/Skeleton',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Skeleton>

--- a/packages/ui/src/components/Feedback/Status/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/Status/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Feedback/Status',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Feedback/Toaster/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Feedback/Toaster/__stories__/index.stories.tsx
@@ -11,10 +11,10 @@ export default {
   parameters: {
     a11y: false,
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 }

--- a/packages/ui/src/components/Layout/Card/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Layout/Card/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Layout/Card',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Layout/ExpandableCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Layout/ExpandableCard/__stories__/index.stories.tsx
@@ -9,10 +9,10 @@ export default {
   },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Layout/Row/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Layout/Row/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Layout/Row',
   parameters: {
     a11yStatus: {
-      perceivable: undefined,
-      operable: undefined,
-      understandable: undefined,
-      robust: undefined,
+      perceivable: true,
+      operable: true,
+      understandable: true,
+      robust: true,
     },
   },
 } as Meta<typeof Row>

--- a/packages/ui/src/components/Layout/Row/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Layout/Row/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Layout/Row',
   parameters: {
     a11yStatus: {
-      perceivable: true,
-      operable: true,
-      understandable: true,
-      robust: true,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Row>

--- a/packages/ui/src/components/Layout/Separator/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Layout/Separator/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Layout/Separator',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Layout/Stack/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Layout/Stack/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Layout/Stack',
   parameters: {
     a11yStatus: {
-      perceivable: true,
-      operable: true,
-      understandable: true,
-      robust: true,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Stack>

--- a/packages/ui/src/components/Layout/Stack/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Layout/Stack/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Layout/Stack',
   parameters: {
     a11yStatus: {
-      perceivable: undefined,
-      operable: undefined,
-      understandable: undefined,
-      robust: undefined,
+      perceivable: true,
+      operable: true,
+      understandable: true,
+      robust: true,
     },
   },
 } as Meta<typeof Stack>

--- a/packages/ui/src/components/Navigation/Breadcrumbs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Navigation/Breadcrumbs/__stories__/index.stories.tsx
@@ -8,10 +8,10 @@ export default {
   title: 'UI/Navigation/Breadcrumbs',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Navigation/Pagination/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Navigation/Pagination/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   parameters: {
     a11y: false,
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 }

--- a/packages/ui/src/components/Navigation/Stepper/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Navigation/Stepper/__stories__/index.stories.tsx
@@ -10,10 +10,10 @@ export default {
   title: 'UI/Navigation/Stepper',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Navigation/Tabs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Navigation/Tabs/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   title: 'UI/Navigation/Tabs',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Tabs>

--- a/packages/ui/src/components/Other/Avatar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Other/Avatar/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Other/Avatar',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Other/Banner/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Other/Banner/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Other/Banner',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Banner>

--- a/packages/ui/src/components/Overlay/ActionBar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Overlay/ActionBar/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   tags: [],
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } satisfies Meta<typeof ActionBar>

--- a/packages/ui/src/components/Overlay/Dialog/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Overlay/Dialog/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Overlay/Dialog',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Dialog>

--- a/packages/ui/src/components/Overlay/Drawer/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Overlay/Drawer/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Overlay/Drawer',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta<typeof Drawer>

--- a/packages/ui/src/components/Overlay/Menu/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Overlay/Menu/__stories__/index.stories.tsx
@@ -12,10 +12,10 @@ export default {
   ],
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
 
     docs: {

--- a/packages/ui/src/components/Typography/Label/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Typography/Label/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Typography/Label',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Typography/Text/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Typography/Text/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'UI/Typography/Text',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
   },
 } as Meta

--- a/packages/ui/src/compositions/CodeEditor/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/CodeEditor/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/CodeEditor',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/ContentCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/ContentCard/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/ContentCard',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/ContentCardGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/ContentCardGroup/__stories__/index.stories.tsx
@@ -7,10 +7,10 @@ export default {
   subcomponents: { 'ContentCardGroup.Card': ContentCardGroup.Card },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/Conversation/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Conversation/__stories__/index.stories.tsx
@@ -12,10 +12,10 @@ export default {
   title: 'Compositions/Conversation',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/CustomerSatisfaction/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/CustomerSatisfaction/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/CustomerSatisfaction',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/EstimateCost/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/EstimateCost/__stories__/index.stories.tsx
@@ -22,10 +22,10 @@ export default {
   title: 'Compositions/EstimateCost',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/FAQ/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/FAQ/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/FAQ',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/InfoTable/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/InfoTable/__stories__/index.stories.tsx
@@ -12,10 +12,10 @@ export default {
   },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
@@ -14,10 +14,10 @@ export default {
   },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
     layout: 'fullscreen',

--- a/packages/ui/src/compositions/OfferList/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OfferList/__stories__/index.stories.tsx
@@ -11,10 +11,10 @@ export default {
   },
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/OptionSelector/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OptionSelector/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/OptionSelector',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/OrderSummary/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OrderSummary/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/OrderSummary',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/Plans/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Plans/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/Plans',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/SteppedListCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/SteppedListCard/__stories__/index.stories.tsx
@@ -6,10 +6,10 @@ export default {
   title: 'Compositions/SteppedListCard',
   parameters: {
     a11yStatus: {
-      perceivable: false,
-      operable: false,
-      understandable: false,
-      robust: false,
+      perceivable: undefined,
+      operable: undefined,
+      understandable: undefined,
+      robust: undefined,
     },
     experimental: true,
   },

--- a/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
+++ b/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
@@ -20,7 +20,7 @@ type ComponentInfo = {
     icon: ReactNode
     description: ReactNode
   }
-  a11yLevel: A11yLevel | null
+  a11yLevel: A11yLevel
   a11yStatus: ComponentA11yStatus
   auditCategories: AuditCategories
 }

--- a/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
+++ b/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
@@ -1,6 +1,7 @@
 import { linkTo } from '@storybook/addon-links'
 import { CheckCircleIcon } from '@ultraviolet/icons/CheckCircleIcon'
 import { CloseCircleOutlineIcon } from '@ultraviolet/icons/CloseCircleOutlineIcon'
+import { HelpCircleOutlineIcon } from '@ultraviolet/icons/HelpCircleOutlineIcon'
 import { Button, Stack, Table, Text, Tooltip, ProgressBar, Link } from '@ultraviolet/ui'
 import { useState, useEffect } from 'react'
 import type { ReactNode } from 'react'
@@ -95,17 +96,19 @@ const AccessibilityAudit = () => {
           Accessibility Levels
         </Text>
         <Stack gap={2} direction="row">
-          {Object.entries(A11Y_LEVELS).map(([key, { icon, label, description }]) => (
-            <Stack key={key} gap={1} justifyContent="left">
-              <Stack direction="row" gap={1} alignItems="center">
-                {icon}
-                <Text as="h3" variant="headingSmall" style={{ margin: 0 }}>
-                  {label}
-                </Text>
+          {Object.entries(A11Y_LEVELS)
+            .filter(([key]) => key !== 'unknown')
+            .map(([key, { icon, label, description }]) => (
+              <Stack key={key} gap={1} justifyContent="left">
+                <Stack direction="row" gap={1} alignItems="center">
+                  {icon}
+                  <Text as="h3" variant="headingSmall" style={{ margin: 0 }}>
+                    {label}
+                  </Text>
+                </Stack>
+                {description}
               </Stack>
-              {description}
-            </Stack>
-          ))}
+            ))}
         </Stack>
       </Stack>
 
@@ -186,32 +189,41 @@ const AccessibilityAudit = () => {
                       </Button>
                     </Table.Cell>
                     <Table.Cell>
-                      {component.a11yLevel ? (
+                      {component.a11yLevel === 'unknown' ? (
+                        <Stack direction="row" gap={0.5} alignItems="center">
+                          <HelpCircleOutlineIcon size="medium" sentiment="neutral" />
+                          <Text as="span" variant="body">
+                            Not audited
+                          </Text>
+                        </Stack>
+                      ) : (
                         <Stack direction="row" gap={0.5} alignItems="center">
                           {A11Y_LEVELS[component.a11yLevel].icon}
                           <Text as="span" variant="body">
                             {A11Y_LEVELS[component.a11yLevel].label}
                           </Text>
                         </Stack>
-                      ) : (
-                        <Text as="span" variant="body">
-                          -
-                        </Text>
                       )}
                     </Table.Cell>
                     <Table.Cell>
                       <Stack direction="row" gap={1}>
-                        {component.auditCategories.map(category => (
-                          <Text as="span" key={category.id} variant="bodySmall">
-                            <Tooltip text={category.label}>
-                              {category.completed ? (
-                                <CheckCircleIcon size="medium" sentiment="success" />
-                              ) : (
-                                <CloseCircleOutlineIcon size="medium" sentiment="danger" />
-                              )}
-                            </Tooltip>
+                        {component.a11yLevel !== 'unknown' ? (
+                          component.auditCategories.map(category => (
+                            <Text as="span" key={category.id} variant="bodySmall">
+                              <Tooltip text={category.label}>
+                                {category.completed ? (
+                                  <CheckCircleIcon size="medium" sentiment="success" />
+                                ) : (
+                                  <CloseCircleOutlineIcon size="medium" sentiment="danger" />
+                                )}
+                              </Tooltip>
+                            </Text>
+                          ))
+                        ) : (
+                          <Text as="span" variant="body">
+                            -
                           </Text>
-                        ))}
+                        )}
                       </Stack>
                     </Table.Cell>
                   </Table.Row>

--- a/utils/stories/src/AccessibilityAudit/constants.tsx
+++ b/utils/stories/src/AccessibilityAudit/constants.tsx
@@ -1,4 +1,9 @@
-import { SettingsOutlineIcon, ShieldCheckOutlineIcon, ProgressCheckIcon } from '@ultraviolet/icons'
+import {
+  SettingsOutlineIcon,
+  ShieldCheckOutlineIcon,
+  ProgressCheckIcon,
+  InformationOutlineIcon,
+} from '@ultraviolet/icons'
 import { Text } from '@ultraviolet/ui'
 import type { A11yLevel, A11yLevelInfo } from './types'
 
@@ -10,6 +15,16 @@ export const WCAG_PRINCIPLES = [
 ] as const
 
 export const A11Y_LEVELS: Record<A11yLevel, A11yLevelInfo> = {
+  unknown: {
+    level: 'unknown',
+    icon: <InformationOutlineIcon size="medium" sentiment="neutral" />,
+    label: 'Unknown',
+    description: (
+      <Text as="p" variant="body">
+        A11y Unknown means the component has not been audited yet.
+      </Text>
+    ),
+  },
   partial: {
     level: 'partial',
     icon: <SettingsOutlineIcon size="medium" sentiment="danger" />,

--- a/utils/stories/src/AccessibilityAudit/helpers.ts
+++ b/utils/stories/src/AccessibilityAudit/helpers.ts
@@ -19,9 +19,12 @@ export const getComponentAuditCategories = (parameters: ComponentStoryParameters
   }))
 }
 
+export const isComponentAudited = (parameters: ComponentStoryParameters): boolean =>
+  Boolean(parameters?.a11yStatus) && WCAG_PRINCIPLES.some(p => parameters.a11yStatus?.[p.name] !== undefined)
+
 export const findA11yLevel = (parameters: { a11yStatus?: ComponentA11yStatus }): A11yLevel => {
-  if (!parameters?.a11yStatus) {
-    return 'partial'
+  if (!isComponentAudited(parameters)) {
+    return 'unknown'
   }
 
   return WCAG_PRINCIPLES.every(principle => parameters.a11yStatus?.[principle.name] === true) ? 'compliant' : 'partial'

--- a/utils/stories/src/AccessibilityAudit/types.ts
+++ b/utils/stories/src/AccessibilityAudit/types.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import type { WCAG_PRINCIPLES } from './constants'
 
-export type A11yLevel = 'partial' | 'compliant' | 'certified'
+export type A11yLevel = 'unknown' | 'partial' | 'compliant' | 'certified'
 
 export type A11yLevelInfo = {
   level: A11yLevel


### PR DESCRIPTION
### Summary

- Mark components without an `A11y.mdx` audit as unaudited by setting their `a11yStatus` flags to `undefined` instead of `false`. This differentiates components that haven't been audited from those that fail all checks.
- In the Accessibility Audit page, add a new `unknown` a11y level: unaudited components now display **"Not audited"**.

### Screenshots

|   Before   |   After    |
| :--------: | :--------: |
| <img width="1086" height="1116" alt="image" src="https://github.com/user-attachments/assets/7e15371e-ae1a-4edd-a937-0ff7ce03a1b6" /> |<img width="1083" height="1118" alt="image" src="https://github.com/user-attachments/assets/6e556ab7-b933-43c9-a4ba-08efc37c2275" /> |