### PR TITLE
fix(EmptyState): title typography

### DIFF
--- a/.changeset/giant-chefs-rush.md
+++ b/.changeset/giant-chefs-rush.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`EmptyState`: title should be bold for size medium and large

--- a/packages/ui/src/components/Data Display/EmptyState/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Data Display/EmptyState/__tests__/__snapshots__/index.test.tsx.snap
@@ -303,7 +303,7 @@ exports[`emptySpace > should work with title 1`] = `
             class="styles__xf61n40 styles_alignItems_center_xxsmall__xf61n4d styles_flexDirection_column_xxsmall__xf61n42d styles_gap_0.25rem_xxsmall__xf61n45j"
           >
             <h2
-              class="style__1do42ls0 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_headingSmall__1do42ls15 style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33"
+              class="style__1do42ls0 style_prominence_strong__1do42ls5 style_sentiment_neutral__1do42lsb style_variant_headingSmallStrong__1do42ls16 style_undefined_compound_1__1do42ls1b style_undefined_compound_65__1do42ls33"
               style="--textAlign__1giziax0: center;"
             >
               test

--- a/packages/ui/src/components/Data Display/EmptyState/index.tsx
+++ b/packages/ui/src/components/Data Display/EmptyState/index.tsx
@@ -77,7 +77,7 @@ export const EmptyState = ({
               placement="center"
               prominence="strong"
               sentiment="neutral"
-              variant={size === 'small' ? 'bodyStrong' : 'headingSmall'}
+              variant={size === 'small' ? 'bodyStrong' : 'headingSmallStrong'}
             >
               {title}
             </Text>


### PR DESCRIPTION
### Summary

`EmptyState`: title should be bold for size medium and large
