### PR TITLE
fix(Pagination): numberOfItemsText typo

### DIFF
--- a/.changeset/few-pandas-think.md
+++ b/.changeset/few-pandas-think.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Pagination`: fix typo in default `numberOfItemsText`

--- a/packages/ui/src/components/Navigation/Pagination/PerPage.tsx
+++ b/packages/ui/src/components/Navigation/Pagination/PerPage.tsx
@@ -73,7 +73,7 @@ export const PerPage = ({
       />
       <Text as="span" prominence="weak" sentiment="neutral" variant="body">
         {(page - 1) * perPage + 1}-{Math.min(page * perPage, numberOfItems)}{' '}
-        {numberOfItemsText ?? `of ${numberOfItems} items"`}
+        {numberOfItemsText ?? `of ${numberOfItems} items`}
       </Text>
     </Stack>
   )

--- a/packages/ui/src/components/Navigation/Pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Navigation/Pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -1162,7 +1162,7 @@ exports[`pagination > should render correctly with perPage - default values 1`] 
         <span
           class="style__1do42ls0 style_prominence_weak__1do42ls7 style_sentiment_neutral__1do42lsb style_variant_body__1do42lsj style_undefined_compound_3__1do42ls1d style_undefined_compound_67__1do42ls35"
         >
-          11-20 of 100 items"
+          11-20 of 100 items
         </span>
       </div>
       <div


### PR DESCRIPTION
### Summary

`Pagination`: fix typo in default `numberOfItemsText`
