### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,2 @@
 *                        @jsulpis @lisalupi
-**/package.json          @scaleway/front-kernel
-Dockerfile                @scaleway/front-kernel
-tsconfig.json             @scaleway/front-kernel
-.oxlintrc.jsonc            @scaleway/front-kernel
-oxfmt.config.ts            @scaleway/front-kernel
-vite.config.ts            @scaleway/front-kernel
-vitest.setup.ts            @scaleway/front-kernel
-vitest.config.ts            @scaleway/front-kernel
-turbo.json               @scaleway/front-kernel
-pnpm-workspace.yaml      @scaleway/front-kernel
-svgo.config.mjs           @scaleway/front-kernel
-.github                  @scaleway/front-kernel
-.changeset/config.json    @scaleway/front-kernel
-.aws                     @scaleway/front-kernel
-e2e                     @scaleway/front-kernel
-utils                     @scaleway/front-kernel
 **/A11y.mdx              @iManu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,18 @@
 *                        @jsulpis @lisalupi
+**/package.json          @philibea
+Dockerfile                @philibea
+tsconfig.json             @philibea
+.oxlintrc.jsonc            @philibea
+oxfmt.config.ts            @philibea
+vite.config.ts            @philibea
+vitest.setup.ts            @philibea
+vitest.config.ts            @philibea
+turbo.json               @philibea
+pnpm-workspace.yaml      @philibea
+svgo.config.mjs           @philibea
+.github                  @philibea
+.changeset/config.json    @philibea
+.aws                     @philibea
+e2e                     @philibea
+utils                     @philibea
 **/A11y.mdx              @iManu


### PR DESCRIPTION
### Summary

Remove all `@scaleway/front-kernel` code owners from CODEOWNERS. Keep `@jsulpis` and `@lisalupi` as owners of everything, and `@iManu` on `A11y.mdx` files.