### PR TITLE
feat(Filters): hide clear all button

### DIFF
--- a/.changeset/fifty-beans-cover.md
+++ b/.changeset/fifty-beans-cover.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Filters`: new prop `hideClearAll` to hide the "Clear All" button on the main row (new property of `layout` prop)

--- a/packages/ui/src/compositions/Filters/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/compositions/Filters/__stories__/Playground.stories.tsx
@@ -42,5 +42,6 @@ Playground.args = {
   layout: {
     mainFilters: ['name', 'status', 'env'],
     templateColumns: 'repeat(auto-fit, minmax(200px, 1fr)',
+    hideClearAll: false,
   },
 }

--- a/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
@@ -525,5 +525,27 @@ describe('filters', () => {
       expect(screen.getByTestId('select-input-env')).toBeVisible()
       expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
     })
+
+    it('should be possible to hide the "clear all" button (main row only)', async () => {
+      renderWithTheme(
+        <Filters
+          config={[
+            {
+              type: 'multiselect',
+              name: 'env',
+              label: 'Environment',
+              selectAll: { label: 'All Environments' },
+              options: fiveOptions,
+            },
+          ]}
+          defaultValues={{ env: [] }}
+          labels={labels}
+          layout={{ mainFilters: [] }}
+          hideClearAllMainRow
+        />,
+      )
+
+      expect(screen.queryByRole('button', { name: 'Clear All' })).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
@@ -540,8 +540,7 @@ describe('filters', () => {
           ]}
           defaultValues={{ env: [] }}
           labels={labels}
-          layout={{ mainFilters: [] }}
-          hideClearAllMainRow
+          layout={{ hideClearAll: true }}
         />,
       )
 

--- a/packages/ui/src/compositions/Filters/parts/FiltersMainRow.tsx
+++ b/packages/ui/src/compositions/Filters/parts/FiltersMainRow.tsx
@@ -22,6 +22,7 @@ export type MainRowProps<V extends AnyObject = AnyObject> = {
     mainFilters?: (keyof V)[]
     size?: 'large' | 'medium'
     templateColumns?: ComponentProps<typeof Row>['templateColumns']
+    hideClearAll?: boolean
   }
   className?: string
 }
@@ -86,9 +87,16 @@ export const FiltersMainRow = <V extends AnyObject>({
             {filters.appliedFilters.length > 0 ? ` (${filters.appliedFilters.length})` : null}
           </Button>
         ) : null}
-        <Button onClick={handleReset} size={filterSize} variant="ghost" disabled={filters.appliedFilters.length === 0}>
-          {labels.clearAll}
-        </Button>
+        {layout?.hideClearAll ? null : (
+          <Button
+            onClick={handleReset}
+            size={filterSize}
+            variant="ghost"
+            disabled={filters.appliedFilters.length === 0}
+          >
+            {labels.clearAll}
+          </Button>
+        )}
       </Stack>
     </Row>
   )


### PR DESCRIPTION
### Summary

`Filters`: new prop `hideClearAll` to hide the "Clear All" button on the main row (new property of `layout` prop)
