### PR TITLE
feat(ThemeProvider): new prop css layer

### DIFF
--- a/.changeset/dark-bananas-burn.md
+++ b/.changeset/dark-bananas-burn.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/themes": patch
+"@ultraviolet/ui": patch
+---
+
+`ThemeProvider`: new prop `cssLayer` to wrap default theme (css variables added in `:root` as well as default color and background-color) in a css layer

--- a/examples/next/src/pages/_app.tsx
+++ b/examples/next/src/pages/_app.tsx
@@ -71,7 +71,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   }, [])
 
   return (
-    <ThemeProvider theme={theme === 'light' ? localLightTheme : localDarkTheme}>
+    <ThemeProvider theme={theme === 'light' ? localLightTheme : localDarkTheme} cssLayer="next-app">
       <Head />
       <Grid>
         <Header className={styles.header} setTheme={setThemes} />

--- a/examples/next/styles/global.css
+++ b/examples/next/styles/global.css
@@ -4,6 +4,9 @@ html {
 
 body {
   font-family: var(--typography-body-font-family);
+  background: var(
+    --color-neutral-background
+  ); /* it should override ThemeProvider's background-color, since a @layer is used */
 }
 
 a {

--- a/packages/themes/src/ThemeProvider.tsx
+++ b/packages/themes/src/ThemeProvider.tsx
@@ -27,13 +27,14 @@ type ThemeProviderProps = {
    */
   theme?: typeof consoleLightTheme
   children: ReactNode
+  cssLayer?: string
 }
 
 /**
  * ThemeProvider will apply generated global CSS variables to the application in the `<head>`.
  * If no theme is provided, it will default to `lightTheme`.
  */
-export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProviderProps) => {
+export const ThemeProvider = ({ children, theme = consoleLightTheme, cssLayer }: ThemeProviderProps) => {
   useLayoutEffect(() => {
     const styleId = 'uv-theme'
     const existingStyle = document.getElementById(styleId)
@@ -47,13 +48,14 @@ export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProv
         background-color: ${theme.colors.neutral.background};
       }
     `
+    const layeredCssString = cssLayer ? `@layer ${cssLayer} { ${cssString} }` : cssString
 
     if (existingStyle) {
-      existingStyle.textContent = cssString
+      existingStyle.textContent = layeredCssString
     } else {
       const style = document.createElement('style')
       style.id = styleId
-      style.textContent = cssString
+      style.textContent = layeredCssString
       document.head.appendChild(style)
     }
 
@@ -63,7 +65,7 @@ export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProv
         style.remove()
       }
     }
-  }, [theme])
+  }, [theme, cssLayer])
 
   return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
 }

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -27,6 +27,7 @@ type ThemeProviderProps = {
    */
   theme?: typeof consoleLightTheme
   children: ReactNode
+  cssLayer?: string
 }
 
 /**
@@ -44,7 +45,7 @@ type ThemeProviderProps = {
  * import '@ultraviolet/icons/styles'
  * ```
  */
-export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProviderProps) => {
+export const ThemeProvider = ({ children, theme = consoleLightTheme, cssLayer }: ThemeProviderProps) => {
   useLayoutEffect(() => {
     const styleId = 'uv-theme'
     const iconsStyleId = 'uv-icons'
@@ -62,12 +63,14 @@ export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProv
       }
     `
 
+    const layeredCssString = cssLayer ? `@layer ${cssLayer} { ${cssString} }` : cssString
+
     if (existingStyle) {
-      existingStyle.textContent = cssString
+      existingStyle.textContent = layeredCssString
     } else {
       const style = document.createElement('style')
       style.id = styleId
-      style.textContent = cssString
+      style.textContent = layeredCssString
       document.head.appendChild(style)
     }
 
@@ -91,7 +94,7 @@ export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProv
         iconsStyle.remove()
       }
     }
-  }, [theme])
+  }, [theme, cssLayer])
 
   return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
 }

--- a/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react'
+import { consoleDarkTheme, consoleLightTheme, ThemeProvider } from '@ultraviolet/themes'
+import { describe, expect, it } from 'vitest'
+
+const getInjectedStyle = (id = 'uv-theme') => document.getElementById(id)
+
+describe('themeProvider', () => {
+  it('injects a style tag with the theme variables with default props', () => {
+    render(
+      <ThemeProvider>
+        <div>child</div>
+      </ThemeProvider>,
+    )
+
+    const style = getInjectedStyle()
+    expect(style).not.toBeNull()
+    expect(style?.tagName).toBe('STYLE')
+    expect(style?.textContent).toContain(':root')
+    expect(style?.textContent).toContain('background-color')
+    expect(style?.textContent).toContain('color')
+    expect(style?.textContent).not.toContain('@layer')
+  })
+
+  it('wraps the dynamic styles in a css @layer when cssLayer is provided', () => {
+    render(
+      <ThemeProvider cssLayer="uv">
+        <div>child</div>
+      </ThemeProvider>,
+    )
+
+    const style = getInjectedStyle()
+    expect(style?.textContent).toMatch(/@layer uv \{\s*:root/)
+  })
+
+  it('applies the theme background color to the body', () => {
+    render(
+      <ThemeProvider theme={consoleLightTheme}>
+        <div>child</div>
+      </ThemeProvider>,
+    )
+
+    const style = getInjectedStyle()
+    expect(style?.textContent).toContain(`background-color: ${consoleLightTheme.colors.neutral.background}`)
+  })
+
+  it('updates the injected styles when the theme changes', () => {
+    const { rerender } = render(
+      <ThemeProvider theme={consoleLightTheme}>
+        <div>child</div>
+      </ThemeProvider>,
+    )
+    const style = getInjectedStyle()
+    expect(style?.textContent).toContain(`background-color: ${consoleLightTheme.colors.neutral.background}`)
+
+    rerender(
+      <ThemeProvider theme={consoleDarkTheme}>
+        <div>child</div>
+      </ThemeProvider>,
+    )
+
+    const newStyle = getInjectedStyle()
+    expect(newStyle?.textContent).toContain(`background-color: ${consoleDarkTheme.colors.neutral.background}`)
+    expect(newStyle?.textContent).not.toContain(`background-color: ${consoleLightTheme.colors.neutral.background}`)
+  })
+
+  it('re-wraps styles in a layer when cssLayer changes', () => {
+    const { rerender } = render(
+      <ThemeProvider>
+        <div>child</div>
+      </ThemeProvider>,
+    )
+
+    expect(getInjectedStyle()?.textContent).not.toContain('@layer')
+
+    rerender(
+      <ThemeProvider cssLayer="uv">
+        <div>child</div>
+      </ThemeProvider>,
+    )
+
+    expect(getInjectedStyle()?.textContent).toContain('@layer uv')
+  })
+})


### PR DESCRIPTION
### Summary

`ThemeProvider`: new prop `cssLayer` to wrap default theme (css variables added in `:root` as well as default color and background-color) in a css layer

