### PR TITLE
fix: update Flag and Submit props

### DIFF
--- a/.changeset/flag-submit-props.md
+++ b/.changeset/flag-submit-props.md
@@ -1,0 +1,8 @@
+---
+"@ultraviolet/form": patch
+"@ultraviolet/icons": patch
+---
+
+`Submit` now spreads all `Button` props, adding `accessibleLabel`, `tooltipLabel` and `tooltipDescription`.
+
+`Flag`: `accessibleLabel` is now a `string` (the flag's accessible name) instead of a boolean, and `className`/`aria-hidden` are now accepted via `SVGProps`.

--- a/.changeset/strict-lamps-press.md
+++ b/.changeset/strict-lamps-press.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Tooltip`: remove event listeners when the tooltip is mounted but not visible, avoid re-renders of the target element

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   publish:
-    if: contains(github.event.pull_request.labels.*.name, 'pkg-pr-new')
+    if: contains(github.event.pull_request.labels.*.name, 'publish-pr')
     runs-on: ubuntu-24.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/packages/form/src/components/Submit/index.tsx
+++ b/packages/form/src/components/Submit/index.tsx
@@ -13,7 +13,17 @@ type SubmitButtonProps = {
 } & Partial<
   Pick<
     ComponentProps<typeof Button>,
-    'size' | 'sentiment' | 'variant' | 'tooltip' | 'fullWidth' | 'onClick' | 'disabled' | 'className'
+    | 'size'
+    | 'sentiment'
+    | 'variant'
+    | 'tooltip'
+    | 'accessibleLabel'
+    | 'tooltipLabel'
+    | 'tooltipDescription'
+    | 'fullWidth'
+    | 'onClick'
+    | 'disabled'
+    | 'className'
   >
 >
 
@@ -21,33 +31,16 @@ type SubmitProps<TFieldValues extends FieldValues> = RHFBase<TFieldValues> & Sub
 
 export const Submit = <TFieldValues extends FieldValues>({
   children,
-  className,
-  disabled = false,
-  size,
-  variant = 'filled',
-  sentiment = 'primary',
-  tooltip,
-  fullWidth,
-  onClick,
   control,
+  disabled = false,
+  ...props
 }: SubmitProps<TFieldValues>) => {
   const { isSubmitting, isValid } = useFormState({ control })
 
   const isDisabled = disabled || isSubmitting || !isValid
 
   return (
-    <Button
-      className={className}
-      disabled={isDisabled}
-      fullWidth={fullWidth}
-      isLoading={isSubmitting}
-      onClick={onClick}
-      sentiment={sentiment}
-      size={size}
-      tooltipDescription={tooltip}
-      type="submit"
-      variant={variant}
-    >
+    <Button disabled={isDisabled} isLoading={isSubmitting} type="submit" {...props}>
       {children}
     </Button>
   )

--- a/packages/icons/src/components/Flags/Icon.tsx
+++ b/packages/icons/src/components/Flags/Icon.tsx
@@ -1,18 +1,16 @@
 'use client'
 
 import { cn } from '@ultraviolet/utils'
-import type { ReactNode } from 'react'
+import type { ReactNode, SVGProps } from 'react'
 import type { SIZES } from './constant'
 import { flag } from './style.css'
 
 export type IconProps = {
   size?: keyof typeof SIZES
-  className?: string
   children: ReactNode
   disabled?: boolean
-  accessibleLabel?: boolean
-  'aria-hidden'?: boolean
-}
+  accessibleLabel?: string
+} & Pick<SVGProps<SVGSVGElement>, 'className' | 'aria-hidden'>
 
 /**
  * Logo component is used to render a set of flags. Their style cannot be changed

--- a/packages/ui/src/components/Overlay/Tooltip/TooltipChildren.tsx
+++ b/packages/ui/src/components/Overlay/Tooltip/TooltipChildren.tsx
@@ -74,7 +74,7 @@ export const TooltipChildren = ({
     }
 
     return clearAriaAttribute
-  }, [tooltip, tabIndex, ariaAttributeName, ariaAttributeValue])
+  }, [tooltip.refs, tabIndex, ariaAttributeName, ariaAttributeValue])
 
   if (typeof children === 'function') {
     return children({

--- a/packages/ui/src/components/Overlay/Tooltip/useTooltip.ts
+++ b/packages/ui/src/components/Overlay/Tooltip/useTooltip.ts
@@ -14,7 +14,7 @@ import {
   useDismiss,
   useInteractions,
 } from '@floating-ui/react'
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import type { CSSProperties } from 'react'
 import type { TooltipPlacement } from './types'
 
@@ -49,13 +49,20 @@ export const useTooltip = ({ visible, placement, delay, transitionDuration, onOp
     context,
     middlewareData,
     placement: finalPlacement,
+    elements,
+    update,
   } = useFloating({
     open,
     onOpenChange: setOpen,
     middleware: [offset(8), flip(), shift(), arrow({ element: arrowRef, padding: 4 })],
-    whileElementsMounted: autoUpdate,
     placement: (placement.replace(/auto-?/, '') || 'top') as Placement,
   })
+
+  useEffect(() => {
+    if (!open || !elements.reference || !elements.floating) return
+    const cleanup = autoUpdate(elements.reference, elements.floating, update)
+    return cleanup
+  }, [open, elements.reference, elements.floating, update])
 
   const { isMounted, status } = useTransitionStatus(context, {
     duration: transitionDuration,


### PR DESCRIPTION
### Summary

- **Submit** (`@ultraviolet/form`): spread all `Button` props directly, adding `accessibleLabel`, `tooltipLabel` and `tooltipDescription` instead of listing a subset individually.
- **Flag (Icon)** (`@ultraviolet/icons`): `accessibleLabel` is now a `string` (the flag's accessible name) instead of a boolean, and `className`/`aria-hidden` are now accepted via `SVGProps`.

### Screenshots

_No visual change._