### PR TITLE
fix(OrderSummary): display non undefined details

### DIFF
--- a/.changeset/fancy-dolls-hope.md
+++ b/.changeset/fancy-dolls-hope.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`OrderSummary`: display categories, sub-categories and details when values are **defined** instead of **truthy** (categories/sub-categories/details with title=0 or title="" can now be displayed)

--- a/packages/ui/src/compositions/OrderSummary/ScrollableContent.tsx
+++ b/packages/ui/src/compositions/OrderSummary/ScrollableContent.tsx
@@ -1,3 +1,4 @@
+import { isNullOrUndefined } from '@ultraviolet/utils'
 import { useContext } from 'react'
 import { Stack } from '../../components/Layout/Stack'
 import { CategoryName } from './components/Category'
@@ -11,7 +12,7 @@ export const ScrollableContent = () => {
   return (
     <Stack className={orderSummaryStyle.scrollableContainer} gap={3}>
       {items.map(category =>
-        Object.keys(category).length > 0 && category.category ? (
+        Object.keys(category).length > 0 && !isNullOrUndefined(category.category) ? (
           <Stack className={orderSummaryStyle.category} gap={1.5} key={category.category}>
             {category.subTitle ? (
               <Stack direction="column">

--- a/packages/ui/src/compositions/OrderSummary/__stories__/productsExample.tsx
+++ b/packages/ui/src/compositions/OrderSummary/__stories__/productsExample.tsx
@@ -19,7 +19,7 @@ export const categoryDefault = {
   subCategories: [
     {
       additionalInfo: <AdditionalInfo />,
-      details: ['Detail 1', 'Detail 2'],
+      details: ['Detail 1', 'Detail 2', 0],
       price: 12.2,
       title: 'SubCategory',
     },

--- a/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,198 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`orderSummary > display titles that are defined and falsy 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <div
+      class="styles__11nvx2k0 styles_backgroundProminence_default__11nvx2k1 styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_justifyContent_space-between_xxsmall__xf61n477"
+    >
+      <div
+        class="styles_showDetails__11nvx2k5 styles__11nvx2k3 styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_row_xxsmall__xf61n42j styles_gap_1rem_xxsmall__xf61n43v styles_justifyContent_space-between_xxsmall__xf61n477"
+      >
+        <h3
+          class="style__1do42ls0 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_headingSmallStrong__1do42ls16 style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33"
+        >
+          summary
+        </h3>
+        <div
+          class="styles__11nvx2k6 styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d"
+        >
+          <div
+            class="styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_0.25rem_xxsmall__xf61n45j"
+            style="--_1d8tbmb1: 200px;"
+          >
+            <div
+              class="styles_small__bjgo2pe styles_default__bjgo2p6 styles__bjgo2p5 styles__1w3vbem0"
+              style="--_85qyp70: 2fr 3fr; --_85qyp71: 2fr 3fr; --_85qyp72: 2fr 3fr; --_85qyp73: 2fr 3fr; --_85qyp74: 2fr 3fr; --_85qyp75: 2fr 3fr;"
+            >
+              <div
+                class="styles__bjgo2pb"
+                id="input-field"
+              >
+                <input
+                  aria-invalid="false"
+                  class="styles_small__bjgo2p4 styles__bjgo2p1"
+                  data-testid="unit-input"
+                  id="_r_1ek_"
+                  max="9007199254740991"
+                  min="0"
+                  name="-value"
+                  placeholder="0"
+                  step="1"
+                  type="number"
+                  value="1"
+                />
+              </div>
+              <div
+                aria-label="-unit"
+                class="styles__bjgo2pg styles__bjgo2pf styles__ei8oq30"
+                style="--bjgo2p0: 100%;"
+              >
+                <div
+                  aria-controls="_r_1eo_"
+                  aria-describedby="_r_1eo_"
+                  class="styles__10e61c29 styles_fullWidth_true__10e61c2b"
+                  tabindex="-1"
+                >
+                  <div
+                    class="styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_0.25rem_xxsmall__xf61n45j"
+                  >
+                    <div
+                      aria-controls="_r_1eo_"
+                      aria-expanded="false"
+                      class="selectBar__1xo4j4b6 selectBar__1xo4j4b5 selectBar_size_small__1xo4j4bc selectBar_state_neutral__1xo4j4be"
+                      data-disabled="false"
+                      data-readonly="false"
+                      data-testid="select-input--unit"
+                      id="unit"
+                      role="combobox"
+                      tabindex="0"
+                    >
+                      <span
+                        class="selectBar__1xo4j4bm style__1do42ls0 style_prominence_default__1do42ls4 style_sentiment_neutral__1do42lsb style_variant_bodySmall__1do42lsk style_undefined_compound_0__1do42ls1a style_undefined_compound_64__1do42ls32"
+                      >
+                        Hour(s)
+                      </span>
+                      <div
+                        class="selectBar_small__1xo4j4b3 styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_row_xxsmall__xf61n42j styles_gap_0.5rem_xxsmall__xf61n43p"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkz9 uv_icons_1sbwqkzf uv_icons_1sbwqkz1i"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="styles__11nvx2kb styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_1.5rem_xxsmall__xf61n441"
+      >
+        <div
+          class="styles__11nvx2kd styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_0.75rem_xxsmall__xf61n45p"
+        >
+          <div
+            class="styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_row_xxsmall__xf61n42j styles_gap_1rem_xxsmall__xf61n43v styles_justifyContent_space-between_xxsmall__xf61n477"
+          >
+            <span
+              class="style__1do42ls0 style_oneLine_true__1do42ls3 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_bodyStrong__1do42lsn style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33 style__1do42ls3e"
+            />
+            <span
+              class="styles__11nvx2kl style__1do42ls0 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_bodyStrong__1do42lsn style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33"
+            >
+              €10
+            </span>
+          </div>
+          <div
+            class="styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_0.5rem_xxsmall__xf61n43p"
+          >
+            <div
+              class="styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_0.5rem_xxsmall__xf61n43p"
+            >
+              <div
+                class="styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_row_xxsmall__xf61n42j styles_gap_1rem_xxsmall__xf61n43v styles_justifyContent_space-between_xxsmall__xf61n477"
+              >
+                <span
+                  class="style__1do42ls0 style_oneLine_true__1do42ls3 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_bodySmallStrong__1do42lsl style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33 style__1do42ls3e"
+                />
+                <span
+                  class="styles__11nvx2kl style__1do42ls0 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_bodySmallStrong__1do42lsl style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33"
+                >
+                  €10
+                </span>
+              </div>
+              <div
+                class="styles__11nvx2kc styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_0.25rem_xxsmall__xf61n45j"
+              >
+                <span
+                  class="style__1do42ls0 style_prominence_default__1do42ls4 style_sentiment_neutral__1do42lsb style_variant_bodySmall__1do42lsk style_undefined_compound_0__1do42ls1a style_undefined_compound_64__1do42ls32"
+                >
+                  0
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="styles__11nvx2k7 styles_compact_false__11nvx2k8 styles__xf61n40 styles_flexDirection_column_xxsmall__xf61n42d styles_gap_1.5rem_xxsmall__xf61n441"
+      >
+        <div
+          class="styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_row_xxsmall__xf61n42j styles_justifyContent_space-between_xxsmall__xf61n477"
+        >
+          <div
+            class="styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_row_xxsmall__xf61n42j styles_gap_0.5rem_xxsmall__xf61n43p"
+          >
+            <span
+              class="style__1do42ls0 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_bodyStrong__1do42lsn style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33"
+              style="--textAlign__1giziax0: right;"
+            >
+              Estimated cost:
+            </span>
+          </div>
+          <div
+            class="styles__xf61n40 styles_alignItems_flex-end_xxsmall__xf61n411 styles_flexDirection_column_xxsmall__xf61n42d"
+          >
+            <div
+              class="styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_row_xxsmall__xf61n42j styles_gap_0.5rem_xxsmall__xf61n43p"
+            >
+              <span
+                class="style__1do42ls0 style_prominence_weak__1do42ls7 style_sentiment_neutral__1do42lsb style_strikeThrough_true__1do42lsh style_variant_bodySmallStrong__1do42lsl style_undefined_compound_3__1do42ls1d style_undefined_compound_67__1do42ls35"
+                style="--textAlign__1giziax0: right;"
+              >
+                €10
+              </span>
+              <span
+                class="styles_default__11nvx2kj style__1do42ls0 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_headingSmallStrong__1do42ls16 style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33"
+                data-testid="total-price"
+                style="--textAlign__1giziax0: right;"
+              >
+                €5
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`orderSummary > should work with additionalInfo 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ui/src/compositions/OrderSummary/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/OrderSummary/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { renderWithTheme, shouldMatchSnapshot } from '@utils/test'
+import { renderWithTheme } from '@utils/test'
 import { describe, expect, it } from 'vitest'
 import { OrderSummary } from '..'
 import {
@@ -12,6 +12,7 @@ import {
   categoryOptions,
   categoryRequest,
   categoryStorage,
+  falsyCategory,
   fixePrice,
   negativeItem,
   numberInputCategory,
@@ -33,14 +34,23 @@ const mockItems = [
 ]
 
 describe('orderSummary', () => {
-  it('should work with default props', () => shouldMatchSnapshot(<OrderSummary items={mockItems} />))
+  it('should work with default props', () => {
+    const { asFragment } = renderWithTheme(<OrderSummary items={mockItems} />)
 
-  it('should work with an empty list of item', () => shouldMatchSnapshot(<OrderSummary items={[]} />))
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work without unitInput', () =>
-    shouldMatchSnapshot(
+  it('should work with an empty list of item', () => {
+    const { asFragment } = renderWithTheme(<OrderSummary items={[]} />)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should work without unitInput', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary currency="EUR" header="summary" hideTimeUnit items={mockItems} localeFormat="en-EN" />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
   it('should work with custom timeUnit', async () => {
     renderWithTheme(
@@ -68,20 +78,24 @@ describe('orderSummary', () => {
     expect(screen.getByTestId('total-price').textContent).toBe('€2.50')
   })
 
-  it('should work with children', () =>
-    shouldMatchSnapshot(
+  it('should work with children', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary currency="EUR" header="summary" items={mockItems} localeFormat="en-EN">
         children
       </OrderSummary>,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with footer', () =>
-    shouldMatchSnapshot(
+  it('should work with footer', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary currency="EUR" footer="footer" header="summary" items={mockItems} localeFormat="en-EN" />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with price information', () =>
-    shouldMatchSnapshot(
+  it('should work with price information', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary
         currency="EUR"
         footer="footer"
@@ -90,10 +104,12 @@ describe('orderSummary', () => {
         localeFormat="en-EN"
         priceInformation="Information"
       />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with price information boolean', () =>
-    shouldMatchSnapshot(
+  it('should work with price information boolean', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary
         currency="EUR"
         footer="footer"
@@ -102,15 +118,19 @@ describe('orderSummary', () => {
         localeFormat="en-EN"
         priceInformation
       />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with price as a range', () =>
-    shouldMatchSnapshot(
+  it('should work with price as a range', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary currency="EUR" footer="footer" header="summary" items={[rangePriceContent]} localeFormat="en-EN" />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with totalPriceInfo', () =>
-    shouldMatchSnapshot(
+  it('should work with totalPriceInfo', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary
         currency="EUR"
         header="summary"
@@ -118,10 +138,12 @@ describe('orderSummary', () => {
         localeFormat="en-EN"
         totalPriceInfo="total price info"
       />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with totalPriceInfo and totalPriceInfoPlacement', () =>
-    shouldMatchSnapshot(
+  it('should work with totalPriceInfo and totalPriceInfoPlacement', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary
         currency="EUR"
         header="summary"
@@ -130,10 +152,12 @@ describe('orderSummary', () => {
         totalPriceInfo="total price info"
         totalPriceInfoPlacement="right"
       />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with additionalInfo', () =>
-    shouldMatchSnapshot(
+  it('should work with additionalInfo', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary
         additionalInfo="additional info"
         currency="EUR"
@@ -143,9 +167,11 @@ describe('orderSummary', () => {
       >
         children
       </OrderSummary>,
-    ))
-  it('should work with numberInputs', () =>
-    shouldMatchSnapshot(
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+  it('should work with numberInputs', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary
         currency="EUR"
         header="summary"
@@ -153,7 +179,9 @@ describe('orderSummary', () => {
         localeFormat="en-EN"
         totalPriceInfo="total price info"
       />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
   it('should work with discount in  %', () => {
     const { asFragment } = renderWithTheme(
@@ -225,26 +253,32 @@ describe('orderSummary', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('works with hideDetails', () =>
-    shouldMatchSnapshot(
+  it('works with hideDetails', () => {
+    const { asFragment } = renderWithTheme(
       <>
         <OrderSummary header="summary" hideDetails items={[categoryAZ]} />
         <OrderSummary discount={0.5} header="summary" hideDetails items={[categoryAZ]} />
       </>,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('works compact', () =>
-    shouldMatchSnapshot(
+  it('works compact', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary header="summary" items={[categoryAZ]} compact backgroundProminence="strong" calculatorIcon />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('works with calculator icon', () =>
-    shouldMatchSnapshot(
+  it('works with calculator icon', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary header="summary" items={[categoryAZ]} compact backgroundProminence="default" calculatorIcon />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('works compact with total price info', () =>
-    shouldMatchSnapshot(
+  it('works compact with total price info', () => {
+    const { asFragment } = renderWithTheme(
       <OrderSummary
         header="summary"
         items={[categoryAZ]}
@@ -254,7 +288,9 @@ describe('orderSummary', () => {
         totalPriceInfo="Info"
         totalPriceInfoPlacement="left"
       />,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
   it('works with negative category price', () => {
     const { asFragment } = renderWithTheme(<OrderSummary header="summary" items={[categoryAZ, negativeItem]} />)
@@ -281,6 +317,24 @@ describe('orderSummary', () => {
 
     await userEvent.click(anchor1Link)
     await userEvent.click(anchor2Link)
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('display titles that are defined and falsy', async () => {
+    const { asFragment } = renderWithTheme(
+      <OrderSummary
+        currency="EUR"
+        discount={0.5}
+        fractionDigits={0}
+        header="summary"
+        items={[falsyCategory]}
+        localeFormat="en-EN"
+      />,
+    )
+
+    expect(screen.getByText('0')).toBeVisible()
+    expect(screen.getAllByText('€10')).toHaveLength(3) // price appears in category, sub-category and total price
 
     expect(asFragment()).toMatchSnapshot()
   })

--- a/packages/ui/src/compositions/OrderSummary/__tests__/resources.tsx
+++ b/packages/ui/src/compositions/OrderSummary/__tests__/resources.tsx
@@ -161,3 +161,14 @@ export const anchorProduct = {
     },
   ],
 }
+
+export const falsyCategory = {
+  category: '',
+  subCategories: [
+    {
+      price: 10,
+      title: '',
+      details: [0],
+    },
+  ],
+}

--- a/packages/ui/src/compositions/OrderSummary/components/Category.tsx
+++ b/packages/ui/src/compositions/OrderSummary/components/Category.tsx
@@ -1,4 +1,5 @@
 import { AttachIcon } from '@ultraviolet/icons/AttachIcon'
+import { isNullOrUndefined } from '@ultraviolet/utils'
 import { useContext } from 'react'
 import { NumberInput } from '../../../components/Data Entry/NumberInput'
 import { Stack } from '../../../components/Layout/Stack'
@@ -19,7 +20,7 @@ export const CategoryName = ({ category }: { category: ItemsType }) => {
     totalPriceWithDiscount: 0,
   }
 
-  return category.category ? (
+  return !isNullOrUndefined(category.category) ? (
     <Stack alignItems="center" direction="row" justifyContent="space-between" gap={2}>
       {category.additionalInfo ? (
         <Stack alignItems="center" direction="row" gap={1} wrap="wrap">

--- a/packages/ui/src/compositions/OrderSummary/components/SubCategory.tsx
+++ b/packages/ui/src/compositions/OrderSummary/components/SubCategory.tsx
@@ -1,4 +1,5 @@
 import { AttachIcon } from '@ultraviolet/icons/AttachIcon'
+import { isNullOrUndefined } from '@ultraviolet/utils'
 import { NumberInput } from '../../../components/Data Entry/NumberInput'
 import { Stack } from '../../../components/Layout/Stack'
 import { Text } from '../../../components/Typography/Text'
@@ -55,10 +56,10 @@ export const SubCategory = ({ subCategory }: { subCategory: SubCategoryType }) =
       ) : null}
       <SubCategoryPrice subCategory={subCategory} />
     </Stack>
-    {subCategory.details ? (
+    {!isNullOrUndefined(subCategory.details) ? (
       <Stack className={orderSummaryStyle.details} direction="column" gap={0.5}>
         {subCategory.details.map((detail, index) =>
-          detail ? (
+          !isNullOrUndefined(detail) ? (
             <Text as="span" key={`${subCategory.title}-${index}`} sentiment="neutral" variant="bodySmall">
               {detail}
             </Text>


### PR DESCRIPTION
### Summary

`OrderSummary`: display categories, sub-categories and details when values are **defined** instead of **truthy** (categories/sub-categories/details with title=0 or title="" can now be displayed)

