### PR TITLE
fix(TextInput): autofill style

### DIFF
--- a/.changeset/clever-rats-greet.md
+++ b/.changeset/clever-rats-greet.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`TextInput`: override browser's default "autofill" style

--- a/packages/ui/src/components/Data Entry/TextInput/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/Data Entry/TextInput/__stories__/Template.stories.tsx
@@ -9,9 +9,6 @@ export const Template: StoryFn<typeof TextInput> = ({ ...args }) => {
 }
 
 Template.args = {
-  'aria-atomic': 'true',
-  'aria-live': 'polite',
   placeholder: 'Placeholder',
-  role: 'status',
-  value: 'Text',
+  type: 'text',
 }

--- a/packages/ui/src/components/Data Entry/TextInput/styles.css.ts
+++ b/packages/ui/src/components/Data Entry/TextInput/styles.css.ts
@@ -120,6 +120,10 @@ const input = style({
   fontSize: theme.typography.bodySmall.fontSize,
   color: theme.colors.neutral.text,
   selectors: {
+    '&:autofill': {
+      WebkitBoxShadow: 'inset 0 0 0 1000px transparent',
+      transition: 'background-color 9999s ease-in-out 0s',
+    },
     '&[data-size="large"]': {
       fontSize: theme.typography.body.fontSize,
     },


### PR DESCRIPTION
### Summary

`TextInput`: override brower's default autofill background
See: [https://css-tricks.com/snippets/css/change-autocomplete-styles-webkit-browsers/](https://css-tricks.com/snippets/css/change-autocomplete-styles-webkit-browsers/)

### Screenshots

The before depends on the browser used. Firefox doesn't seem to apply any default style, so this is a fix mostly for chromium-based browers & Safari.

|browser|   Before   |   After    |
|:-:|:-:|:-:|
| chrome | <img width="205" height="92" alt="Capture d’écran 2026-09-10 à 15 05 24" src="https://github.com/user-attachments/assets/71d90d26-6eab-470b-94c2-2c79ba815fbb" />|  <img width="183" height="84" alt="Capture d’écran 2026-09-10 à 15 05 19" src="https://github.com/user-attachments/assets/f32e4d97-da75-49b9-84da-71a28fc1a1c2" />|
| safari |<img width="225" height="103" alt="Capture d’écran 2026-09-10 à 15 03 46" src="https://github.com/user-attachments/assets/007ac846-10cd-4dae-b54a-2c62651b8655" /> | <img width="174" height="90" alt="Capture d’écran 2026-09-10 à 15 03 34" src="https://github.com/user-attachments/assets/47d36bf8-d31a-48ca-8e74-62f67620c8cf" />|
